### PR TITLE
[macos] Simplify view controller initialization

### DIFF
--- a/macos/library/FLEViewController.m
+++ b/macos/library/FLEViewController.m
@@ -171,7 +171,7 @@ static bool HeadlessOnMakeResourceCurrent(FLEViewController *controller) { retur
 /**
  * Performs initialization that's common between the different init paths.
  */
-void CommonInit(FLEViewController *controller) {
+static void CommonInit(FLEViewController *controller) {
   controller->_plugins = [[NSMutableDictionary alloc] init];
   controller->_additionalKeyResponders = [[NSMutableOrderedSet alloc] init];
 }


### PR DESCRIPTION
Moves internal plugin registration to just before the engine starts
rather than during init, to avoid the complexity of having plugin
registration potentially happening during init.

Also moves common ivar initialization from an ObjC method to a static
function, which is a safer pattern as it isn't subject to naming
collisions in subclasses.