### PR TITLE
Ensure Dart is present in update_flutter_engine

### DIFF
--- a/tools/update_flutter_engine
+++ b/tools/update_flutter_engine
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 base_dir="$(dirname "$0")"
-exec "$base_dir/../../flutter/bin/cache/dart-sdk/bin/dart" "$base_dir/dart_tools/bin/update_flutter_engine.dart" $@
+flutter_bin_dir="$base_dir/../../flutter/bin"
+dart_bin_dir="$flutter_bin_dir/cache/dart-sdk/bin"
+# Ensure that the Dart SDK has been downloaded.
+if [[ ! -e $dart_bin_dir ]]; then
+  "$flutter_bin_dir/flutter" precache
+fi
+exec "$dart_bin_dir/dart" "$base_dir/dart_tools/bin/update_flutter_engine.dart" $@


### PR DESCRIPTION
A clean Flutter doesn't contain Dart; check whether Dart is present
before trying to use it, and if not run 'flutter precache'.

Fixes issue #63