### PR TITLE
Linux library file cleanup

### DIFF
--- a/linux/library/Makefile
+++ b/linux/library/Makefile
@@ -14,12 +14,14 @@
 FLUTTER_ENGINE_LIB_NAME=flutter_engine
 FLUTTER_ENGINE_LIB_FILE=lib$(FLUTTER_ENGINE_LIB_NAME).so
 FLUTTER_ENGINE_HEADER=flutter_embedder.h
-TOOLS_DIR=../../tools
+PROJECT_ROOT=../..
+TOOLS_DIR=$(PROJECT_ROOT)/tools
 ENGINE_UPDATER=$(TOOLS_DIR)/update_flutter_engine
 FLUTTER_DIR=$(shell "$(TOOLS_DIR)/flutter_location")
 LIBRARY_OUT=libflutter_embedder.so
 CXX=g++ -std=c++14
 CXXFLAGS= -Wall -Werror -shared -fPIC \
+	-I$(PROJECT_ROOT) \
 	-I$(CURDIR)/include \
 	$(shell pkg-config --cflags gtk+-3.0 epoxy x11 jsoncpp)
 LDFLAGS= -L$(CURDIR) \

--- a/linux/library/include/flutter_desktop_embedding/channels.h
+++ b/linux/library/include/flutter_desktop_embedding/channels.h
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_CHANNELS_H_
-#define LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_CHANNELS_H_
+#ifndef LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_CHANNELS_H_
+#define LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_CHANNELS_H_
 
 #include <json/json.h>
 
@@ -117,4 +117,4 @@ class JsonMethodResult : public MethodResult {
 
 }  // namespace flutter_desktop_embedding
 
-#endif  // LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_CHANNELS_H_
+#endif  // LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_CHANNELS_H_

--- a/linux/library/include/flutter_desktop_embedding/embedder.h
+++ b/linux/library/include/flutter_desktop_embedding/embedder.h
@@ -22,7 +22,7 @@
 #include <memory>
 #include <string>
 
