### PR TITLE
make edits in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This repository contains code that implements basic embedders for
 [Flutter](https://github.com/flutter/flutter) on desktop platforms, as starting
-points for building native desktop applications that embed Flutter.
-Currently macOS and Linux are supported, and the goal is to support Windows
+points for building native applications.
+Currently macOS and Linux are supported. The goal is to support Windows
 in the future as well.
 
 It contains shared libraries that implement [Flutter's embedding


### PR DESCRIPTION
- "... contains basic embeders for Flutter on desktop platforms, ... for building desktop applications that embed Flutter."
"desktop" and "embed flutter" was removed from the supporting clause to reduce redundancy. It is mentioned in the first part of the sentence that "native application" is on desktop, and it embeds Flutter

- "Currently macOS and Linux are supported, and the goal is to support Windows..."
"the goal is to..." clause is not equivalent to "macOS and Linux are supported". The sentence is broken down into two sentences to separate two independent ideas.