### PR TITLE
Use update_flutter_engine in the Linux build

### DIFF
--- a/linux/.gitignore
+++ b/linux/.gitignore
@@ -1,3 +1,4 @@
+.last_engine_version
 *.so
-embedder.h
+flutter_embedder.h
 flutter_embedder_example

--- a/linux/README.md
+++ b/linux/README.md
@@ -8,10 +8,6 @@ the Linux desktop. This currently includes support for:
 
 # How to Use This Code
 
-Note that the example build here is `host_debug_unopt` (you'll find more info on
-what that means in this section). This can be changed to whatever version of the
-Flutter Engine you end up building.
-
 First you will need to install the relevant dependencies.
 
 ## Dependencies
@@ -32,44 +28,14 @@ $ sudo apt-get install libglfw3-dev libepoxy-dev libjsoncpp-dev libgtk-3-dev \
       libx11-dev pkg-config
 ```
 
-Also requires a checkout of the Flutter repo and Flutter Engine repo. For the
-most straightforward build make sure to set up all checkouts with the same
-parent directory like so:
+You will also need a checkout of the Flutter repository. The tooling and
+build system expect it to be in the same directory as your checkout of
+this repository:
 
 ```
 <parent dir>
   ├─ flutter/ (from http://github.com/flutter/flutter)
-  ├─ engine/ (from https://github.com/flutter/engine)
   └─ flutter-desktop-embedding/ (from https://github.com/google/flutter-desktop-embedding)
-```
-
-Next you will need to build the flutter engine. First, after you've checked out
-the engine code, make sure to build the version appropriate for your checkout of
-Flutter. This can be done using the `engine.version` file. Here is how you can
-check out the correct version of the engine when inside the `engine/` repo.
-
-```
-$ git checkout $(cat ../flutter/bin/internal/engine.version)
-```
-
-Then, follow the steps outlined on the flutter engine's
-[contributing](https://github.com/flutter/engine/blob/master/CONTRIBUTING.md)
-page so that you can build a copy of `libflutter_engine.so`.
-
-Then copy it from `out/host_debug_unopt/` (if you built the unoptimized binary)
-into the `flutter-desktop-embedding/linux/library/` directory.
-
-```
-$ cp <path_to_flutter_engine>/src/out/host_debug_unopt/libflutter_engine.so \
-       <path_to_flutter_desktop_embedding_repo>/linux/library
-```
-
-Then copy `embedder.h` into the include directory (the file can be found under
-the the flutter engine checkout).
-
-```
-$ cp <path_to_flutter_engine>/src/flutter/shell/platform/embedder/embedder.h \
-     <path_to_flutter_desktop_embedding_repo>/linux/library/include
 ```
 
 ## Building and Running a Flutter App

--- a/linux/example/Makefile
+++ b/linux/example/Makefile
@@ -12,44 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Before editing these, make sure you have read the documentation on how to
-# build the flutter engine here:
-# https://github.com/flutter/engine/blob/master/CONTRIBUTING.md
-#
-# $(FLUTTER_ENGINE_PATH) is the variable pointing to the git checkout of the
-# flutter engine, under the assumption that you have already built it. Here,
-# the flutter engine path is relative to
-# `flutter-desktop-embedding/example_flutter`, as this Makefile will build that
-# application during the build process.
-#
-# This variable will be used when building `example_flutter/` to pass the
-# `--local-engine-src-path` flag to the flutter binary.
-FLUTTER_ENGINE_PATH=../../engine
-
-# See above regarding building the flutter engine before editing these
-# variables.
-#
-# $(FLUTTER_ENGINE_BUILD) refers to the `gn` configuration used to build the
-# engine. When running `gn --unoptimized` to generate the build configuration,
-# the variable should be set (as it is now) to `host_debug_unopt`. If building
-# with the flags `--runtime-mode release`, then this variable will be set to
-# `host_release`.
-#
-# A simple way to figure out how to set this flag is to check the output of `gn`
-# and then set $(FLUTTER_ENGINE_BUILD) to be the name of the directory after `out/`
-#
-# Example output:
-#
-#```
-# $ ./src/flutter/gn --unoptimized
-# gn gen --check in out/host_debug_unopt
-# Done. Made 385 Targets from 168 files in 379ms
-#```
-#
-# From the above, you should then set this flag to `host_debug_unopt`.
-FLUTTER_ENGINE_BUILD=host_debug_unopt
-
-FLUTTER_ENGINE_SRC=$(FLUTTER_ENGINE_PATH)/src
 FLUTTER_EMBEDDER_LIB=flutter_embedder
 FLUTTER_EXAMPLE_DIR=../../example_flutter
 FLUTTER_BIN_FROM_EXAMPLE_DIR=../../flutter/bin/flutter
@@ -71,9 +33,7 @@ all: $(FLUTTER_EXAMPLE_DIR)/build $(BIN_OUT)
 
 $(FLUTTER_EXAMPLE_DIR)/build:
 	cd $(FLUTTER_EXAMPLE_DIR); \
-	$(FLUTTER_BIN_FROM_EXAMPLE_DIR) build bundle \
-		--local-engine-src-path=$(FLUTTER_ENGINE_SRC) \
-		--local-engine=$(FLUTTER_ENGINE_BUILD);
+	$(FLUTTER_BIN_FROM_EXAMPLE_DIR) build bundle
 
 $(BIN_OUT): $(SOURCES) $(LIBRARIES)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(SOURCES) $(LDFLAGS) -o $@

--- a/linux/example/flutter_embedder_example.cc
+++ b/linux/example/flutter_embedder_example.cc
@@ -14,7 +14,7 @@
 #include <cstdlib>
 #include <iostream>
 
-#include <flutter_desktop_embedding/flutter_embedder.h>
+#include <flutter_desktop_embedding/embedder.h>
 
 int main(int argc, char **argv) {
   std::string flutter_example_root = "../example_flutter";

--- a/linux/library/Makefile
+++ b/linux/library/Makefile
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FLUTTER_ENGINE_LIB=flutter_engine
+FLUTTER_ENGINE_LIB_NAME=flutter_engine
+FLUTTER_ENGINE_LIB_FILE=lib$(FLUTTER_ENGINE_LIB_NAME).so
+FLUTTER_ENGINE_HEADER=flutter_embedder.h
+ENGINE_UPDATER=../../tools/update_flutter_engine
 LIBRARY_OUT=libflutter_embedder.so
 CXX=g++ -std=c++14
 CXXFLAGS= -Wall -Werror -shared -fPIC \
@@ -19,11 +22,11 @@ CXXFLAGS= -Wall -Werror -shared -fPIC \
 	$(shell pkg-config --cflags gtk+-3.0 epoxy x11 jsoncpp)
 LDFLAGS= -L$(CURDIR) \
 	$(shell pkg-config --libs gtk+-3.0 epoxy x11 jsoncpp) \
-	-lglfw -lGL -l$(FLUTTER_ENGINE_LIB) \
+	-lglfw -lGL -l$(FLUTTER_ENGINE_LIB_NAME) \
 	-Wl,-rpath=$(CURDIR)
 
 
-LIBRARIES=lib$(FLUTTER_ENGINE_LIB).so
+LIBRARIES=$(FLUTTER_ENGINE_LIB_FILE)
 HEADERS=$(shell find include/ -type f -name '*.h')
 SOURCES=$(shell find src/ -type f -name '*.cc')
 
@@ -32,6 +35,18 @@ all: $(LIBRARY_OUT)
 
 $(LIBRARY_OUT): $(SOURCES) $(HEADERS) $(LIBRARIES)
 	$(CXX) $(CXXFLAGS) $(SOURCES) $(LDFLAGS) -o $@
+
+# Ideally this would use a .PHONY target since the script knows when it
+# needs to re-run, but that causes the embedder to need to re-link every
+# time. Instead, this duplicates the dependency information that the script
+# already has, and makes things slightly more fragile, in exchange for
+# avoiding unnecessary relinks.
+$(FLUTTER_ENGINE_LIB_FILE): \
+	../../../flutter/bin/internal/engine.version
+	$(ENGINE_UPDATER) ./
+	if [ -f $(FLUTTER_ENGINE_HEADER) ]; then \
+		mv $(FLUTTER_ENGINE_HEADER) include/; \
+		fi
 
 .PHONY: clean
 clean:

--- a/linux/library/Makefile
+++ b/linux/library/Makefile
@@ -41,8 +41,7 @@ $(LIBRARY_OUT): $(SOURCES) $(HEADERS) $(LIBRARIES)
 # time. Instead, this duplicates the dependency information that the script
 # already has, and makes things slightly more fragile, in exchange for
 # avoiding unnecessary relinks.
-$(FLUTTER_ENGINE_LIB_FILE): \
-	../../../flutter/bin/internal/engine.version
+$(FLUTTER_ENGINE_LIB_FILE): ../../../flutter/bin/internal/engine.version
 	$(ENGINE_UPDATER) ./
 	if [ -f $(FLUTTER_ENGINE_HEADER) ]; then \
 		mv $(FLUTTER_ENGINE_HEADER) include/; \

--- a/linux/library/include/flutter_desktop_embedding/channels.h
+++ b/linux/library/include/flutter_desktop_embedding/channels.h
@@ -19,7 +19,7 @@
 #include <memory>
 #include <string>
 
-#include <embedder.h>
+#include <flutter_embedder.h>
 
 namespace flutter_desktop_embedding {
 

--- a/linux/library/include/flutter_desktop_embedding/embedder.h
+++ b/linux/library/include/flutter_desktop_embedding/embedder.h
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_FLUTTER_EMBEDDER_H_
-#define LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_FLUTTER_EMBEDDER_H_
+#ifndef LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_EMBEDDER_H_
+#define LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_EMBEDDER_H_
 
 // Epoxy must be included before any graphics-related code.
 #include <epoxy/gl.h>
@@ -79,4 +79,4 @@ void FlutterWindowLoop(GLFWwindow *flutter_window);
 
 }  // namespace flutter_desktop_embedding
 
-#endif  // LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_FLUTTER_EMBEDDER_H_
+#endif  // LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_EMBEDDER_H_

--- a/linux/library/include/flutter_desktop_embedding/plugin.h
+++ b/linux/library/include/flutter_desktop_embedding/plugin.h
@@ -19,7 +19,7 @@
 #include <memory>
 #include <string>
 
-#include <embedder.h>
+#include <flutter_embedder.h>
 
 #include "channels.h"
 

--- a/linux/library/src/embedder.cc
+++ b/linux/library/src/embedder.cc
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <flutter_desktop_embedding/flutter_embedder.h>
+#include <flutter_desktop_embedding/embedder.h>
 
 #include <X11/Xlib.h>
 #include <assert.h>
@@ -24,7 +24,7 @@
 #include <memory>
 #include <string>
 
-#include <embedder.h>
+#include <flutter_embedder.h>
 #include <flutter_desktop_embedding/channels.h>
 #include <flutter_desktop_embedding/color_picker_plugin.h>
 #include <flutter_desktop_embedding/file_chooser_plugin.h>


### PR DESCRIPTION
Instead of requiring that the Linux engine be manually added to the tree,
fetch the correct prebuilt version automatically as is done on macOS.

Updates the source to expect the engine's header to be called
flutter_embedder.h, as that is what it is named in the archive. The
desktop embedding header has been renamed from flutter_embedder.h
to just embedder.h to avoid confusion.