### PR TITLE
Add support for snapshot mode to FLEViewController

### DIFF
--- a/macos/example/Example Embedder.xcodeproj/project.pbxproj
+++ b/macos/example/Example Embedder.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		33CC110D2044A8790003C045 /* FlutterEmbedderMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33CC11042044A7620003C045 /* FlutterEmbedderMac.framework */; };
 		33CC110F2044A8940003C045 /* FlutterEmbedderMac.framework in Bundle Framework */ = {isa = PBXBuildFile; fileRef = 33CC11042044A7620003C045 /* FlutterEmbedderMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		33CC11132044BFA00003C045 /* ExampleWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* ExampleWindow.swift */; };
+		33CC112F204626C80003C045 /* flutter_assets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC112C20461AD40003C045 /* flutter_assets */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,6 +77,7 @@
 		33CC10FE2044A7620003C045 /* FlutterEmbedderMac.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FlutterEmbedderMac.xcodeproj; path = ../library/FlutterEmbedderMac.xcodeproj; sourceTree = "<group>"; };
 		33CC11122044BFA00003C045 /* ExampleWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleWindow.swift; sourceTree = "<group>"; };
 		33CC11162044C3600003C045 /* Example Embedder-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Example Embedder-Bridging-Header.h"; sourceTree = "<group>"; };
+		33CC112C20461AD40003C045 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = ../../example_flutter/build/flutter_assets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -124,6 +126,7 @@
 				33CC10F22044A3C60003C045 /* Assets.xcassets */,
 				33CC10F42044A3C60003C045 /* MainMenu.xib */,
 				33CC10F72044A3C60003C045 /* Info.plist */,
+				33CC112C20461AD40003C045 /* flutter_assets */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -214,6 +217,7 @@
 			files = (
 				33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */,
 				33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */,
+				33CC112F204626C80003C045 /* flutter_assets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/example/ExampleWindow.swift
+++ b/macos/example/ExampleWindow.swift
@@ -18,16 +18,9 @@ class ExampleWindow: NSWindow {
   @IBOutlet weak var flutterViewController: FLEViewController!
 
   override func awakeFromNib() {
-    // TODO: Package all the Flutter resources, and use bundle-relative paths. For now, the path to
-    // the sample Flutter app in the source tree is passed as a command-line argument.
-    let baseURL = NSURL.fileURL(withPath: CommandLine.arguments.remove(at: 1))
-    let assets = NSURL.fileURL(withPath: "build/flutter_assets", relativeTo: baseURL)
-    let main = NSURL.fileURL(withPath: "lib/main.dart", relativeTo: baseURL)
-    let packages = NSURL.fileURL(withPath: ".packages", relativeTo: baseURL)
+    let assets = NSURL.fileURL(withPath: "flutter_assets", relativeTo: Bundle.main.resourceURL)
     flutterViewController.launchEngine(
-      withMainPath: main,
-      assetsPath: assets,
-      packagesPath: packages,
+      withAssetsPath: assets,
       asHeadless: false,
       commandLineArguments: [CommandLine.arguments[0], "--dart-non-checked-mode"])
 

--- a/macos/library/FLEViewController.h
+++ b/macos/library/FLEViewController.h
@@ -33,10 +33,28 @@
 @property(nullable) NSView<FLEOpenGLContextHandling> *view;
 
 /**
- * Launches the Flutter engine with the provided configuration. The path arguments are used
- * to identify the Flutter application the engine should be configured with. See
+ * Launches the Flutter engine in snapshot mode with the provided configuration. The path argument
+ * is used to identify the Flutter application the engine should be configured with. See
  * https://github.com/flutter/engine/wiki/Custom-Flutter-Engine-Embedders for more information
  * on embedding, including the meaning of various possible arguments.
+ *
+ * In snapshot mode, the snapshot in the assets directory will be used instead of the original
+ * dart sources.
+ */
+- (BOOL)launchEngineWithAssetsPath:(nonnull NSURL *)assets
+                        asHeadless:(BOOL)headless
+              commandLineArguments:(nonnull NSArray<NSString *> *)arguments;
+
+/**
+ * Launches the Flutter engine in source mode with the provided configuration. The path arguments
+ * are used to identify the Flutter application the engine should be configured with. See
+ * https://github.com/flutter/engine/wiki/Custom-Flutter-Engine-Embedders for more information
+ * on embedding, including the meaning of various possible arguments.
+ *
+ * In source mode, the Dart source and its dependencies will be read directly from their locations
+ * on disk.
+ * TODO: Evaluate whether this mode needs to be present in the long term, and if so reconsider this
+ * API structure.
  */
 - (BOOL)launchEngineWithMainPath:(nonnull NSURL *)main
                       assetsPath:(nonnull NSURL *)assets


### PR DESCRIPTION
The embedding API allows passing empty main and package paths to use
snapshot mode rather than source mode, which allows for easy bundling.

Switches the example app to use snapshot mode, and bundles the build
resources directory, so that the app is self-contained. Removes the
need for the command-line argument workaround (which was accidentally
missing from the previous patch due to the scheme that passed the path
to the example app directory not being marked as shared, so this has
the added effect of fixing the sample app).

Closes #8