### PR TITLE
Extract codecs from plugin API

### DIFF
--- a/linux/library/include/flutter_desktop_embedding/json_method_call.h
+++ b/linux/library/include/flutter_desktop_embedding/json_method_call.h
@@ -1,0 +1,53 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_METHOD_CALL_H_
+#define LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_METHOD_CALL_H_
+
+#include <string>
+
+#include <json/json.h>
+
+#include "method_call.h"
+
+namespace flutter_desktop_embedding {
+
+// A concrete implmentation of MethodCall for use with the JSON codec.
+class JsonMethodCall : public MethodCall {
+ public:
+  // Creates a MethodCall with the given name and, optionally, arguments.
+  explicit JsonMethodCall(const std::string &method_name,
+                          const Json::Value &arguments = Json::Value());
+  ~JsonMethodCall();
+
+  // Prevent copying.
+  JsonMethodCall(JsonMethodCall const &) = delete;
+  JsonMethodCall &operator=(JsonMethodCall const &) = delete;
+
+  // MethodCall:
+  // Returns a pointer to a Json::Value object. This will never return null;
+  // 'no arguments' is represented with a JSON::nullValue.
+  const void *arguments() const override;
+
+  // Returns a reference to the object pointed to by arguments().
+  // This is a convience method for code that is interacting directly with a
+  // JsonMethodCall to avoid casting and dereferencing.
+  const Json::Value &GetArgumentsAsJson() const;
+
+ private:
+  Json::Value arguments_;
+};
+
+}  // namespace flutter_desktop_embedding
+
+#endif  // LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_METHOD_CALL_H_

--- a/linux/library/include/flutter_desktop_embedding/json_method_codec.h
+++ b/linux/library/include/flutter_desktop_embedding/json_method_codec.h
@@ -1,0 +1,61 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_METHOD_CODEC_H_
+#define LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_METHOD_CODEC_H_
+
+#include <json/json.h>
+
+#include "method_codec.h"
+
+namespace flutter_desktop_embedding {
+
+// An implementation of MethodCodec that uses JSON strings as the serialization.
+//
+// void* types in this implementation must always be Json::Value* types (from
+// the jsoncpp library).
+class JsonMethodCodec : public MethodCodec {
+ public:
+  // Returns the shared instance of the codec.
+  static const JsonMethodCodec &GetInstance();
+
+  ~JsonMethodCodec() = default;
+
+  // Prevent copying.
+  JsonMethodCodec(JsonMethodCodec const &) = delete;
+  JsonMethodCodec &operator=(JsonMethodCodec const &) = delete;
+
+ protected:
+  // Instances should be obtained via GetInstance.
+  JsonMethodCodec() = default;
+
+  // MethodCodec:
+  std::unique_ptr<MethodCall> DecodeMethodCallInternal(
+      const uint8_t *message, const size_t message_size) const override;
+  std::unique_ptr<std::vector<uint8_t>> EncodeMethodCallInternal(
+      const MethodCall &method_call) const override;
+  std::unique_ptr<std::vector<uint8_t>> EncodeSuccessEnvelopeInternal(
+      const void *result) const override;
+  std::unique_ptr<std::vector<uint8_t>> EncodeErrorEnvelopeInternal(
+      const std::string &error_code, const std::string &error_message,
+      const void *error_details) const override;
+
+ private:
+  // Serializes |json| into a byte stream.
+  std::unique_ptr<std::vector<uint8_t>> EncodeJsonObject(
+      const Json::Value &json) const;
+};
+
+}  // namespace flutter_desktop_embedding
+
+#endif  // LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_METHOD_CODEC_H_

--- a/linux/library/include/flutter_desktop_embedding/json_plugin.h
+++ b/linux/library/include/flutter_desktop_embedding/json_plugin.h
@@ -1,0 +1,55 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_PLUGIN_H_
+#define LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_PLUGIN_H_
+
+#include "json_method_call.h"
+#include "plugin.h"
+
+namespace flutter_desktop_embedding {
+
+// A base class for plugins using the JSON method codec.
+//
+// Provides a few utility shims from the type-agnostic Plugin class.
+class JsonPlugin : public Plugin {
+ public:
+  // See Plugin for constructor details.
+  explicit JsonPlugin(const std::string &channel, bool input_blocking = false);
+  virtual ~JsonPlugin();
+
+  // Prevent copying.
+  JsonPlugin(JsonPlugin const &) = delete;
+  JsonPlugin &operator=(JsonPlugin const &) = delete;
+
+  // Plugin implementation:
+  const MethodCodec &GetCodec() const override;
+  void HandleMethodCall(const MethodCall &method_call,
+                        std::unique_ptr<MethodResult> result) override;
+
+ protected:
+  // Identical to HandleMethodCall, except that the call has been cast to the
+  // more specific type. Subclasses must implement this instead of
+  // HandleMethodCall.
+  virtual void HandleJsonMethodCall(const JsonMethodCall &method_call,
+                                    std::unique_ptr<MethodResult> result) = 0;
+
+  // Calls InvokeMethodCall with a JsonMethodCall constructed from the given
+  // values.
+  void InvokeMethod(const std::string &method,
+                    const Json::Value &arguments = Json::Value());
+};
+
+}  // namespace flutter_desktop_embedding
+
+#endif  // LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_PLUGIN_H_

--- a/linux/library/include/flutter_desktop_embedding/method_call.h
+++ b/linux/library/include/flutter_desktop_embedding/method_call.h
@@ -14,43 +14,31 @@
 #ifndef LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_METHOD_CALL_H_
 #define LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_METHOD_CALL_H_
 
-#include <json/json.h>
-
-#include <memory>
 #include <string>
