### PR TITLE
[macos] Move FLEMethodCall and FLEMethodError

### DIFF
--- a/macos/library/FLEChannels.h
+++ b/macos/library/FLEChannels.h
@@ -15,38 +15,8 @@
 #import <Foundation/Foundation.h>
 
 /**
- * An object encapsulating a method call from Flutter.
- */
-@interface FLEMethodCall : NSObject
-
-/**
- * Initializes an FLEMethodCall. If |arguments| is provided, it must be serializable to JSON.
- */
-- (nonnull instancetype)initWithMethodName:(nonnull NSString *)name
-                                 arguments:(nullable id)arguments NS_DESIGNATED_INITIALIZER;
-- (nonnull instancetype)init NS_UNAVAILABLE;
-
-/**
- * The name of the method being called.
- */
-@property(readonly, nonatomic, nonnull) NSString *methodName;
-
-/**
- * The arguments to the method being called, if any.
- *
- * This object must be serializable to JSON. See
- * https://docs.flutter.io/flutter/services/JSONMethodCodec-class.html
- * for supported types.
- */
-@property(readonly, nonatomic, nullable) id arguments;
-
-@end
-
-#pragma mark -
-
-/**
  * A method call result callback. Used for sending a method call's response back to the
- * Flutter engine. The result must be serializable to JSON.
+ * Flutter engine. The result must be serializable by the codec used to encode the message.
  */
 typedef void (^FLEMethodResult)(id _Nullable result);
 
@@ -55,36 +25,3 @@ typedef void (^FLEMethodResult)(id _Nullable result);
  * (e.g., the method name is unknown).
  */
 extern NSString const *_Nonnull FLEMethodNotImplemented;
-
-/**
- * An error object that can be passed to an FLEMethodResult to send an error response to the caller
- * on the Flutter side.
- */
-@interface FLEMethodError : NSObject
-
-/**
- * Initializes an FLEMethodError. If |details| is provided, it must be serializable to JSON.
- */
-- (nonnull instancetype)initWithCode:(nonnull NSString *)code
-                             message:(nullable NSString *)message
-                             details:(nullable id)details NS_DESIGNATED_INITIALIZER;
-- (nonnull instancetype)init NS_UNAVAILABLE;
-
-/**
- * The error code, as a string.
- */
-@property(readonly, nonatomic, nonnull) NSString *code;
-
-/**
- * A human-readable description of the error.
- */
-@property(readonly, nonatomic, nullable) NSString *message;
-
-/**
- * Any additional details or context about the error.
- *
- * This object must be serializable to JSON.
- */
-@property(readonly, nonatomic, nullable) id details;
-
-@end

--- a/macos/library/FLEChannels.m
+++ b/macos/library/FLEChannels.m
@@ -15,35 +15,3 @@
 #import "FLEChannels.h"
 
 NSString const *FLEMethodNotImplemented = @"notimplemented";
-
-@implementation FLEMethodCall
-
-- (nonnull instancetype)initWithMethodName:(nonnull NSString *)name
-                                 arguments:(nullable id)arguments {
-  self = [super init];
-  if (self) {
-    _methodName = name;
-    _arguments = arguments;
-  }
-  return self;
-}
-
-@end
-
-#pragma mark -
-
-@implementation FLEMethodError
-
-- (nonnull instancetype)initWithCode:(nonnull NSString *)code
-                             message:(nullable NSString *)message
-                             details:(nullable id)details {
-  self = [super init];
-  if (self) {
-    _code = code;
-    _message = message;
-    _details = details;
-  }
-  return self;
-}
-
-@end

