### PR TITLE
Add a resource context on macOS

### DIFF
--- a/macos/library/FLEOpenGLContextHandling.h
+++ b/macos/library/FLEOpenGLContextHandling.h
@@ -24,11 +24,6 @@
 - (void)makeCurrentContext;
 
 /**
- * Clears the current receiver, setting the OpenGL context to nil.
- */
-- (void)clearCurrentContext;
-
-/**
  * Called when the display is updated. In an NSOpenGLView this is best handled via a flushBuffer
  * call.
  */

--- a/macos/library/FLEView.m
+++ b/macos/library/FLEView.m
@@ -19,10 +19,6 @@
 #pragma mark -
 #pragma mark FLEContextHandlingProtocol
 
-- (void)clearCurrentContext {
-  [NSOpenGLContext clearCurrentContext];
-}
-
 - (void)makeCurrentContext {
   [self.openGLContext makeCurrentContext];
 }


### PR DESCRIPTION
Creates an NSOpenGLContext sharing with the view's OpenGLContext,
and makes it available to the engine via the new resource context
callback.

Closes #19