-#include <flutter_desktop_embedding/plugin.h>
+#include "plugin.h"
 
 namespace flutter_desktop_embedding {
 

--- a/linux/library/include/flutter_desktop_embedding/plugin.h
+++ b/linux/library/include/flutter_desktop_embedding/plugin.h
@@ -11,8 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_PLUGIN_H_
-#define LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_PLUGIN_H_
+#ifndef LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_PLUGIN_H_
+#define LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_PLUGIN_H_
+
 #include <json/json.h>
 
 #include <functional>
@@ -75,4 +76,4 @@ class Plugin {
 
 }  // namespace flutter_desktop_embedding
 
-#endif  // LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_PLUGIN_H_
+#endif  // LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_PLUGIN_H_

--- a/linux/library/src/channels.cc
+++ b/linux/library/src/channels.cc
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <flutter_desktop_embedding/channels.h>
+#include "linux/library/include/flutter_desktop_embedding/channels.h"
 
 #include <iostream>
 

--- a/linux/library/src/embedder.cc
+++ b/linux/library/src/embedder.cc
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <flutter_desktop_embedding/embedder.h>
+#include "linux/library/include/flutter_desktop_embedding/embedder.h"
 
 #include <X11/Xlib.h>
 #include <assert.h>
@@ -24,11 +24,12 @@
 #include <memory>
 #include <string>
 
-#include <flutter_desktop_embedding/channels.h>
-#include <flutter_desktop_embedding/input/keyboard_hook_handler.h>
-#include <flutter_desktop_embedding/plugin_handler.h>
-#include <flutter_desktop_embedding/text_input_plugin.h>
 #include <flutter_embedder.h>
+
+#include "linux/library/include/flutter_desktop_embedding/channels.h"
+#include "linux/library/src/internal/keyboard_hook_handler.h"
+#include "linux/library/src/internal/plugin_handler.h"
+#include "linux/library/src/internal/text_input_plugin.h"
 
 static_assert(FLUTTER_ENGINE_VERSION == 1, "");
 

--- a/linux/library/src/internal/keyboard_hook_handler.h
+++ b/linux/library/src/internal/keyboard_hook_handler.h
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_INPUT_KEYBOARD_HOOK_HANDLER_H_
-#define LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_INPUT_KEYBOARD_HOOK_HANDLER_H_
+#ifndef LINUX_LIBRARY_SRC_INTERNAL_KEYBOARD_HOOK_HANDLER_H_
+#define LINUX_LIBRARY_SRC_INTERNAL_KEYBOARD_HOOK_HANDLER_H_
 
 #include <GLFW/glfw3.h>
 
@@ -31,4 +31,4 @@ class KeyboardHookHandler {
 
 }  // namespace flutter_desktop_embedding
 
-#endif  // LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_INPUT_KEYBOARD_HOOK_HANDLER_H_
+#endif  // LINUX_LIBRARY_SRC_INTERNAL_KEYBOARD_HOOK_HANDLER_H_

--- a/linux/library/src/internal/plugin_handler.cc
+++ b/linux/library/src/internal/plugin_handler.cc
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <flutter_desktop_embedding/plugin_handler.h>
+#include "linux/library/src/internal/plugin_handler.h"
 
 #include <iostream>
 

--- a/linux/library/src/internal/plugin_handler.h
+++ b/linux/library/src/internal/plugin_handler.h
@@ -11,15 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_PLUGIN_HANDLER_H_
-#define LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_PLUGIN_HANDLER_H_
+#ifndef LINUX_LIBRARY_SRC_INTERNAL_PLUGIN_HANDLER_H_
+#define LINUX_LIBRARY_SRC_INTERNAL_PLUGIN_HANDLER_H_
 
 #include <json/json.h>
 #include <map>
 #include <memory>
 #include <string>
 
-#include "plugin.h"
+#include "linux/library/include/flutter_desktop_embedding/plugin.h"
 
 namespace flutter_desktop_embedding {
 
@@ -56,4 +56,4 @@ class PluginHandler {
 
 }  // namespace flutter_desktop_embedding
 
-#endif  // LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_PLUGIN_HANDLER_H_
+#endif  // LINUX_LIBRARY_SRC_INTERNAL_PLUGIN_HANDLER_H_

--- a/linux/library/src/internal/text_input_model.cc
+++ b/linux/library/src/internal/text_input_model.cc
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <flutter_desktop_embedding/text_input_model.h>
+#include "linux/library/src/internal/text_input_model.h"
 
 #include <iostream>
 

--- a/linux/library/src/internal/text_input_model.h
+++ b/linux/library/src/internal/text_input_model.h
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_TEXT_INPUT_MODEL_H_
-#define LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_TEXT_INPUT_MODEL_H_
+#ifndef LINUX_LIBRARY_SRC_INTERNAL_TEXT_INPUT_MODEL_H_
+#define LINUX_LIBRARY_SRC_INTERNAL_TEXT_INPUT_MODEL_H_
 
 #include <json/json.h>
 #include <string>
@@ -94,4 +94,4 @@ class TextInputModel {
 
 }  // namespace flutter_desktop_embedding
 
-#endif  // LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_TEXT_INPUT_MODEL_H_
+#endif  // LINUX_LIBRARY_SRC_INTERNAL_INPUT_MODEL_H_

--- a/linux/library/src/internal/text_input_plugin.cc
+++ b/linux/library/src/internal/text_input_plugin.cc
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <flutter_desktop_embedding/text_input_plugin.h>
+#include "linux/library/src/internal/text_input_plugin.h"
 
 #include <cstdint>
 #include <iostream>

--- a/linux/library/src/internal/text_input_plugin.h
+++ b/linux/library/src/internal/text_input_plugin.h
@@ -11,16 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_TEXT_INPUT_PLUGIN_H_
-#define LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_TEXT_INPUT_PLUGIN_H_
+#ifndef LINUX_LIBRARY_SRC_INTERNAL_TEXT_INPUT_PLUGIN_H_
+#define LINUX_LIBRARY_SRC_INTERNAL_TEXT_INPUT_PLUGIN_H_
 
 #include <map>
 #include <memory>
 
-#include <flutter_desktop_embedding/input/keyboard_hook_handler.h>
-
-#include "plugin.h"
-#include "text_input_model.h"
+#include "linux/library/include/flutter_desktop_embedding/plugin.h"
+#include "linux/library/src/internal/keyboard_hook_handler.h"
+#include "linux/library/src/internal/text_input_model.h"
 
 namespace flutter_desktop_embedding {
 
@@ -56,4 +55,4 @@ class TextInputPlugin : public KeyboardHookHandler, public Plugin {
 
 }  // namespace flutter_desktop_embedding
 
-#endif  // LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_TEXT_INPUT_PLUGIN_H_
+#endif  // LINUX_LIBRARY_SRC_INTERNAL_TEXT_INPUT_PLUGIN_H_

--- a/linux/library/src/plugin.cc
+++ b/linux/library/src/plugin.cc
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <flutter_desktop_embedding/plugin.h>
+#include "linux/library/include/flutter_desktop_embedding/plugin.h"
 
 namespace flutter_desktop_embedding {
 


### PR DESCRIPTION
Various minor cleanup to the Linux library source:
- Moves code (both implementation and headers) that's only intended for
  use by the embedding library, rather than clients of it, into a new
  src/internal.
- Standardizes include format: For public headers, use relative paths in
  quotes, to ensure the correct files are used. For everything else, use
  standard Google style of full path from repository root.
- Fixes a few include guards that didn't match the file path.