--- a/macos/library/FLECodecs.h
+++ b/macos/library/FLECodecs.h
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FLEChannels.h"
+#import "FLEMethods.h"
 
 /**
  * Translates between a binary message and higher-level method call and response/error objects.

--- a/macos/library/FLEMethods.h
+++ b/macos/library/FLEMethods.h
@@ -1,0 +1,77 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+/**
+ * An object encapsulating a method call from Flutter.
+ */
+@interface FLEMethodCall : NSObject
+
+/**
+ * Initializes an FLEMethodCall. If |arguments| is provided, it must be serializable by the codec
+ * used to encode the call.
+ */
+- (nonnull instancetype)initWithMethodName:(nonnull NSString *)name
+                                 arguments:(nullable id)arguments NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)init NS_UNAVAILABLE;
+
+/**
+ * The name of the method being called.
+ */
+@property(readonly, nonatomic, nonnull) NSString *methodName;
+
+/**
+ * The arguments to the method being called, if any.
+ *
+ * This object must be serializable by the codec used to encode the call.
+ */
+@property(readonly, nonatomic, nullable) id arguments;
+
+@end
+
+#pragma mark -
+
+/**
+ * An error object that can be passed to an FLEMethodResult to send an error response to the caller
+ * on the Flutter side.
+ */
+@interface FLEMethodError : NSObject
+
+/**
+ * Initializes an FLEMethodError. If |details| is provided, it must be serializable to JSON.
+ */
+- (nonnull instancetype)initWithCode:(nonnull NSString *)code
+                             message:(nullable NSString *)message
+                             details:(nullable id)details NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)init NS_UNAVAILABLE;
+
+/**
+ * The error code, as a string.
+ */
+@property(readonly, nonatomic, nonnull) NSString *code;
+
+/**
+ * A human-readable description of the error.
+ */
+@property(readonly, nonatomic, nullable) NSString *message;
+
+/**
+ * Any additional details or context about the error.
+ *
+ * This object must be serializable to JSON.
+ */
+@property(readonly, nonatomic, nullable) id details;
+
+@end

--- a/macos/library/FLEMethods.m
+++ b/macos/library/FLEMethods.m
@@ -1,0 +1,47 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FLEMethods.h"
+
+@implementation FLEMethodCall
+
+- (nonnull instancetype)initWithMethodName:(nonnull NSString *)name
+                                 arguments:(nullable id)arguments {
+  self = [super init];
+  if (self) {
+    _methodName = name;
+    _arguments = arguments;
+  }
+  return self;
+}
+
+@end
+
+#pragma mark -
+
+@implementation FLEMethodError
+
+- (nonnull instancetype)initWithCode:(nonnull NSString *)code
+                             message:(nullable NSString *)message
+                             details:(nullable id)details {
+  self = [super init];
+  if (self) {
+    _code = code;
+    _message = message;
+    _details = details;
+  }
+  return self;
+}
+
+@end

--- a/macos/library/FlutterEmbedderMac.h
+++ b/macos/library/FlutterEmbedderMac.h
@@ -14,6 +14,7 @@
 
 #import "FLEChannels.h"
 #import "FLECodecs.h"
+#import "FLEMethods.h"
 #import "FLEOpenGLContextHandling.h"
 #import "FLEPlugin.h"
 #import "FLEReshapeListener.h"

