### PR TITLE
Overhaul the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,41 +2,71 @@
 
 This repository contains code that implements basic embedders for
 [Flutter](https://github.com/flutter/flutter) on desktop platforms, as starting
-points for building native desktop applications that embed Flutter. It does not
-contain the Flutter engine itself, as that is part of the Flutter project, only
-implementation of [Flutter's embedding
-API](https://github.com/flutter/engine/wiki/Custom-Flutter-Engine-Embedders)
-(e.g., passing mouse and keyboard events to Flutter).
-
+points for building native desktop applications that embed Flutter.
 Currently macOS and Linux are supported, and the goal is to support Windows
 in the future as well.
 
-## How to use this code
+It contains shared libraries that implement [Flutter's embedding
+API](https://github.com/flutter/engine/wiki/Custom-Flutter-Engine-Embedders),
+handling drawing, mouse event handling, and keyboard support. It also
+includes optional plugins to access other native platform functionality.
 
-See the README file in the directory corresponding to your platform.
+## How to Use This Code
 
-## Discussion
+### Setting Up
+
+The tooling and build infrastructure for this project requires that you have
+a Flutter tree in the same parent directory as the clone of this project:
+
+```
+<parent dir>
+  ├─ flutter (from http://github.com/flutter/flutter)
+  └─ flutter-desktop-embedding (from https://github.com/google/flutter-desktop-embedding)
+```
+
+### Repository Structure
+
+Each supported platform has a top-level directory named for the platform.
+Within that directory is a `library` directory containing the core embedding
+library, and an `example` directory containing an example application using it.
+
+See the `README` file in the directory corresponding to your platform for more
+details.
+
+In addition, there is:
+* `example_flutter`: The Flutter application loaded by the example application
+  provided for each platform.
+* `plugins`: Plugins which provide access to additional platform functionality.
+  These follow a similar structure to [Flutter
+  plugins](https://flutter.io/developing-packages/). See the
+  [README](plugins/README.md) for details.
+* `third_party`: Dependencies used by this repository, beyond Flutter itself.
+* `tools`: Tools used in the development process. Currently these are used
+  by the build systems, but in the future developer utilities providing
+  some functionality similar to the `flutter` tool may be added.
+
+## Feedback and Discussion
 
 For bug reports and specific feature requests, you can file GitHub issues. For
 general discussion and questions there's a [project mailing
 list](https://groups.google.com/forum/#!forum/flutter-desktop-embedding-dev).
 
 When submitting issues related to build errors or other bugs, please make sure
-to include the git hash of the `Flutter` checkout you are using, as well as the
-git hash of the `Flutter Engine` checkout you are using. This will help speed up
-the debugging process.
-
-Example:
-
-```
-Flutter Version: abcdefg123456
-Flutter Engine:  2345678qwertyu
-```
+to include the git hash of the Flutter checkout you are using. This will help
+speed up the debugging process.
 
 ## Caveats
 
-This is not an officially supported Google product.
-
-This is an exploratory effort, and is not part of the Flutter project. See the
-[Flutter FAQ](https://flutter.io/faq/#can-i-use-flutter-to-build-desktop-apps)
-for Flutter's official stance on desktop development.
+* This is not an officially supported Google product.
+* This is an exploratory effort, and is not part of the Flutter project. See the
+  [Flutter FAQ](https://flutter.io/faq/#can-i-use-flutter-to-build-desktop-apps)
+  for Flutter's official stance on desktop development.
+* Currently the development workflow assumes you are starting from an existing
+  native application shell, and provides the pieces to add Flutter support. This
+  is very different from the Flutter model, where the native application
+  projects are created automatically. This may change in the future, but for now
+  there is no equivalent to `flutter create`.
+* Many features that would be useful for desktop development do not exist yet.
+  Check the `plugins` directory for support for native features beyond drawing
+  and event processing. If the feature you need isn't there, file a feature
+  request, or [write a plugin](plugins/README.md#writing-your-own-plugins)!

--- a/linux/README.md
+++ b/linux/README.md
@@ -1,19 +1,16 @@
 # The Flutter Linux Desktop Embedder
 
 This framework provides the basic functionality for embedding a Flutter app on
-the Linux desktop. This currently includes support for:
+the Linux desktop.
 
-*   Drawing a Flutter view.
-*   Mouse event handling.
+This README assumes you have already read [the top level README](../README.md),
+which contains important information and setup common to all platforms.
 
-# How to Use This Code
+## How to Use This Code
 
-First you will need to install the relevant dependencies.
+### Dependencies
 
-## Dependencies
-
-Requires:
-
+First you will need to install the relevant dependencies:
 *   GLFW3
 *   GTK 3
 *   jsoncpp
@@ -28,21 +25,18 @@ $ sudo apt-get install libglfw3-dev libepoxy-dev libjsoncpp-dev libgtk-3-dev \
       libx11-dev pkg-config
 ```
 
-You will also need a checkout of the Flutter repository. The tooling and
-build system expect it to be in the same directory as your checkout of
-this repository:
+### Using the Library
 
-```
-<parent dir>
-  ├─ flutter/ (from http://github.com/flutter/flutter)
-  └─ flutter-desktop-embedding/ (from https://github.com/google/flutter-desktop-embedding)
-```
+Run `make` under `library/`, then link `libflutter_embedder.so` into your
+binary. See [embedder.h](library/include/flutter_desktop_embedding/embedder.h)
+for details on calling into the library.
 
-## Building and Running a Flutter App
+## Example Application
 
-This assumes you're using the existing example app contained in the repo.
+The application under `example/` shows an example application using the library,
+including adding plugins.
 
-You should be able to run `make` within the `linux` directory and have access to
+You should be able to run `make` within the this directory and have access to
 a `flutter_embedder_example` binary.
 
 ```
@@ -50,23 +44,14 @@ $ make
 ```
 
 This should generate all the files necessary to run the example application.
-
-## Running the Example Code
-
-Once the directories are setup like above and you've built everything, the
-`flutter_embedder_example` code expects to be run from the `linux/` directory
-like so:
+The resulting `flutter_embedder_example` executable expects to be run from
+this directory like so:
 
 ```
 $ ./example/flutter_embedder_example
 ```
 
-# Caveats
-
-Platform-specific features like a file chooser, menu bar interaction, etc, are
-not yet present, but will be added over time.
+## Caveats
 
 While GLFW is in use in the current iteration, this is not going to be the final
 state for Linux support.
-
-Stay tuned for more documentation.

--- a/macos/README.md
+++ b/macos/README.md
@@ -1,25 +1,23 @@
 # macOS Embedding for Flutter
 
 This framework provides basic embedding functionality for embedding a
-Flutter view into a macOS application:
-* Drawing
-* Mouse event handling
-* Basic text input
+Flutter view into a macOS application.
 
-## How to use this code
+This README assumes you have already read [the top level README](../README.md),
+which contains important information and setup common to all platforms.
 
-_Note:_ For the below steps to work, the https://github.com/google/flutter-desktop-embedding
-repo must be cloned into the same parent directory as the
-http://github.com/flutter/flutter repo.
+## How to Use This Code
 
-```
-<parent dir>
-  ├─ flutter/ (from http://github.com/flutter/flutter)
-  └─ flutter-desktop-embedding/ (from https://github.com/google/flutter-desktop-embedding)
-```
+### Dependencies
 
-Build the Xcode project under library/, then link the resulting framework
-into your application. See the headers for FLEView and FLEViewController
+You must have a current version of [Xcode](https://developer.apple.com/xcode/)
+installed.
+
+### Using the Framework
+
+Build the Xcode project under `library/`, then link the resulting framework
+into your application. See [FLEView.h](library/FLEView.h) and
+[FLEViewController.h](library/FLEViewController.h)
 for details on how to use them.
 
 The framework includes the macOS Flutter engine (FlutterEmbedder.framework),
@@ -32,23 +30,10 @@ so you do not need to include that framework in your project.
 * FlutterEmbedderMac.framework is the output of this project. It wraps
   FlutterEmbedder and implements the embedding API.
 
-### Example Application
+## Example Application
 
-See the example application under example/ to see a simple proof of concept
-application using the framework.
-
-## Caveats
-
-Many features that would be useful for desktop development (e.g., the ability to
-interact with the menu bar) do not yet exist. More platform plugins that provide
-additional functionality will be added over time.
-
-Stay tuned for more documentation.
-
-### Example Application
-The sample application will be improved over time. Currently it only
-works in the context of the build environment, for example, as it does not
-bundle any of the Flutter resources.
+The application under `example/` shows an example application using the
+framework, including bundling plugins via project dependencies.
 
 Future iterations will likely move away from the use of the XIB file, as it
 makes it harder to see the necessary setup. Most notably, to add an FLEView
@@ -56,4 +41,7 @@ to a XIB in your project:
 * Drag in an OpenGL View.
 * Change the class to FLEView.
 * Check the Double Buffer option. If your view doesn't draw, you have likely
+  forgotten this step.
+* Check the Supports Hi-Res Backing option. If you only see a portion of
+  your application when running on a high-DPI monitor, you have likely
   forgotten this step.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -12,7 +12,7 @@ from this repository.
 ### Flutter
 
 Add local package references for the plugins you want to use to your
-pubspec.yaml. E.g.,:
+pubspec.yaml. For example:
 
 ```
 dependencies:
@@ -41,7 +41,7 @@ instance:
 
 ### Linux
 
-Run `make` in the linux directory for each plugin you want to use, then
+Run `make` in the `linux` directory for each plugin you want to use, then
 link the resulting library in your application.
 
 After creating your Flutter window, call AddPlugin with an instance of each
@@ -49,13 +49,16 @@ plugin you want to use. For instance:
 
 ```cpp
   AddPlugin(window,
-            std::make_unique<flutter_desktop_embedding::ColorPanelPlugin>());
+            std::make_unique<plugins_color_panel::ColorPanelPlugin>());
 ```
 
 ### Example Application
 
-See the example application under example/ in each platform's top-level
+See the example application under `example` in each platform's top-level
 directory to see an example of including optional plugins on that platform.
+
+The Flutter application under `example_flutter` shows examples of using
+optional plugins on the Dart side.
 
 ## Writing your own plugins
 


### PR DESCRIPTION
Removes stale information, moves common setup and discussion
to the top-level README, improves consistency between macOS
and Linux README structure, and makes it somewhat more
evergreen by reducing discussion of specific things that are
not implemented (since those things have tended to become
stale quickly).

Also adds some new documentation, including a repository
structure overview.