### PR TITLE
#19 linux target g++ command order

### DIFF
--- a/linux/example/Makefile
+++ b/linux/example/Makefile
@@ -75,7 +75,7 @@ $(FLUTTER_EXAMPLE_DIR)/build:
 		--local-engine=$(FLUTTER_ENGINE_BUILD);
 
 $(BIN_OUT): $(SOURCES) $(LIBRARIES)
-	$(CXX) $(CXXFLAGS) -o $@ $(SOURCES)
+	$(CXX) $(SOURCES) $(CXXFLAGS) -o $@
 
 .PHONY: clean
 clean:

--- a/linux/library/Makefile
+++ b/linux/library/Makefile
@@ -28,7 +28,7 @@ SOURCES=flutter_embedder.cc
 all: $(LIBRARY_OUT)
 
 $(LIBRARY_OUT): $(SOURCES) $(HEADERS) $(LIBRARIES)
-	$(CXX) $(CXXFLAGS) -o $@ $(SOURCES)
+	$(CXX) $(SOURCES) $(CXXFLAGS) -o $@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Currently linux target gives an undefined reference due to the sources being included at the end of the g++ command. See #19 