### PR TITLE
Add input fields to example app

### DIFF
--- a/example_flutter/lib/main.dart
+++ b/example_flutter/lib/main.dart
@@ -164,10 +164,11 @@ class _MyHomePage extends StatelessWidget {
             const Text(
               'You have pushed the button this many times:',
             ),
-            Text(
+            new Text(
               '$counter',
               style: Theme.of(context).textTheme.display1,
             ),
+            TextInputTestWidget(),
             FileChooserTestWidget(),
           ],
         ),
@@ -211,6 +212,37 @@ class FileChooserTestWidget extends StatelessWidget {
           },
         ),
       ],
+    );
+  }
+}
+
+/// A widget containing controls to test text input.
+class TextInputTestWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: const <Widget>[
+        SampleTextField(),
+        SampleTextField(),
+      ],
+    );
+  }
+}
+
+/// A text field with styling suitable for including in a TextInputTestWidget.
+class SampleTextField extends StatelessWidget {
+  /// Creates a new sample text field.
+  const SampleTextField();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 200.0,
+      padding: const EdgeInsets.all(10.0),
+      child: TextField(
+        decoration: InputDecoration(border: OutlineInputBorder()),
+      ),
     );
   }
 }

--- a/example_flutter/pubspec.lock
+++ b/example_flutter/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.5"
   csslib:
     dependency: transitive
     description:
@@ -151,6 +151,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.1"
+  json_rpc_2:
+    dependency: transitive
+    description:
+      name: json_rpc_2
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.8"
   kernel:
     dependency: transitive
     description:
@@ -171,7 +178,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.2+1"
+    version: "0.12.2"
   menubar:
     dependency: "direct main"
     description:
@@ -227,7 +234,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "1.6.1"
   plugin:
     dependency: transitive
     description:
@@ -344,7 +351,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.40"
+    version: "0.12.41"
   typed_data:
     dependency: transitive
     description:
@@ -366,6 +373,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.6"
+  vm_service_client:
+    dependency: transitive
+    description:
+      name: vm_service_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.4+3"
   watcher:
     dependency: transitive
     description:
@@ -388,4 +402,4 @@ packages:
     source: hosted
     version: "2.1.14"
 sdks:
-  dart: ">=2.0.0-dev.55.0 <=2.0.0-dev.61.0.flutter-c95617b19c"
+  dart: ">=2.0.0-dev.62.0 <=2.0.0-dev.63.0.flutter-4c9689c1d2"


### PR DESCRIPTION
This makes it easy to test basic text input support from the example
applications on each platform.

Includes two widgets since at some point in the future we can
hopefully support tabbing between fields, so having two will
be useful for testing.