--- a/macos/library/FlutterEmbedderMac.xcodeproj/project.pbxproj
+++ b/macos/library/FlutterEmbedderMac.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		1E2492411FCF50BE00DD3BBB /* FlutterEmbedderMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E2492371FCF50BE00DD3BBB /* FlutterEmbedderMac.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1EEF8E071FD1F0C300DD563C /* FLEView.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EEF8E051FD1F0C300DD563C /* FLEView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1EEF8E081FD1F0C300DD563C /* FLEView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EEF8E061FD1F0C300DD563C /* FLEView.m */; };
+		3389A68D215949CB00A27898 /* FLEMethods.m in Sources */ = {isa = PBXBuildFile; fileRef = 3389A68C215949CB00A27898 /* FLEMethods.m */; };
+		3389A68F215949D600A27898 /* FLEMethods.h in Headers */ = {isa = PBXBuildFile; fileRef = 3389A68E215949D600A27898 /* FLEMethods.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		33A87EB620F6BCDB0086D21D /* FLECodecs.h in Headers */ = {isa = PBXBuildFile; fileRef = 33A87EB420F6BCDB0086D21D /* FLECodecs.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		33A87EB720F6BCDB0086D21D /* FLECodecs.m in Sources */ = {isa = PBXBuildFile; fileRef = 33A87EB520F6BCDB0086D21D /* FLECodecs.m */; };
 		33D7B59920A4F54400296EFC /* FLEChannels.h in Headers */ = {isa = PBXBuildFile; fileRef = 33D7B59720A4F54400296EFC /* FLEChannels.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -80,6 +82,8 @@
 		1E2492381FCF50BE00DD3BBB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		1EEF8E051FD1F0C300DD563C /* FLEView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEView.h; sourceTree = "<group>"; };
 		1EEF8E061FD1F0C300DD563C /* FLEView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEView.m; sourceTree = "<group>"; };
+		3389A68C215949CB00A27898 /* FLEMethods.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEMethods.m; sourceTree = "<group>"; };
+		3389A68E215949D600A27898 /* FLEMethods.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEMethods.h; sourceTree = "<group>"; };
 		33A87EB420F6BCDB0086D21D /* FLECodecs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FLECodecs.h; sourceTree = "<group>"; };
 		33A87EB520F6BCDB0086D21D /* FLECodecs.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FLECodecs.m; sourceTree = "<group>"; };
 		33B1650F201A5F7D00732DC9 /* FlutterEmbedder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FlutterEmbedder.framework; path = ../../../flutter_engine_framework/macos/FlutterEmbedder.framework; sourceTree = SOURCE_ROOT; };
@@ -113,6 +117,7 @@
 				1E2492451FCF536200DD3BBB /* Public */,
 				33D7B59820A4F54400296EFC /* FLEChannels.m */,
 				33A87EB520F6BCDB0086D21D /* FLECodecs.m */,
+				3389A68C215949CB00A27898 /* FLEMethods.m */,
 				AA8AE8B71FD948AC00B6FB31 /* FLETextInputModel.h */,
 				AA8AE8B91FD948BA00B6FB31 /* FLETextInputModel.m */,
 				1E2492331FCF50BE00DD3BBB /* FLETextInputPlugin.h */,
@@ -141,6 +146,7 @@
 			children = (
 				33D7B59720A4F54400296EFC /* FLEChannels.h */,
 				33A87EB420F6BCDB0086D21D /* FLECodecs.h */,
+				3389A68E215949D600A27898 /* FLEMethods.h */,
 				1E24922F1FCF50BE00DD3BBB /* FLEOpenGLContextHandling.h */,
 				1E2492311FCF50BE00DD3BBB /* FLEPlugin.h */,
 				1E2492321FCF50BE00DD3BBB /* FLEReshapeListener.h */,
@@ -177,6 +183,7 @@
 				AA8AE8B81FD948AC00B6FB31 /* FLETextInputModel.h in Headers */,
 				1EEF8E071FD1F0C300DD563C /* FLEView.h in Headers */,
 				33A87EB620F6BCDB0086D21D /* FLECodecs.h in Headers */,
+				3389A68F215949D600A27898 /* FLEMethods.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -273,6 +280,7 @@
 			files = (
 				33D7B59A20A4F54400296EFC /* FLEChannels.m in Sources */,
 				1E2492401FCF50BE00DD3BBB /* FLEViewController.m in Sources */,
+				3389A68D215949CB00A27898 /* FLEMethods.m in Sources */,
 				64C76C2820D7BE2E00B16256 /* FLEKeyEventPlugin.m in Sources */,
 				1E24923E1FCF50BE00DD3BBB /* FLETextInputPlugin.m in Sources */,
 				1EEF8E081FD1F0C300DD563C /* FLEView.m in Sources */,


### PR DESCRIPTION
Moves FLEMethodCall and FLEMethodError out of Channels.h. This better
aligns with the Flutter iOS structure, although this deviates in that on
iOS these classes live in the Codecs.* files, while this keeps them
separate to reduce the number of classes being declared in a single
header.

Preparation for the remaining plugin refactoring (which adds channel
classes to the Channels.* files).