### PR TITLE
[macOS] Quit the example app when closing the window

### DIFF
--- a/macos/example/AppDelegate.swift
+++ b/macos/example/AppDelegate.swift
@@ -17,5 +17,9 @@ import Cocoa
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
   @IBOutlet weak var window: NSWindow!
+
+  func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    return true
+  }
 }
 


### PR DESCRIPTION
The application is not multi-window, so it should quit when the window
is closed.