### PR TITLE
[linux] Split channels.h into separate files

### DIFF
--- a/linux/library/include/flutter_desktop_embedding/method_call.h
+++ b/linux/library/include/flutter_desktop_embedding/method_call.h
@@ -1,0 +1,58 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_METHOD_CALL_H_
+#define LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_METHOD_CALL_H_
+
+#include <json/json.h>
+
+#include <memory>
+#include <string>
+
+#include <flutter_embedder.h>
+
+namespace flutter_desktop_embedding {
+
+// An object encapsulating a method call from Flutter.
+// TODO: Move serialization details into a method codec class, to match mobile
+// Flutter plugin APIs.
+class MethodCall {
+ public:
+  // Creates a MethodCall with the given name and, optionally, arguments.
+  explicit MethodCall(const std::string &method_name,
+                      const Json::Value &arguments = Json::Value());
+
+  // Returns a new MethodCall created from a JSON message received from the
+  // Flutter engine.
+  static std::unique_ptr<MethodCall> CreateFromMessage(
+      const Json::Value &message);
+  ~MethodCall();
+
+  // The name of the method being called.
+  const std::string &method_name() const { return method_name_; }
+
+  // The arguments to the method call, or a nullValue if there are none.
+  const Json::Value &arguments() const { return arguments_; }
+
+  // Returns a version of the method call serialized in the format expected by
+  // the Flutter engine.
+  Json::Value AsMessage() const;
+
+ private:
+  std::string method_name_;
+  Json::Value arguments_;
+};
+
+}  // namespace flutter_desktop_embedding
+
+#endif  // LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_METHOD_CALL_H_

--- a/linux/library/include/flutter_desktop_embedding/method_result.h
+++ b/linux/library/include/flutter_desktop_embedding/method_result.h
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_CHANNELS_H_
-#define LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_CHANNELS_H_
+#ifndef LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_METHOD_RESULT_H_
+#define LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_METHOD_RESULT_H_
 
 #include <json/json.h>
 
@@ -22,36 +22,6 @@
 #include <flutter_embedder.h>
 
 namespace flutter_desktop_embedding {
-
-// An object encapsulating a method call from Flutter.
-// TODO: Move serialization details into a method codec class, to match mobile
-// Flutter plugin APIs.
-class MethodCall {
- public:
-  // Creates a MethodCall with the given name and, optionally, arguments.
-  explicit MethodCall(const std::string &method_name,
-                      const Json::Value &arguments = Json::Value());
-
-  // Returns a new MethodCall created from a JSON message received from the
-  // Flutter engine.
-  static std::unique_ptr<MethodCall> CreateFromMessage(
-      const Json::Value &message);
-  ~MethodCall();
-
-  // The name of the method being called.
-  const std::string &method_name() const { return method_name_; }
-
-  // The arguments to the method call, or a nullValue if there are none.
-  const Json::Value &arguments() const { return arguments_; }
-
-  // Returns a version of the method call serialized in the format expected by
-  // the Flutter engine.
-  Json::Value AsMessage() const;
-
- private:
-  std::string method_name_;
-  Json::Value arguments_;
-};
 
 // Encapsulates a result sent back to the Flutter engine in response to a
 // MethodCall. Only one method should be called on any given instance.
@@ -117,4 +87,4 @@ class JsonMethodResult : public MethodResult {
 
 }  // namespace flutter_desktop_embedding
 
-#endif  // LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_CHANNELS_H_
+#endif  // LINUX_LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_METHOD_RESULT_H_

--- a/linux/library/include/flutter_desktop_embedding/plugin.h
+++ b/linux/library/include/flutter_desktop_embedding/plugin.h
@@ -22,7 +22,8 @@
 
 #include <flutter_embedder.h>
 
-#include "channels.h"
+#include "method_call.h"
+#include "method_result.h"
 
 namespace flutter_desktop_embedding {
 

--- a/linux/library/src/embedder.cc
+++ b/linux/library/src/embedder.cc
@@ -26,7 +26,8 @@
 
 #include <flutter_embedder.h>
 
-#include "linux/library/include/flutter_desktop_embedding/channels.h"
+#include "linux/library/include/flutter_desktop_embedding/method_call.h"
+#include "linux/library/include/flutter_desktop_embedding/method_result.h"
 #include "linux/library/src/internal/keyboard_hook_handler.h"
 #include "linux/library/src/internal/plugin_handler.h"
 #include "linux/library/src/internal/text_input_plugin.h"

--- a/linux/library/src/method_call.cc
+++ b/linux/library/src/method_call.cc
@@ -1,0 +1,44 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "linux/library/include/flutter_desktop_embedding/method_call.h"
+
+namespace flutter_desktop_embedding {
+
+constexpr char kMessageMethodKey[] = "method";
+constexpr char kMessageArgumentsKey[] = "args";
+
+MethodCall::MethodCall(const std::string &method_name,
+                       const Json::Value &arguments)
+    : method_name_(method_name), arguments_(arguments) {}
+
+MethodCall::~MethodCall() {}
+
+std::unique_ptr<MethodCall> MethodCall::CreateFromMessage(
+    const Json::Value &message) {
+  Json::Value method = message[kMessageMethodKey];
+  if (method.isNull()) {
+    return nullptr;
+  }
+  Json::Value arguments = message[kMessageArgumentsKey];
+  return std::make_unique<MethodCall>(method.asString(), arguments);
+}
+
+Json::Value MethodCall::AsMessage() const {
+  Json::Value message(Json::objectValue);
+  message[kMessageMethodKey] = method_name_;
+  message[kMessageArgumentsKey] = arguments_;
+  return message;
+}
+
+}  // namespace flutter_desktop_embedding

--- a/linux/library/src/method_result.cc
+++ b/linux/library/src/method_result.cc
@@ -11,37 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "linux/library/include/flutter_desktop_embedding/channels.h"
+#include "linux/library/include/flutter_desktop_embedding/method_result.h"
 
 #include <iostream>
 
 namespace flutter_desktop_embedding {
-
-constexpr char kMessageMethodKey[] = "method";
-constexpr char kMessageArgumentsKey[] = "args";
-
-MethodCall::MethodCall(const std::string &method_name,
-                       const Json::Value &arguments)
-    : method_name_(method_name), arguments_(arguments) {}
-
-MethodCall::~MethodCall() {}
-
-std::unique_ptr<MethodCall> MethodCall::CreateFromMessage(
-    const Json::Value &message) {
-  Json::Value method = message[kMessageMethodKey];
-  if (method.isNull()) {
-    return nullptr;
-  }
-  Json::Value arguments = message[kMessageArgumentsKey];
-  return std::make_unique<MethodCall>(method.asString(), arguments);
-}
-
-Json::Value MethodCall::AsMessage() const {
-  Json::Value message(Json::objectValue);
-  message[kMessageMethodKey] = method_name_;
-  message[kMessageArgumentsKey] = arguments_;
-  return message;
-}
 
 void MethodResult::Success(const Json::Value &result) {
   SuccessInternal(result);


### PR DESCRIPTION
Splits MethodCall and MethodResult into separate files. This follows the
more usual C++ convention of having one file per class, and makes the
code structure more consistent with the Android Flutter plugin
implementation (vs. following the iOS file structure, as it did before).

This is purely a move of code, with no implementation changes.
It is a precursor to the next plugin refactor, to avoid having
substantial functionality change mixed with file moves.

JsonMethodResult is left with MethodResult since it will be eliminated
in the refactor anyway.