### PR TITLE
Add a wrapper script for 'flutter build bundle'

### DIFF
--- a/linux/example/Makefile
+++ b/linux/example/Makefile
@@ -16,7 +16,8 @@
 FLUTTER_EMBEDDER_LIB_DIR=$(CURDIR)/../library
 FLUTTER_APP_DIR=$(CURDIR)/../../example_flutter
 PLUGINS_DIR=$(CURDIR)/../../plugins
-FLUTTER_DIR=$(shell ../../tools/flutter_location)
+TOOLS_DIR=../../tools
+FLUTTER_DIR=$(shell $(TOOLS_DIR)/flutter_location)
 
 # Libraries
 FLUTTER_EMBEDDER_LIB_NAME=flutter_embedder
@@ -38,6 +39,7 @@ LIBRARY_DIRS=$(FLUTTER_EMBEDDER_LIB_DIR) $(PLUGIN_DIRS)
 INCLUDE_DIRS=$(patsubst %,%/include,$(LIBRARY_DIRS))
 
 # Tools
+BUILD_ASSETS_BIN=$(TOOLS_DIR)/build_flutter_assets
 FLUTTER_BIN=$(FLUTTER_DIR)/bin/flutter
 
 # Resources
@@ -104,8 +106,7 @@ bundleflutterassets: $(FLUTTER_ASSETS_SOURCE)
 # to know if 'build bundle' needs to be re-run.
 .PHONY: $(FLUTTER_ASSETS_SOURCE)
 $(FLUTTER_ASSETS_SOURCE):
-	cd $(FLUTTER_APP_DIR); \
-	$(FLUTTER_BIN) build bundle
+	$(BUILD_ASSETS_BIN) $(FLUTTER_APP_DIR)
 
 .PHONY: clean
 clean:

--- a/macos/example/Example Embedder.xcodeproj/project.pbxproj
+++ b/macos/example/Example Embedder.xcodeproj/project.pbxproj
@@ -349,7 +349,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$PROJECT_DIR\"/../../example_flutter\n\"$(\"$PROJECT_DIR\"/../../tools/flutter_location)\"/bin/flutter build bundle";
+			shellScript = "DEPOT_ROOT=\"$PROJECT_DIR\"/../..\n\"$DEPOT_ROOT\"/tools/build_flutter_assets \"$DEPOT_ROOT\"/example_flutter";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/tools/build_flutter_assets
+++ b/tools/build_flutter_assets
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs the necessary Flutter commands to build the Flutter assets
+# than need to be packaged in an embedding application.
+# It should be called with one argument, which is the directory of the
+# Flutter application to build.
+
+readonly base_dir="$(dirname "$0")"
+readonly flutter_dir="$("$base_dir/flutter_location")"
+readonly flutter_binary="$flutter_dir/bin/flutter"
+
+# To use a custom Flutter engine, uncomment the following variables, and set
+# engine_src_path to the path on your machine to your Flutter engine tree's
+# src/ directory (and build_type if your engine build is not debug).
+#readonly engine_src_path="/path/to/engine/src"
+#readonly build_type=host_debug_unopt
+#readonly extra_flags=(--local-engine-src-path $engine_src_path --local-engine=$build_type)
+
+cd $1
+echo Running "$flutter_binary" ${extra_flags[*]} build bundle
+exec "$flutter_binary" ${extra_flags[*]} build bundle

--- a/tools/build_flutter_assets.bat
+++ b/tools/build_flutter_assets.bat
@@ -1,0 +1,34 @@
+:: Copyright 2018 Google LLC
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::      http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+@echo off
+
+:: This script runs the necessary Flutter commands to build the Flutter assets
+:: than need to be packaged in an embedding application.
+:: It should be called with one argument, which is the directory of the
+:: Flutter application to build.
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+for /f "delims=" %%i in ('%~dp0flutter_location') do set FLUTTER_DIR=%%i
+set FLUTTER_BINARY=%FLUTTER_DIR%\bin\flutter
+
+:: To use a custom Flutter engine, uncomment the following variables, and set
+:: ENGINE_SRC_PATH to the path on your machine to your Flutter engine tree's
+:: src\ directory (and BUILD_TYPE if your engine build is not debug).
+::set ENGINE_SRC_PATH=path\to\engine\src
+::set BUILD_TYPE=host_debug_unopt
+::set EXTRA_FLAGS=--local-engine-src-path %ENGINE_SRC_PATH% --local-engine=%BUILD_TYPE%
+
+cd %1
+echo Running %FLUTTER_BINARY% %EXTRA_FLAGS% build bundle
+call %FLUTTER_BINARY% %EXTRA_FLAGS% build bundle

--- a/windows/scripts/build_example_app.bat
+++ b/windows/scripts/build_example_app.bat
@@ -12,6 +12,4 @@
 :: See the License for the specific language governing permissions and
 :: limitations under the License.
 @echo off
-for /f "delims=" %%i in ('%~dp0..\..\tools\flutter_location') do set FLUTTER_DIR=%%i
-cd ..\..\example_flutter
-%FLUTTER_DIR%\bin\flutter build bundle
+..\..\tools\build_flutter_assets ..\..\example_flutter


### PR DESCRIPTION
This consolidates the logic for creating the flutter_assets directory in
a central location, rather than it being embedded into each
platform-specific project. Benefits:
- Easier to update if the command changes, as happend with the change
  from flx to bundle. Clients can use this script and be insulated from
  any such changes in the future.
- Easier to understand the details of what's run without having to find
  it in the native projects (e.g., in Xcode, where it's non-trivial to
  find especially for people not familiar with Xcode's UI).
- Easier to change to a local engine build for testing, due to including
  the necessary flags as commended-out variables. (In the future, if
  it's sufficient useful, the scripts could be extended to take a config
  file as with Flutter location.)