-
-#include <flutter_embedder.h>
 
 namespace flutter_desktop_embedding {
 
 // An object encapsulating a method call from Flutter.
-// TODO: Move serialization details into a method codec class, to match mobile
-// Flutter plugin APIs.
 class MethodCall {
  public:
-  // Creates a MethodCall with the given name and, optionally, arguments.
-  explicit MethodCall(const std::string &method_name,
-                      const Json::Value &arguments = Json::Value());
+  // Creates a MethodCall with the given name. Used only as a superclass
+  // constructor for subclasses, which should also take the arguments.
+  explicit MethodCall(const std::string &method_name);
+  virtual ~MethodCall();
 
-  // Returns a new MethodCall created from a JSON message received from the
-  // Flutter engine.
-  static std::unique_ptr<MethodCall> CreateFromMessage(
-      const Json::Value &message);
-  ~MethodCall();
+  // Prevent copying.
+  MethodCall(MethodCall const &) = delete;
+  MethodCall &operator=(MethodCall const &) = delete;
 
   // The name of the method being called.
   const std::string &method_name() const { return method_name_; }
 
-  // The arguments to the method call, or a nullValue if there are none.
-  const Json::Value &arguments() const { return arguments_; }
-
-  // Returns a version of the method call serialized in the format expected by
-  // the Flutter engine.
-  Json::Value AsMessage() const;
+  // The arguments to the method call, or NULL if there are none. The type of
+  // the object being pointed to is determined by the concrete subclasses.
+  virtual const void *arguments() const = 0;
 
  private:
   std::string method_name_;
-  Json::Value arguments_;
 };
 
 }  // namespace flutter_desktop_embedding

--- a/linux/library/include/flutter_desktop_embedding/method_codec.h
+++ b/linux/library/include/flutter_desktop_embedding/method_codec.h
@@ -1,0 +1,68 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_METHOD_CODEC_H_
+#define LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_METHOD_CODEC_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "method_call.h"
+
+namespace flutter_desktop_embedding {
+
+// Translates between a binary message and higher-level method call and
+// response/error objects.
+class MethodCodec {
+ public:
+  virtual ~MethodCodec();
+
+  // Returns the MethodCall encoded in |message|, or nullptr if it cannot be
+  // decoded.
+  // TODO: Consider adding absl as a dependency and using absl::Span.
+  std::unique_ptr<MethodCall> DecodeMethodCall(const uint8_t *message,
+                                               const size_t message_size) const;
+
+  // Returns a binary encoding of the given |method_call|, or nullptr if the
+  // method call cannot be serialized by this codec.
+  std::unique_ptr<std::vector<uint8_t>> EncodeMethodCall(
+      const MethodCall &method_call) const;
+
+  // Returns a binary encoding of |result|. |result| must be a type supported
+  // by the codec.
+  std::unique_ptr<std::vector<uint8_t>> EncodeSuccessEnvelope(
+      const void *result = nullptr) const;
+
+  // Returns a binary encoding of |error|. The |error_details| must be a type
+  // supported by the codec.
+  std::unique_ptr<std::vector<uint8_t>> EncodeErrorEnvelope(
+      const std::string &error_code, const std::string &error_message = "",
+      const void *error_details = nullptr) const;
+
+ protected:
+  // Implementations of the public interface, to be provided by subclasses.
+  virtual std::unique_ptr<MethodCall> DecodeMethodCallInternal(
+      const uint8_t *message, const size_t message_size) const = 0;
+  virtual std::unique_ptr<std::vector<uint8_t>> EncodeMethodCallInternal(
+      const MethodCall &method_call) const = 0;
+  virtual std::unique_ptr<std::vector<uint8_t>> EncodeSuccessEnvelopeInternal(
+      const void *result) const = 0;
+  virtual std::unique_ptr<std::vector<uint8_t>> EncodeErrorEnvelopeInternal(
+      const std::string &error_code, const std::string &error_message,
+      const void *error_details) const = 0;
+};
+
+}  // namespace flutter_desktop_embedding
+
+#endif  // LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_METHOD_CODEC_H_

--- a/linux/library/include/flutter_desktop_embedding/plugin.h
+++ b/linux/library/include/flutter_desktop_embedding/plugin.h
@@ -14,8 +14,6 @@
 #ifndef LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_PLUGIN_H_
 #define LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_PLUGIN_H_
 
-#include <json/json.h>
-
 #include <functional>
 #include <memory>
 #include <string>
@@ -23,13 +21,14 @@
 #include <flutter_embedder.h>
 
 #include "method_call.h"
