### PR TITLE
Add a configuration option for Flutter location

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ a Flutter tree in the same parent directory as the clone of this project:
   └─ flutter-desktop-embedding (from https://github.com/google/flutter-desktop-embedding)
 ```
 
+Alternately, you can place a `.flutter_location_config` file in the directory
+containing flutter-desktop-embedding, containng a path to the Flutter tree to
+use, if you prefer not to have the Flutter tree next to
+flutter-desktop-emebbing.
+
 ### Repository Structure
 
 Each supported platform has a top-level directory named for the platform.

--- a/linux/.gitignore
+++ b/linux/.gitignore
@@ -2,3 +2,4 @@
 *.so
 flutter_embedder.h
 flutter_embedder_example
+icudtl.dat

--- a/linux/example/Makefile
+++ b/linux/example/Makefile
@@ -14,8 +14,13 @@
 
 FLUTTER_EMBEDDER_LIB=flutter_embedder
 FLUTTER_EXAMPLE_DIR=../../example_flutter
-FLUTTER_BIN_FROM_EXAMPLE_DIR=../../flutter/bin/flutter
+FLUTTER_DIR=$(shell ../../tools/flutter_location)
+FLUTTER_BIN=$(FLUTTER_DIR)/bin/flutter
 BIN_OUT=flutter_embedder_example
+
+ICU_FILENAME=icudtl.dat
+ICU_SOURCE=$(FLUTTER_DIR)/bin/cache/artifacts/engine/linux-x64/$(ICU_FILENAME)
+ICU_DAT=./$(ICU_FILENAME)
 
 PLUGINS=color_panel file_chooser
 FLUTTER_EMBEDDER_LIB_DIR=$(CURDIR)/../library
@@ -41,18 +46,21 @@ LIBRARIES=$(CURDIR)/../library/lib$(FLUTTER_EMBEDDER_LIB).so \
 SOURCES=flutter_embedder_example.cc
 
 .PHONY: all
-all: $(FLUTTER_EXAMPLE_DIR)/build $(BIN_OUT)
+all: $(FLUTTER_EXAMPLE_DIR)/build $(BIN_OUT) $(ICU_DAT)
 
 .PHONY: $(FLUTTER_EXAMPLE_DIR)/build
 $(FLUTTER_EXAMPLE_DIR)/build:
 	cd $(FLUTTER_EXAMPLE_DIR); \
-	$(FLUTTER_BIN_FROM_EXAMPLE_DIR) build bundle
+	$(FLUTTER_BIN) build bundle
 
 $(BIN_OUT): $(SOURCES) $(LIBRARIES)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(SOURCES) $(LDFLAGS) -o $@
+
+$(ICU_DAT): $(ICU_SOURCE)
+	cp $(ICU_SOURCE) $(ICU_DAT)
 
 .PHONY: clean
 clean:
 	rm -f $(BIN_OUT); \
 	cd $(FLUTTER_EXAMPLE_DIR); \
-	$(FLUTTER_BIN_FROM_EXAMPLE_DIR) clean
+	$(FLUTTER_BIN) clean

--- a/linux/example/flutter_embedder_example.cc
+++ b/linux/example/flutter_embedder_example.cc
@@ -21,7 +21,6 @@
 
 int main(int argc, char **argv) {
   std::string flutter_example_root = "../example_flutter";
-  std::string flutter_git_root = "../../flutter";
   if (!glfwInit()) {
     std::cout << "Couldn't init GLFW";
   }
@@ -37,8 +36,7 @@ int main(int argc, char **argv) {
   // Start the engine.
   auto window = flutter_desktop_embedding::CreateFlutterWindowInSnapshotMode(
       640, 480, flutter_example_root + "/build/flutter_assets",
-      flutter_git_root + "/bin/cache/artifacts/engine/linux-x64/icudtl.dat",
-      arg_count, const_cast<char **>(args_arr));
+      "example/icudtl.dat", arg_count, const_cast<char **>(args_arr));
   if (window == nullptr) {
     glfwTerminate();
     return EXIT_FAILURE;

--- a/linux/library/Makefile
+++ b/linux/library/Makefile
@@ -14,7 +14,9 @@
 FLUTTER_ENGINE_LIB_NAME=flutter_engine
 FLUTTER_ENGINE_LIB_FILE=lib$(FLUTTER_ENGINE_LIB_NAME).so
 FLUTTER_ENGINE_HEADER=flutter_embedder.h
-ENGINE_UPDATER=../../tools/update_flutter_engine
+TOOLS_DIR=../../tools
+ENGINE_UPDATER=$(TOOLS_DIR)/update_flutter_engine
+FLUTTER_DIR=$(shell "$(TOOLS_DIR)/flutter_location")
 LIBRARY_OUT=libflutter_embedder.so
 CXX=g++ -std=c++14
 CXXFLAGS= -Wall -Werror -shared -fPIC \
@@ -41,8 +43,8 @@ $(LIBRARY_OUT): $(SOURCES) $(HEADERS) $(LIBRARIES)
 # time. Instead, this duplicates the dependency information that the script
 # already has, and makes things slightly more fragile, in exchange for
 # avoiding unnecessary relinks.
-$(FLUTTER_ENGINE_LIB_FILE): ../../../flutter/bin/internal/engine.version
-	$(ENGINE_UPDATER) ./
+$(FLUTTER_ENGINE_LIB_FILE): $(FLUTTER_DIR)/bin/internal/engine.version
+	$(ENGINE_UPDATER) --flutter_root=$(FLUTTER_DIR) ./
 	if [ -f $(FLUTTER_ENGINE_HEADER) ]; then \
 		mv $(FLUTTER_ENGINE_HEADER) include/; \
 		fi

--- a/macos/example/Example Embedder.xcodeproj/project.pbxproj
+++ b/macos/example/Example Embedder.xcodeproj/project.pbxproj
@@ -349,7 +349,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$PROJECT_DIR\"/../../example_flutter\n../../flutter/bin/flutter build bundle";
+			shellScript = "cd \"$PROJECT_DIR\"/../../example_flutter\n\"$(\"$PROJECT_DIR\"/../../tools/flutter_location)\"/bin/flutter build bundle";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/macos/library/FlutterEmbedderMac.xcodeproj/project.pbxproj
+++ b/macos/library/FlutterEmbedderMac.xcodeproj/project.pbxproj
@@ -243,8 +243,8 @@
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"$PROJECT_DIR\"/../../tools/update_flutter_engine \"$PROJECT_DIR\"/../../../flutter_engine_framework/macos";
+			shellPath = /bin/bash;
+			shellScript = "readonly TOOLS_DIR=\"$PROJECT_DIR\"/../../tools\n\"$TOOLS_DIR\"/update_flutter_engine --flutter_root=\"$(\"$TOOLS_DIR\"/flutter_location)\" \"$PROJECT_DIR\"/../../../flutter_engine_framework/macos";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/tools/flutter_location
+++ b/tools/flutter_location
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script prints the location of the Flutter tree that should be used by
+# any tools or build processes that depend on Flutter.
+set -e
+
+readonly base_dir="$(dirname "$0")"
+readonly config_file_dir="$base_dir/../.."
+readonly config_file="$config_file_dir/.flutter_location_config"
+
+# Default to a sibling directory to this repository.
+flutter_dir="$base_dir/../../flutter"
+# If the config file is present, use that instead.
+if [[ -e $config_file ]]; then
+  override_dir="$(cat "$config_file")"
+  # Support paths starting with ~/.
+  override_dir="${override_dir/#~\//$HOME/}"
+  # If the path is relative, treat it as relative to the directory containing
+  # the config file.
+  if [[ $override_dir != /* && $override_dir != ~* ]]; then
+    override_dir="$config_file_dir/$override_dir"
+  fi
+  flutter_dir="$override_dir"
+fi
+# Normalize the path if possible.
+if [[ -d $flutter_dir ]]; then
+  flutter_dir="$(cd "$flutter_dir" && pwd)"
+fi
+echo "$flutter_dir"

--- a/tools/update_flutter_engine
+++ b/tools/update_flutter_engine
@@ -13,9 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-base_dir="$(dirname "$0")"
-flutter_bin_dir="$base_dir/../../flutter/bin"
-dart_bin_dir="$flutter_bin_dir/cache/dart-sdk/bin"
+readonly base_dir="$(dirname "$0")"
+readonly flutter_dir="$("$base_dir/flutter_location")"
+readonly flutter_bin_dir="$flutter_dir/bin"
+readonly dart_bin_dir="$flutter_bin_dir/cache/dart-sdk/bin"
 # Ensure that the Dart SDK has been downloaded.
 if [[ ! -e $dart_bin_dir ]]; then
   "$flutter_bin_dir/flutter" precache


### PR DESCRIPTION
Requiring the Flutter tree to be in a specific location is problematic
for client projects that need to control layouts (e.g., need to map
Flutter at another location for other reasons), and also makes it
difficult for individuals to share the tree used for this project with
other uses of Flutter.

To improve flexibility, allow a .flutter_location_config file in the
directory containing this repository (not inside it, so that it can be
checked in to an enclosing repository if desired) that specifies the
location of the Flutter tree.