### PR TITLE
Enable checked mode for debug builds

### DIFF
--- a/linux/example/flutter_embedder_example.cc
+++ b/linux/example/flutter_embedder_example.cc
@@ -14,6 +14,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <memory>
+#include <vector>
 
 #include <color_panel/color_panel_plugin.h>
 #include <file_chooser/file_chooser_plugin.h>
@@ -25,18 +26,17 @@ int main(int argc, char **argv) {
     std::cout << "Couldn't init GLFW";
   }
   // Arguments for the Flutter Engine.
-  int arg_count = 2;
+  std::vector<std::string> arguments;
   // First argument is argv[0] since the engine is expecting real command line
   // args.
-  const char *args_arr[] = {
-      argv[0],
-      "--dart-non-checked-mode",
-      NULL,
-  };
+  arguments.push_back(argv[0]);
+#ifdef NDEBUG
+  arguments.push_back("--dart-non-checked-mode");
+#endif
   // Start the engine.
   auto window = flutter_desktop_embedding::CreateFlutterWindowInSnapshotMode(
       640, 480, flutter_example_root + "/build/flutter_assets",
-      "example/icudtl.dat", arg_count, const_cast<char **>(args_arr));
+      "example/icudtl.dat", arguments);
   if (window == nullptr) {
     glfwTerminate();
     return EXIT_FAILURE;

--- a/linux/library/include/flutter_desktop_embedding/embedder.h
+++ b/linux/library/include/flutter_desktop_embedding/embedder.h
@@ -40,8 +40,8 @@ GLFWwindow *CreateFlutterWindow(size_t initial_width, size_t initial_height,
                                 const std::string &main_path,
                                 const std::string &assets_path,
                                 const std::string &packages_path,
-                                const std::string &icu_data_path, int argc,
-                                char **argv);
+                                const std::string &icu_data_path,
+                                const std::vector<std::string> &arguments);
 
 // Creates a GLFW Window running a Flutter Application in snapshot mode.
 //
