### PR TITLE
Set debugDefaultTargetPlatformOverride

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,71 @@ In addition, there is:
   by the build systems, but in the future developer utilities providing
   some functionality similar to the `flutter` tool may be added.
 
+## Flutter Application Requirements
+
+Because desktop platforms are not supported Flutter targets, existing Flutter
+applications are likely to require slight modifications to run.
+
+### Target Platform Override
+
+Most applications will need to override the target platform for the application
+to one of the supported values in order to avoid 'Unknown platform' exceptions.
+This should be done as early as possible.
+
+In the simplest case, where the code will only run on desktop and the behavior
+should be consistent on all platforms, you can hard-code a single target:
+
+```dart
+import 'package:flutter/foundation.dart'
+    show debugDefaultTargetPlatformOverride;
+[...]
+
+void main() {
+  debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
+  [...]
+}
+```
+
+If the code needs to run on both mobile and desktop, or you want different
+behavior on different desktop platforms, you can conditionalize on `Platform`.
+For example, the line in `main()` above could be replaced with a call to:
+
+```dart
+/// If the current platform is desktop, override the default platform to
+/// a supported platform (iOS for macOS, Android for Linux and Windows).
+/// Otherwise, do nothing.
+void _setTargetPlatformForDesktop() {
+  TargetPlatform targetPlatform;
+  if (Platform.isMacOS) {
+    targetPlatform = TargetPlatform.iOS;
+  } else if (Platform.isLinux || Platform.isWindows) {
+    targetPlatform = TargetPlatform.android;
+  }
+  if (targetPlatform != null) {
+    debugDefaultTargetPlatformOverride = targetPlatform;
+  }
+}
+```
+
+Note that the target platform you use will affect not only the behavior and
+appearance of the widgets, but also the expectations Flutter will have for
+what is available on the platform, such as fonts.
+
+### Fonts
+
+Flutter applications may default to fonts that are standard for the target
+platform, but unavailable on desktop. For instance, if the target platform is
+`TargetPlatform.iOS` the Material library will default to San Francisco, which
+is available on macOS but not Linux or Windows.
+
+Most applications will need to set the font (e.g., via `ThemeData`) based
+on the host platform, or set a specific font that is bundled with the
+application. The example application demonstrates using and bundling Roboto
+on all platforms.
+
+Symptoms of missing fonts can include text failing to display, console logging
+about failure to load fonts, or in some cases crashes.
+
 ## Feedback and Discussion
 
 For bug reports and specific feature requests, you can file GitHub issues. For

--- a/example_flutter/lib/main.dart
+++ b/example_flutter/lib/main.dart
@@ -13,12 +13,20 @@
 // limitations under the License.
 import 'dart:io' show Platform;
 
+import 'package:flutter/foundation.dart'
+    show debugDefaultTargetPlatformOverride;
 import 'package:flutter/material.dart';
+
 import 'package:color_panel/color_panel.dart';
 import 'package:file_chooser/file_chooser.dart' as file_chooser;
 import 'package:menubar/menubar.dart';
 
-void main() => runApp(new MyApp());
+void main() {
+  // Desktop platforms are not recognized as valid targets by
+  // Flutter; force a specific target to prevent exceptions.
+  debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
+  runApp(new MyApp());
+}
 
 /// Top level widget for the example application.
 class MyApp extends StatefulWidget {
@@ -121,9 +129,8 @@ class _AppState extends State<MyApp> {
         primarySwatch: Colors.blue,
         primaryColor: _primaryColor,
         accentColor: _primaryColor,
-        // Specify a platform and font to reduce potential issues with the
+        // Specify a font to reduce potential issues with the
         // example behaving differently on different platforms.
-        platform: TargetPlatform.fuchsia,
         fontFamily: 'Roboto',
       ),
       home: _MyHomePage(title: 'Flutter Demo Home Page', counter: _counter),


### PR DESCRIPTION
Flutter no longer maps desktop host platforms to mobile target
platforms, and instead throws 'Unknown platform' exceptions.
This adds a debugDefaultTargetPlatformOverride to bypass the
detection logic so that the example runs on desktop.

Also updates the main README to include a section on likely pitfalls
when attempting to run a stock Flutter application on desktop (so far,
this issue and font handling), along with suggested solutions.