+#include "method_codec.h"
 #include "method_result.h"
 
 namespace flutter_desktop_embedding {
 
 // Represents a plugin that can be registered with the Flutter Embedder.
 //
-// A plugin listens on a platform channel and processes JSON requests that come
+// A plugin listens on a platform channel and processes requests that come
 // in on said channel.  See https://flutter.io/platform-channels/ for more
 // details on what these channels look like.
 class Plugin {
@@ -39,8 +38,11 @@ class Plugin {
   // |input_blocking| Determines whether user input should be blocked during the
   // duration of this plugin's platform callback handler (in most cases this
   // can be set to false).
-  explicit Plugin(std::string channel, bool input_blocking = false);
+  explicit Plugin(const std::string &channel, bool input_blocking = false);
   virtual ~Plugin();
+
+  // Returns the codec to use for this plugin.
+  virtual const MethodCodec &GetCodec() const = 0;
 
   // Handles a method call from Flutter on this platform's channel.
   //
@@ -65,8 +67,7 @@ class Plugin {
 
  protected:
   // Calls a method in the Flutter engine on this Plugin's channel.
-  void InvokeMethod(const std::string &method,
-                    const Json::Value &arguments = Json::Value());
+  void InvokeMethodCall(const MethodCall &method_call);
 
  private:
   std::string channel_;

--- a/linux/library/src/embedder.cc
+++ b/linux/library/src/embedder.cc
@@ -11,12 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "linux/library/include/flutter_desktop_embedding/embedder.h"
+#include <flutter_desktop_embedding/embedder.h>
 
 #include <X11/Xlib.h>
 #include <assert.h>
 #include <gtk/gtk.h>
-#include <json/json.h>
 
 #include <chrono>
 #include <cstdlib>
@@ -26,8 +25,6 @@
 
 #include <flutter_embedder.h>
 
-#include "linux/library/include/flutter_desktop_embedding/method_call.h"
-#include "linux/library/include/flutter_desktop_embedding/method_result.h"
 #include "linux/library/src/internal/keyboard_hook_handler.h"
 #include "linux/library/src/internal/plugin_handler.h"
 #include "linux/library/src/internal/text_input_plugin.h"
@@ -92,28 +89,11 @@ static void GLFWOnFlutterPlatformMessage(const FlutterPlatformMessage *message,
               << message->struct_size << std::endl;
     return;
   }
+
   GLFWwindow *window = reinterpret_cast<GLFWwindow *>(user_data);
-  Json::CharReaderBuilder reader_builder;
-  std::unique_ptr<Json::CharReader> parser(reader_builder.newCharReader());
-  Json::Value json;
-  std::string parse_errors;
-  auto raw_message = reinterpret_cast<const char *>(message->message);
-  bool parsing_successful = parser->parse(
-      raw_message, raw_message + message->message_size, &json, &parse_errors);
-  if (!parsing_successful) {
-    std::cerr << "Unable to parse platform message" << std::endl
-              << parse_errors << std::endl;
-    return;
-  }
   auto state = GetSavedEmbedderState(window);
-  std::string channel(message->channel);
-  std::unique_ptr<flutter_desktop_embedding::MethodCall> method_call =
-      flutter_desktop_embedding::MethodCall::CreateFromMessage(json);
-  auto result = std::make_unique<flutter_desktop_embedding::JsonMethodResult>(
-      state->engine, message->response_handle);
-  state->plugin_handler->HandleMethodCall(
-      channel, *method_call, std::move(result),
-      [window] { GLFWClearEventCallbacks(window); },
+  state->plugin_handler->HandleMethodCallMessage(
+      message, [window] { GLFWClearEventCallbacks(window); },
       [window] { GLFWAssignEventCallbacks(window); });
 }
 
@@ -274,15 +254,15 @@ GLFWwindow *CreateFlutterWindow(size_t initial_width, size_t initial_height,
     return nullptr;
   }
   GLFWClearCanvas(window);
-  auto flutter_engine_run_result = RunFlutterEngine(
-      window, main_path, assets_path, packages_path, icu_data_path, argc, argv);
-  if (flutter_engine_run_result == nullptr) {
+  auto engine = RunFlutterEngine(window, main_path, assets_path, packages_path,
+                                 icu_data_path, argc, argv);
+  if (engine == nullptr) {
     glfwDestroyWindow(window);
     return nullptr;
   }
   FlutterEmbedderState *state = new FlutterEmbedderState();
-  state->plugin_handler = std::make_unique<PluginHandler>();
-  state->engine = flutter_engine_run_result;
+  state->plugin_handler = std::make_unique<PluginHandler>(engine);
+  state->engine = engine;
   auto input_plugin = std::make_unique<TextInputPlugin>();
   state->keyboard_hook_handlers.push_back(input_plugin.get());
 

--- a/linux/library/src/internal/engine_method_result.cc
+++ b/linux/library/src/internal/engine_method_result.cc
@@ -1,0 +1,74 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "linux/library/src/internal/engine_method_result.h"
+
+#include <iostream>
+
+namespace flutter_desktop_embedding {
+
+EngineMethodResult::EngineMethodResult(
+    FlutterEngine engine,
+    const FlutterPlatformMessageResponseHandle *response_handle,
+    const MethodCodec *codec)
+    : engine_(engine), response_handle_(response_handle), codec_(codec) {
+  if (!response_handle_) {
+    std::cerr << "Error: Response handle must be provided for a response."
+              << std::endl;
+  }
+}
+
+EngineMethodResult::~EngineMethodResult() {
+  if (response_handle_) {
+    // Warn, rather than send a not-implemented response, since the engine may
+    // no longer be valid at this point.
+    std::cerr
+        << "Warning: Failed to respond to a message. This is a memory leak."
+        << std::endl;
+  }
+}
+
+void EngineMethodResult::SuccessInternal(const void *result) {
+  std::unique_ptr<std::vector<uint8_t>> data =
+      codec_->EncodeSuccessEnvelope(result);
+  SendResponseData(data.get());
+}
+
+void EngineMethodResult::ErrorInternal(const std::string &error_code,
+                                       const std::string &error_message,
+                                       const void *error_details) {
+  std::unique_ptr<std::vector<uint8_t>> data =
+      codec_->EncodeErrorEnvelope(error_code, error_message, error_details);
+  SendResponseData(data.get());
+}
+
+void EngineMethodResult::NotImplementedInternal() { SendResponseData(nullptr); }
+
+void EngineMethodResult::SendResponseData(const std::vector<uint8_t> *data) {
+  if (!response_handle_) {
+    std::cerr
+        << "Error: Response can be set only once. Ignoring duplicate response."
+        << std::endl;
+    return;
+  }
+
+  const uint8_t *message = data && !data->empty() ? data->data() : nullptr;
+  size_t message_size = data ? data->size() : 0;
+  FlutterEngineSendPlatformMessageResponse(engine_, response_handle_, message,
+                                           message_size);
+  // The engine frees the response handle once
+  // FlutterEngineSendPlatformMessageResponse is called.
+  response_handle_ = nullptr;
+}
+
+}  // namespace flutter_desktop_embedding

--- a/linux/library/src/internal/engine_method_result.h
+++ b/linux/library/src/internal/engine_method_result.h
@@ -39,6 +39,7 @@ class EngineMethodResult : public MethodResult {
   ~EngineMethodResult();
 
  protected:
+  // MethodResult:
   void SuccessInternal(const void *result) override;
   void ErrorInternal(const std::string &error_code,
                      const std::string &error_message,

--- a/linux/library/src/internal/engine_method_result.h
+++ b/linux/library/src/internal/engine_method_result.h
@@ -1,0 +1,61 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LINUX_LIBRARY_SRC_INTERNAL_ENGINE_METHOD_RESULT_H_
+#define LINUX_LIBRARY_SRC_INTERNAL_ENGINE_METHOD_RESULT_H_
+
+#include <string>
+#include <vector>
+
+#include <flutter_embedder.h>
+
+#include "linux/library/include/flutter_desktop_embedding/method_codec.h"
+#include "linux/library/include/flutter_desktop_embedding/method_result.h"
+
+namespace flutter_desktop_embedding {
+
+// Implemention of MethodResult that sends responses to the Flutter egnine.
+class EngineMethodResult : public MethodResult {
+ public:
+  // Creates a result object that will send results to |engine|, tagged as
+  // associated with |response_handle|, encoded using |codec|. The |engine|
+  // and |codec| pointers must remain valid for as long as this object exists.
+  //
+  // If the codec is null, only NotImplemented() may be called.
+  EngineMethodResult(
+      FlutterEngine engine,
+      const FlutterPlatformMessageResponseHandle *response_handle,
+      const MethodCodec *codec);
+  ~EngineMethodResult();
+
+ protected:
+  void SuccessInternal(const void *result) override;
+  void ErrorInternal(const std::string &error_code,
+                     const std::string &error_message,
+                     const void *error_details) override;
+  void NotImplementedInternal() override;
+
+ private:
+  // Sends the given response data (which must either be nullptr, which
+  // indicates an unhandled method, or a response serialized with |codec_|) to
+  // the engine.
+  void SendResponseData(const std::vector<uint8_t> *data);
+
+  FlutterEngine engine_;
+  const FlutterPlatformMessageResponseHandle *response_handle_;
+  const MethodCodec *codec_;
+};
+
+}  // namespace flutter_desktop_embedding
+
+#endif  // LINUX_LIBRARY_SRC_INTERNAL_ENGINE_METHOD_RESULT_H_

--- a/linux/library/src/internal/keyboard_hook_handler.h
+++ b/linux/library/src/internal/keyboard_hook_handler.h
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef LINUX_LIBRARY_SRC_INTERNAL_KEYBOARD_HOOK_HANDLER_H_
-#define LINUX_LIBRARY_SRC_INTERNAL_KEYBOARD_HOOK_HANDLER_H_
+#ifndef LINUX_LIBRARY_SRC_INTERNAL_INPUT_KEYBOARD_HOOK_HANDLER_H_
+#define LINUX_LIBRARY_SRC_INTERNAL_INPUT_KEYBOARD_HOOK_HANDLER_H_
 
 #include <GLFW/glfw3.h>
 
@@ -31,4 +31,4 @@ class KeyboardHookHandler {
 
 }  // namespace flutter_desktop_embedding
 
-#endif  // LINUX_LIBRARY_SRC_INTERNAL_KEYBOARD_HOOK_HANDLER_H_
+#endif  // LINUX_LIBRARY_SRC_INTERNAL_INPUT_KEYBOARD_HOOK_HANDLER_H_

--- a/linux/library/src/internal/text_input_model.h
+++ b/linux/library/src/internal/text_input_model.h
@@ -14,8 +14,9 @@
 #ifndef LINUX_LIBRARY_SRC_INTERNAL_TEXT_INPUT_MODEL_H_
 #define LINUX_LIBRARY_SRC_INTERNAL_TEXT_INPUT_MODEL_H_
 
-#include <json/json.h>
 #include <string>
+
+#include <json/json.h>
 
 namespace flutter_desktop_embedding {
 // Handles underlying text input state, using a simple ASCII model.
@@ -94,4 +95,4 @@ class TextInputModel {
 
 }  // namespace flutter_desktop_embedding
 
-#endif  // LINUX_LIBRARY_SRC_INTERNAL_INPUT_MODEL_H_
+#endif  // LINUX_LIBRARY_SRC_INTERNAL_TEXT_INPUT_MODEL_H_

--- a/linux/library/src/internal/text_input_plugin.cc
+++ b/linux/library/src/internal/text_input_plugin.cc
@@ -92,12 +92,12 @@ void TextInputPlugin::KeyboardHook(GLFWwindow *window, int key, int scancode,
 }
 
 TextInputPlugin::TextInputPlugin()
-    : Plugin(kChannelName, false), active_model_(nullptr) {}
+    : JsonPlugin(kChannelName, false), active_model_(nullptr) {}
 
 TextInputPlugin::~TextInputPlugin() {}
 
-void TextInputPlugin::HandleMethodCall(const MethodCall &method_call,
-                                       std::unique_ptr<MethodResult> result) {
+void TextInputPlugin::HandleJsonMethodCall(
+    const JsonMethodCall &method_call, std::unique_ptr<MethodResult> result) {
   const std::string &method = method_call.method_name();
 
   if (method.compare(kShowMethod) == 0 || method.compare(kHideMethod) == 0) {
@@ -106,7 +106,7 @@ void TextInputPlugin::HandleMethodCall(const MethodCall &method_call,
     active_model_ = nullptr;
   } else {
     // Every following method requires args.
-    const Json::Value &args = method_call.arguments();
+    const Json::Value &args = method_call.GetArgumentsAsJson();
     if (args.isNull()) {
       result->Error(kBadArgumentError, "Method invoked without args");
       return;

--- a/linux/library/src/internal/text_input_plugin.h
+++ b/linux/library/src/internal/text_input_plugin.h
@@ -17,7 +17,7 @@
 #include <map>
 #include <memory>
 
-#include "linux/library/include/flutter_desktop_embedding/plugin.h"
+#include "linux/library/include/flutter_desktop_embedding/json_plugin.h"
 #include "linux/library/src/internal/keyboard_hook_handler.h"
 #include "linux/library/src/internal/text_input_model.h"
 
@@ -26,14 +26,14 @@ namespace flutter_desktop_embedding {
 // Implements a text input plugin.
 //
 // Specifically handles window events within GLFW.
-class TextInputPlugin : public KeyboardHookHandler, public Plugin {
+class TextInputPlugin : public KeyboardHookHandler, public JsonPlugin {
  public:
   TextInputPlugin();
   virtual ~TextInputPlugin();
 
   // Plugin.
-  void HandleMethodCall(const MethodCall &method_call,
-                        std::unique_ptr<MethodResult> result) override;
+  void HandleJsonMethodCall(const JsonMethodCall &method_call,
+                            std::unique_ptr<MethodResult> result) override;
 
   // KeyboardHookHandler.
   void KeyboardHook(GLFWwindow *window, int key, int scancode, int action,

--- a/linux/library/src/json_method_call.cc
+++ b/linux/library/src/json_method_call.cc
@@ -11,22 +11,20 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "linux/library/include/flutter_desktop_embedding/method_result.h"
+#include "linux/library/include/flutter_desktop_embedding/json_method_call.h"
 
 namespace flutter_desktop_embedding {
 
-MethodResult::MethodResult() {}
+JsonMethodCall::JsonMethodCall(const std::string &method_name,
+                               const Json::Value &arguments)
+    : MethodCall(method_name), arguments_(arguments) {}
 
-MethodResult::~MethodResult() {}
+JsonMethodCall::~JsonMethodCall() {}
 
-void MethodResult::Success(const void *result) { SuccessInternal(result); }
+const void *JsonMethodCall::arguments() const { return &arguments_; }
 
-void MethodResult::Error(const std::string &error_code,
-                         const std::string &error_message,
-                         const void *error_details) {
-  ErrorInternal(error_code, error_message, error_details);
+const Json::Value &JsonMethodCall::GetArgumentsAsJson() const {
+  return arguments_;
 }
-
-void MethodResult::NotImplemented() { NotImplementedInternal(); }
 
 }  // namespace flutter_desktop_embedding

--- a/linux/library/src/json_method_codec.cc
+++ b/linux/library/src/json_method_codec.cc
@@ -1,0 +1,99 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "linux/library/include/flutter_desktop_embedding/json_method_codec.h"
+
+#include <iostream>
+
+#include "linux/library/include/flutter_desktop_embedding/json_method_call.h"
+
+namespace flutter_desktop_embedding {
+
+namespace {
+// Keys used in MethodCall encoding.
+constexpr char kMessageMethodKey[] = "method";
+constexpr char kMessageArgumentsKey[] = "args";
+}  // namespace
+
+// static
+const JsonMethodCodec &JsonMethodCodec::GetInstance() {
+  static JsonMethodCodec sInstance;
+  return sInstance;
+}
+
+std::unique_ptr<MethodCall> JsonMethodCodec::DecodeMethodCallInternal(
+    const uint8_t *message, const size_t message_size) const {
+  Json::CharReaderBuilder reader_builder;
+  std::unique_ptr<Json::CharReader> parser(reader_builder.newCharReader());
+
+  auto raw_message = reinterpret_cast<const char *>(message);
+  Json::Value json_message;
+  std::string parse_errors;
+  bool parsing_successful = parser->parse(
+      raw_message, raw_message + message_size, &json_message, &parse_errors);
+  if (!parsing_successful) {
+    std::cerr << "Unable to parse JSON method call:" << std::endl
+              << parse_errors << std::endl;
+    return nullptr;
+  }
+
+  Json::Value method = json_message[kMessageMethodKey];
+  if (method.isNull()) {
+    return nullptr;
+  }
+  Json::Value arguments = json_message[kMessageArgumentsKey];
+  return std::make_unique<JsonMethodCall>(method.asString(), arguments);
+}
+
+std::unique_ptr<std::vector<uint8_t>> JsonMethodCodec::EncodeMethodCallInternal(
+    const MethodCall &method_call) const {
+  Json::Value message(Json::objectValue);
+  message[kMessageMethodKey] = method_call.method_name();
+  message[kMessageArgumentsKey] =
+      *static_cast<const Json::Value *>(method_call.arguments());
+
+  return EncodeJsonObject(message);
+}
+
+std::unique_ptr<std::vector<uint8_t>>
+JsonMethodCodec::EncodeSuccessEnvelopeInternal(const void *result) const {
+  Json::Value envelope(Json::arrayValue);
+  envelope.append(result == nullptr
+                      ? Json::Value()
+                      : *static_cast<const Json::Value *>(result));
+  return EncodeJsonObject(envelope);
+}
+
+std::unique_ptr<std::vector<uint8_t>>
+JsonMethodCodec::EncodeErrorEnvelopeInternal(const std::string &error_code,
+                                             const std::string &error_message,
+                                             const void *error_details) const {
+  Json::Value envelope(Json::arrayValue);
+  envelope.append(error_code);
+  envelope.append(error_message.empty() ? Json::Value() : error_message);
+  envelope.append(error_details == nullptr
+                      ? Json::Value()
+                      : *static_cast<const Json::Value *>(error_details));
+  return EncodeJsonObject(envelope);
+}
+
+std::unique_ptr<std::vector<uint8_t>> JsonMethodCodec::EncodeJsonObject(
+    const Json::Value &json) const {
+  Json::StreamWriterBuilder writer_builder;
+  std::string serialization = Json::writeString(writer_builder, json);
+
+  return std::make_unique<std::vector<uint8_t>>(serialization.begin(),
+                                                serialization.end());
+}
+
+}  // namespace flutter_desktop_embedding

--- a/linux/library/src/method_call.cc
+++ b/linux/library/src/method_call.cc
@@ -15,30 +15,9 @@
 
 namespace flutter_desktop_embedding {
 
-constexpr char kMessageMethodKey[] = "method";
-constexpr char kMessageArgumentsKey[] = "args";
-
-MethodCall::MethodCall(const std::string &method_name,
-                       const Json::Value &arguments)
-    : method_name_(method_name), arguments_(arguments) {}
+MethodCall::MethodCall(const std::string &method_name)
+    : method_name_(method_name) {}
 
 MethodCall::~MethodCall() {}
-
-std::unique_ptr<MethodCall> MethodCall::CreateFromMessage(
-    const Json::Value &message) {
-  Json::Value method = message[kMessageMethodKey];
-  if (method.isNull()) {
-    return nullptr;
-  }
-  Json::Value arguments = message[kMessageArgumentsKey];
-  return std::make_unique<MethodCall>(method.asString(), arguments);
-}
-
-Json::Value MethodCall::AsMessage() const {
-  Json::Value message(Json::objectValue);
-  message[kMessageMethodKey] = method_name_;
-  message[kMessageArgumentsKey] = arguments_;
-  return message;
-}
 
 }  // namespace flutter_desktop_embedding

--- a/linux/library/src/method_codec.cc
+++ b/linux/library/src/method_codec.cc
@@ -1,0 +1,41 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "linux/library/include/flutter_desktop_embedding/method_codec.h"
+
+namespace flutter_desktop_embedding {
+
+MethodCodec::~MethodCodec() {}
+
+std::unique_ptr<MethodCall> MethodCodec::DecodeMethodCall(
+    const uint8_t *message, const size_t message_size) const {
+  return DecodeMethodCallInternal(message, message_size);
+}
+
+std::unique_ptr<std::vector<uint8_t>> MethodCodec::EncodeMethodCall(
+    const MethodCall &method_call) const {
+  return EncodeMethodCallInternal(method_call);
+}
+
+std::unique_ptr<std::vector<uint8_t>> MethodCodec::EncodeSuccessEnvelope(
+    const void *result) const {
+  return EncodeSuccessEnvelopeInternal(result);
+}
+
+std::unique_ptr<std::vector<uint8_t>> MethodCodec::EncodeErrorEnvelope(
+    const std::string &error_code, const std::string &error_message,
+    const void *error_details) const {
+  return EncodeErrorEnvelopeInternal(error_code, error_message, error_details);
+}
+
+}  // namespace flutter_desktop_embedding

--- a/macos/library/FLEChannels.h
+++ b/macos/library/FLEChannels.h
@@ -16,15 +16,8 @@
 
 /**
  * An object encapsulating a method call from Flutter.
- *
- * TODO: Move serialization details into a method codec class, to match mobile Flutter plugin APIs.
  */
 @interface FLEMethodCall : NSObject
-
-/**
- * Returns a new FLEMethodCall created from a JSON message received from the Flutter engine.
- */
-+ (nullable instancetype)methodCallFromMessage:(nonnull NSDictionary *)message;
 
 /**
  * Initializes an FLEMethodCall. If |arguments| is provided, it must be serializable to JSON.
@@ -46,11 +39,6 @@
  * for supported types.
  */
 @property(readonly, nonatomic, nullable) id arguments;
-
-/**
- * Returns a version of the method call serialized in the format expected by the Flutter engine.
- */
-- (nonnull NSDictionary *)asMessage;
 
 @end
 
@@ -100,11 +88,3 @@ extern NSString const *_Nonnull FLEMethodNotImplemented;
 @property(readonly, nonatomic, nullable) id details;
 
 @end
-
-/**
- * Returns the serialized JSON data that should be sent to the engine for the given
- * FLEMethodResult argument.
- *
- * // TODO: Move this logic into method codecs.
- */
-NSData *_Nullable EngineResponseForMethodResult(id _Nullable result);

--- a/macos/library/FLECodecs.h
+++ b/macos/library/FLECodecs.h
@@ -44,7 +44,7 @@
 - (nullable NSData*)encodeSuccessEnvelope:(nullable id)result;
 
 /**
- * Returns a binary encoding of |error|. Returns nil if the |details| parameter of |erorr| is not
+ * Returns a binary encoding of |error|. Returns nil if the |details| parameter of |error| is not
  * a type supported by the codec.
  */
 - (nullable NSData*)encodeErrorEnvelope:(nonnull FLEMethodError*)error;
@@ -55,7 +55,7 @@
  * A codec that uses JSON as the encoding format. Method arguments and error details for plugins
  * using this codec must be serializable to JSON.
  */
-@interface FLEJSONMethodCodec : NSObject <FLEMethodCodec>
+@interface FLEJSONMethodCodec : NSObject<FLEMethodCodec>
 @end
 
 // TODO: Implement the other core Flutter codecs. Issue #67.

--- a/macos/library/FLECodecs.h
+++ b/macos/library/FLECodecs.h
@@ -1,0 +1,61 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import "FLEChannels.h"
+
+/**
+ * Translates between a binary message and higher-level method call and response/error objects.
+ */
+@protocol FLEMethodCodec
+
+/**
+ * Returns the shared instance of the codec.
+ */
++ (nonnull instancetype)sharedInstance;
+
+/**
+ * Returns a binary encoding of the given |methodCall|, or nil if the method call cannot be
+ * serialized by this codec.
+ */
+- (nullable NSData*)encodeMethodCall:(nonnull FLEMethodCall*)methodCall;
+
+/**
+ * Returns the FLEMethodCall encoded in |methodData|, or nil if it cannot be decoded.
+ */
+- (nullable FLEMethodCall*)decodeMethodCall:(nonnull NSData*)methodData;
+
+/**
+ * Returns a binary encoding of |result|. Returns nil if |result| is not a type supported by the
+ * codec.
+ */
+- (nullable NSData*)encodeSuccessEnvelope:(nullable id)result;
+
+/**
+ * Returns a binary encoding of |error|. Returns nil if the |details| parameter of |erorr| is not
+ * a type supported by the codec.
+ */
+- (nullable NSData*)encodeErrorEnvelope:(nonnull FLEMethodError*)error;
+
+@end
+
+/**
+ * A codec that uses JSON as the encoding format. Method arguments and error details for plugins
+ * using this codec must be serializable to JSON.
+ */
+@interface FLEJSONMethodCodec : NSObject <FLEMethodCodec>
+@end
+
+// TODO: Implement the other core Flutter codecs. Issue #67.

--- a/macos/library/FLECodecs.m
+++ b/macos/library/FLECodecs.m
@@ -1,0 +1,85 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FLECodecs.h"
+
+// Keys for JSON-encoded method calls.
+static NSString *const kMessageMethodKey = @"method";
+static NSString *const kMessageArgumentsKey = @"args";
+
+/**
+ * Returns the JSON serialiazation of |object|. If |object| is not serializable to JSON, logs an
+ * error and returns nil.
+ */
+static NSData *SerializeAsJSON(id object) {
+  if (![NSJSONSerialization isValidJSONObject:object]) {
+    NSLog(@"Error: Unable to construct a valid JSON object from %@", object);
+    return nil;
+  }
+
+  NSError *error = nil;
+  NSData *data = [NSJSONSerialization dataWithJSONObject:object options:0 error:&error];
+  if (error) {
+    NSLog(@"Error: Failed to create JSON message for %@: %@", object, error.debugDescription);
+  }
+  return data;
+}
+
+// See the documentation for the Dart JSONMethodCodec class for the JSON structures used by this
+// this class.
+@implementation FLEJSONMethodCodec
+
+#pragma mark FLEMethodCodec
+
++ (instancetype)sharedInstance {
+  static FLEJSONMethodCodec *sharedInstance;
+  if (!sharedInstance) {
+    sharedInstance = [[FLEJSONMethodCodec alloc] init];
+  }
+  return sharedInstance;
+}
+
+- (NSData *)encodeMethodCall:(FLEMethodCall *)methodCall {
+  return SerializeAsJSON(@{
+    kMessageMethodKey : methodCall.methodName,
+    kMessageArgumentsKey : methodCall.arguments ?: [NSNull null],
+  });
+}
+
+- (FLEMethodCall *)decodeMethodCall:(NSData *)methodData {
+  NSDictionary *message = [NSJSONSerialization JSONObjectWithData:methodData options:0 error:NULL];
+  NSString *method = message[kMessageMethodKey];
+  if (!method) {
+    return nil;
+  }
+  id arguments = message[kMessageArgumentsKey];
+  if (arguments == [NSNull null]) {
+    arguments = nil;
+  }
+  return [[FLEMethodCall alloc] initWithMethodName:method arguments:arguments];
+}
+
+- (NSData *)encodeSuccessEnvelope:(id _Nullable)result {
+  return SerializeAsJSON(@[ result ?: [NSNull null] ]);
+}
+
+- (NSData *)encodeErrorEnvelope:(FLEMethodError *)error {
+  return SerializeAsJSON(@[
+    error.code,
+    error.message ?: [NSNull null],
+    error.details ?: [NSNull null],
+  ]);
+}
+
+@end

--- a/macos/library/FLEPlugin.h
+++ b/macos/library/FLEPlugin.h
@@ -15,14 +15,18 @@
 #import <Foundation/Foundation.h>
 
 #import "FLEChannels.h"
+#import "FLECodecs.h"
 
 @class FLEViewController;
 
 /**
  * A plugin is an object that can respond appropriately to Flutter platform messages over a specific
  * named system channel. See https://flutter.io/platform-channels/.
+ *
+ * Note: This interface will be changing in the future to more closely match the iOS Flutter
+ * platform message API. It will be a one-time breaking change.
  */
-@protocol FLEPlugin
+@protocol FLEPlugin <NSObject>
 
 /**
  * A weak reference to the owning controller. May be used to send messages to the Flutter
@@ -49,5 +53,16 @@
  * -[FLEViewController invokeMethod:arguments:onChannel:].
  */
 - (void)handleMethodCall:(nonnull FLEMethodCall *)call result:(nonnull FLEMethodResult)result;
+
+@optional
+
+/**
+ * If implemented, returns the codec to use for method calls to this plugin.
+ *
+ * If not implemented, the codec is assumed to be FLEJSONMethodCodec. Note that this is different
+ * from existing Flutter platforms, which default to the standard codec; this is to preserve
+ * backwards compatibility for FLEPlugin until the breaking change for the platform messages API.
+ */
+@property(nonnull, readonly) id<FLEMethodCodec> codec;
 
 @end

--- a/macos/library/FLEViewController.h
+++ b/macos/library/FLEViewController.h
@@ -14,6 +14,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+#import "FLECodecs.h"
 #import "FLEOpenGLContextHandling.h"
 #import "FLEPlugin.h"
 
@@ -71,9 +72,19 @@
 - (BOOL)addPlugin:(nonnull id<FLEPlugin>)plugin;
 
 /**
- * Sends a platform message to the Flutter engine on the given channel.
+ * Sends a platform message to the Flutter engine on |channel|, encoded using |codec|.
  *
+ * // TODO: Move to an API that mirrors the FlutterMethodChannel API.
  * // TODO: Support responses.
+ */
+- (void)invokeMethod:(nonnull NSString *)method
+           arguments:(nullable id)arguments
+           onChannel:(nonnull NSString *)channel
+           withCodec:(nonnull id<FLEMethodCodec>)codec;
+
+/**
+ * Calls invokeMethod:arguments:onChannel:withCodec: using FLEJSONCodec. See the note in
+ * FLEPlugin.h for why JSON is the default.
  */
 - (void)invokeMethod:(nonnull NSString *)method
            arguments:(nullable id)arguments

--- a/macos/library/FlutterEmbedderMac.xcodeproj/project.pbxproj
+++ b/macos/library/FlutterEmbedderMac.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		1E2492411FCF50BE00DD3BBB /* FlutterEmbedderMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E2492371FCF50BE00DD3BBB /* FlutterEmbedderMac.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1EEF8E071FD1F0C300DD563C /* FLEView.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EEF8E051FD1F0C300DD563C /* FLEView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1EEF8E081FD1F0C300DD563C /* FLEView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EEF8E061FD1F0C300DD563C /* FLEView.m */; };
+		33A87EB620F6BCDB0086D21D /* FLECodecs.h in Headers */ = {isa = PBXBuildFile; fileRef = 33A87EB420F6BCDB0086D21D /* FLECodecs.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		33A87EB720F6BCDB0086D21D /* FLECodecs.m in Sources */ = {isa = PBXBuildFile; fileRef = 33A87EB520F6BCDB0086D21D /* FLECodecs.m */; };
 		33D7B59920A4F54400296EFC /* FLEChannels.h in Headers */ = {isa = PBXBuildFile; fileRef = 33D7B59720A4F54400296EFC /* FLEChannels.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		33D7B59A20A4F54400296EFC /* FLEChannels.m in Sources */ = {isa = PBXBuildFile; fileRef = 33D7B59820A4F54400296EFC /* FLEChannels.m */; };
 		AA8AE8B81FD948AC00B6FB31 /* FLETextInputModel.h in Headers */ = {isa = PBXBuildFile; fileRef = AA8AE8B71FD948AC00B6FB31 /* FLETextInputModel.h */; };
@@ -75,6 +77,8 @@
 		1E2492381FCF50BE00DD3BBB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		1EEF8E051FD1F0C300DD563C /* FLEView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEView.h; sourceTree = "<group>"; };
 		1EEF8E061FD1F0C300DD563C /* FLEView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEView.m; sourceTree = "<group>"; };
+		33A87EB420F6BCDB0086D21D /* FLECodecs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FLECodecs.h; sourceTree = "<group>"; };
+		33A87EB520F6BCDB0086D21D /* FLECodecs.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FLECodecs.m; sourceTree = "<group>"; };
 		33B1650F201A5F7D00732DC9 /* FlutterEmbedder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FlutterEmbedder.framework; path = ../../../flutter_engine_framework/macos/FlutterEmbedder.framework; sourceTree = SOURCE_ROOT; };
 		33D7B59720A4F54400296EFC /* FLEChannels.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FLEChannels.h; sourceTree = "<group>"; };
 		33D7B59820A4F54400296EFC /* FLEChannels.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FLEChannels.m; sourceTree = "<group>"; };
@@ -102,6 +106,7 @@
 				1E2492371FCF50BE00DD3BBB /* FlutterEmbedderMac.h */,
 				1E2492451FCF536200DD3BBB /* Public */,
 				33D7B59820A4F54400296EFC /* FLEChannels.m */,
+				33A87EB520F6BCDB0086D21D /* FLECodecs.m */,
 				AA8AE8B91FD948BA00B6FB31 /* FLETextInputModel.m */,
 				1E2492341FCF50BE00DD3BBB /* FLETextInputPlugin.m */,
 				1E2492361FCF50BE00DD3BBB /* FLEViewController.m */,
@@ -124,6 +129,7 @@
 			isa = PBXGroup;
 			children = (
 				33D7B59720A4F54400296EFC /* FLEChannels.h */,
+				33A87EB420F6BCDB0086D21D /* FLECodecs.h */,
 				1E24922F1FCF50BE00DD3BBB /* FLEOpenGLContextHandling.h */,
 				1E2492311FCF50BE00DD3BBB /* FLEPlugin.h */,
 				1E2492321FCF50BE00DD3BBB /* FLEReshapeListener.h */,
@@ -159,6 +165,7 @@
 				1E24923C1FCF50BE00DD3BBB /* FLEReshapeListener.h in Headers */,
 				AA8AE8B81FD948AC00B6FB31 /* FLETextInputModel.h in Headers */,
 				1EEF8E071FD1F0C300DD563C /* FLEView.h in Headers */,
+				33A87EB620F6BCDB0086D21D /* FLECodecs.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -257,6 +264,7 @@
 				1E2492401FCF50BE00DD3BBB /* FLEViewController.m in Sources */,
 				1E24923E1FCF50BE00DD3BBB /* FLETextInputPlugin.m in Sources */,
 				1EEF8E081FD1F0C300DD563C /* FLEView.m in Sources */,
+				33A87EB720F6BCDB0086D21D /* FLECodecs.m in Sources */,
 				AA8AE8BA1FD948BA00B6FB31 /* FLETextInputModel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/plugins/color_panel/linux/include/color_panel/color_panel_plugin.h
+++ b/plugins/color_panel/linux/include/color_panel/color_panel_plugin.h
@@ -13,20 +13,21 @@
 // limitations under the License.
 #ifndef PLUGINS_COLOR_PANEL_LINUX_INCLUDE_COLOR_PANEL_COLOR_PANEL_PLUGIN_H_
 #define PLUGINS_COLOR_PANEL_LINUX_INCLUDE_COLOR_PANEL_COLOR_PANEL_PLUGIN_H_
-#include <flutter_desktop_embedding/plugin.h>
 
 #include <memory>
+
+#include <flutter_desktop_embedding/json_plugin.h>
 
 namespace plugins_color_panel {
 
 // A plugin for communicating with a native color picker panel.
-class ColorPanelPlugin : public flutter_desktop_embedding::Plugin {
+class ColorPanelPlugin : public flutter_desktop_embedding::JsonPlugin {
  public:
   ColorPanelPlugin();
   virtual ~ColorPanelPlugin();
 
-  void HandleMethodCall(
-      const flutter_desktop_embedding::MethodCall &method_call,
+  void HandleJsonMethodCall(
+      const flutter_desktop_embedding::JsonMethodCall &method_call,
       std::unique_ptr<flutter_desktop_embedding::MethodResult> result) override;
 
  protected:

--- a/plugins/color_panel/linux/src/color_panel_plugin.cc
+++ b/plugins/color_panel/linux/src/color_panel_plugin.cc
@@ -21,7 +21,7 @@
 static constexpr char kWindowTitle[] = "Flutter Color Picker";
 
 namespace plugins_color_panel {
-using flutter_desktop_embedding::MethodCall;
+using flutter_desktop_embedding::JsonMethodCall;
 using flutter_desktop_embedding::MethodResult;
 
 // Private implementation class containing the color picker widget.
@@ -86,12 +86,12 @@ class ColorPanelPlugin::ColorPanel {
 };
 
 ColorPanelPlugin::ColorPanelPlugin()
-    : Plugin(kChannelName), color_panel_(nullptr) {}
+    : JsonPlugin(kChannelName), color_panel_(nullptr) {}
 
 ColorPanelPlugin::~ColorPanelPlugin() {}
 
-void ColorPanelPlugin::HandleMethodCall(const MethodCall &method_call,
-                                        std::unique_ptr<MethodResult> result) {
+void ColorPanelPlugin::HandleJsonMethodCall(
+    const JsonMethodCall &method_call, std::unique_ptr<MethodResult> result) {
   if (method_call.method_name().compare(kShowColorPanelMethod) == 0) {
     result->Success();
     // There is only one color panel that can be displayed at once.

--- a/plugins/file_chooser/linux/include/file_chooser/file_chooser_plugin.h
+++ b/plugins/file_chooser/linux/include/file_chooser/file_chooser_plugin.h
@@ -13,18 +13,19 @@
 // limitations under the License.
 #ifndef PLUGINS_FILE_CHOOSER_LINUX_INCLUDE_FILE_CHOOSER_FILE_CHOOSER_PLUGIN_H_
 #define PLUGINS_FILE_CHOOSER_LINUX_INCLUDE_FILE_CHOOSER_FILE_CHOOSER_PLUGIN_H_
-#include <flutter_desktop_embedding/plugin.h>
+
+#include <flutter_desktop_embedding/json_plugin.h>
 
 namespace plugins_file_chooser {
 
 // Implements a file chooser plugin.
-class FileChooserPlugin : public flutter_desktop_embedding::Plugin {
+class FileChooserPlugin : public flutter_desktop_embedding::JsonPlugin {
  public:
   FileChooserPlugin();
   virtual ~FileChooserPlugin();
 
-  void HandleMethodCall(
-      const flutter_desktop_embedding::MethodCall &method_call,
+  void HandleJsonMethodCall(
+      const flutter_desktop_embedding::JsonMethodCall &method_call,
       std::unique_ptr<flutter_desktop_embedding::MethodResult> result) override;
 };
 


### PR DESCRIPTION
The splitting of channel.* into separate files for each class, and the fact that plugin_handler was changed enough that it wasn't recognized as a move, makes the Linux change look larger than it actually is (as does the define guard and include path churn). If that gets in the way of reviewing let me know and I can retroactively create a prequel that does all the source rearranging and include path cleanup without any of the code changes.