@@ -56,11 +56,10 @@ GLFWwindow *CreateFlutterWindow(size_t initial_width, size_t initial_height,
 //
 // Returns a null pointer in the event of an error. The caller owns the pointer
 // when it is non-null.
-GLFWwindow *CreateFlutterWindowInSnapshotMode(size_t initial_width,
-                                              size_t initial_height,
-                                              const std::string &assets_path,
-                                              const std::string &icu_data_path,
-                                              int argc, char **argv);
+GLFWwindow *CreateFlutterWindowInSnapshotMode(
+    size_t initial_width, size_t initial_height, const std::string &assets_path,
+    const std::string &icu_data_path,
+    const std::vector<std::string> &arguments);
 
 // Adds a plugin to the flutter_window.
 //

--- a/macos/example/ExampleWindow.swift
+++ b/macos/example/ExampleWindow.swift
@@ -18,14 +18,21 @@ class ExampleWindow: NSWindow {
   @IBOutlet weak var flutterViewController: FLEViewController!
 
   override func awakeFromNib() {
-    let assets = NSURL.fileURL(withPath: "flutter_assets", relativeTo: Bundle.main.resourceURL)
     flutterViewController.add(FLEColorPanelPlugin())
     flutterViewController.add(FLEFileChooserPlugin())
     flutterViewController.add(FLEMenubarPlugin())
+
+    let assets = NSURL.fileURL(withPath: "flutter_assets", relativeTo: Bundle.main.resourceURL)
+    // Pass through argument zero, since the Flutter engine expects to be processing a full
+    // command line string.
+    var arguments = [CommandLine.arguments[0]];
+#if !DEBUG
+    arguments.append("--dart-non-checked-mode");
+#endif
     flutterViewController.launchEngine(
       withAssetsPath: assets,
       asHeadless: false,
-      commandLineArguments: [CommandLine.arguments[0], "--dart-non-checked-mode"])
+      commandLineArguments: arguments)
 
     super.awakeFromNib()
   }

--- a/windows/example/flutter_embedder_example.cpp
+++ b/windows/example/flutter_embedder_example.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <iostream>
+#include <vector>
 
 #include <embedder.h>
 
@@ -21,20 +22,18 @@ int main(int argc, char **argv) {
     std::cout << "Couldn't init GLFW" << std::endl;
   }
   // Arguments for the Flutter Engine.
-  int arg_count = 2;
+  std::vector<std::string> arguments;
   // First argument is argv[0] since the engine is expecting real command line
   // args.
-  const char *args_arr[] = {
-      argv[0],
-      "--dart-non-checked-mode",
-      NULL,
-  };
+  arguments.push_back(argv[0]);
+#ifndef _DEBUG
+  arguments.push_back("--dart-non-checked-mode");
+#endif
   // Start the engine.
   // TODO: Make paths relative to the executable so it can be run from anywhere.
   auto window = CreateFlutterWindowInSnapshotMode(
       640, 480, "..\\example_flutter\\build\\flutter_assets",
-      "dependencies\\engine\\icudtl.dat", arg_count,
-      const_cast<char **>(args_arr));
+      "dependencies\\engine\\icudtl.dat", arguments);
   if (window == nullptr) {
     FlutterTerminate();
     return EXIT_FAILURE;

--- a/windows/library/embedder.cpp
+++ b/windows/library/embedder.cpp
@@ -14,8 +14,8 @@
 
 #include "embedder.h"
 
-#include <algorithm>
 #include <assert.h>
+#include <algorithm>
 #include <chrono>
 #include <iostream>
 
@@ -127,12 +127,11 @@ static void GLFWClearCanvas(GLFWwindow *window) {
 // the necessary callbacks for rendering within a GLFWwindow.
 //
 // Returns a caller-owned pointer to the engine.
-static FlutterEngine RunFlutterEngine(GLFWwindow *window,
-                                      const std::string &main_path,
-                                      const std::string &assets_path,
-                                      const std::string &packages_path,
-                                      const std::string &icu_data_path,
-                                      const std::vector<std::string> &arguments) {
+static FlutterEngine RunFlutterEngine(
+    GLFWwindow *window, const std::string &main_path,
+    const std::string &assets_path, const std::string &packages_path,
+    const std::string &icu_data_path,
+    const std::vector<std::string> &arguments) {
   std::vector<const char *> argv;
   std::transform(
       arguments.begin(), arguments.end(), std::back_inserter(argv),
@@ -191,8 +190,8 @@ GLFWwindow *CreateFlutterWindow(size_t initial_width, size_t initial_height,
 }
 
 GLFWwindow *CreateFlutterWindowInSnapshotMode(
-    size_t initial_width, size_t initial_height,
-    const std::string &assets_path, const std::string &icu_data_path,
+    size_t initial_width, size_t initial_height, const std::string &assets_path,
+    const std::string &icu_data_path,
     const std::vector<std::string> &arguments) {
   return CreateFlutterWindow(initial_width, initial_height, "", assets_path, "",
                              icu_data_path, arguments);

--- a/windows/library/embedder.h
+++ b/windows/library/embedder.h
@@ -16,6 +16,7 @@
 #define WINDOWS_LIBRARY_EMBEDDER_H_
 
 #include <string>
+#include <vector>
 
 #include <glfw3.h>
 
@@ -43,8 +44,8 @@ GLFWwindow *CreateFlutterWindow(size_t initial_width, size_t initial_height,
                                 const std::string &main_path,
                                 const std::string &assets_path,
                                 const std::string &packages_path,
-                                const std::string &icu_data_path, int argc,
-                                char **argv);
+                                const std::string &icu_data_path,
+                                const std::vector<std::string> &arguments);
 
 // Creates a GLFW Window running a Flutter Application in snapshot mode.
 //
@@ -59,11 +60,9 @@ GLFWwindow *CreateFlutterWindow(size_t initial_width, size_t initial_height,
 //
 // Returns a null pointer in the event of an error. The caller owns the pointer
 // when it is non-null.
-GLFWwindow *CreateFlutterWindowInSnapshotMode(size_t initial_width,
-                                              size_t initial_height,
-                                              const std::string &assets_path,
-                                              const std::string &icu_data_path,
-                                              int argc, char **argv);
+GLFWwindow *CreateFlutterWindowInSnapshotMode(
+    size_t initial_width, size_t initial_height, const std::string &assets_path,
+    const std::string &icu_data_path, const std::vector<std::string> &arguments);
 
 // Loops on flutter window events until termination.
 //

--- a/windows/library/embedder.h
+++ b/windows/library/embedder.h
@@ -62,7 +62,8 @@ GLFWwindow *CreateFlutterWindow(size_t initial_width, size_t initial_height,
 // when it is non-null.
 GLFWwindow *CreateFlutterWindowInSnapshotMode(
     size_t initial_width, size_t initial_height, const std::string &assets_path,
-    const std::string &icu_data_path, const std::vector<std::string> &arguments);
+    const std::string &icu_data_path,
+    const std::vector<std::string> &arguments);
 
 // Loops on flutter window events until termination.
 //


### PR DESCRIPTION
Since the example apps should show best practice, only enable
--dart-non-checked-mode for release builds. This also makes it easier
to do proper testing of Flutter framework and/or engine changes using
the example app.

On Windows and Linux, updated the launch APIs to take a vector of
strings to make it easier to manage optional arguments.