### PR TITLE
[macos] Add MethodChannel

### DIFF
--- a/macos/library/FLEBinaryMessenger.h
+++ b/macos/library/FLEBinaryMessenger.h
@@ -1,0 +1,54 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+/**
+ * A message reply callback.
+ *
+ * Used for submitting a reply back to a Flutter message sender.
+ */
+typedef void (^FLEBinaryReply)(NSData *_Nullable reply);
+
+/**
+ * A message handler callback.
+ *
+ * Used for receiving messages from Flutter and providing an asynchronous reply.
+ */
+typedef void (^FLEBinaryMessageHandler)(NSData *_Nullable message, FLEBinaryReply _Nonnull reply);
+
+/**
+ * A protocol for a class that handles communication of binary data on named channels to and from
+ * the Flutter engine.
+ */
+@protocol FLEBinaryMessenger <NSObject>
+
+/**
+ * Sends a binary message to the Flutter side on the specified channel, expecting
+ * no reply.
+ */
+- (void)sendOnChannel:(nonnull NSString *)channel message:(nullable NSData *)message;
+
+// TODO: Add support for sendOnChannel:message:binaryReply: once
+// https://github.com/flutter/flutter/issues/18852 is fixed.
+
+/**
+ * Registers a message handler for incoming binary messages from the Flutter side
+ * on the specified channel.
+ *
+ * Replaces any existing handler. Provide a nil handler to unregister the existing handler.
+ */
+- (void)setMessageHandlerOnChannel:(nonnull NSString *)channel
+              binaryMessageHandler:(nullable FLEBinaryMessageHandler)handler;
+@end

--- a/macos/library/FLEChannels.h
+++ b/macos/library/FLEChannels.h
@@ -14,6 +14,10 @@
 
 #import <Foundation/Foundation.h>
 
+#import "FLEBinaryMessenger.h"
+#import "FLECodecs.h"
+#import "FLEMethods.h"
+
 /**
  * A method call result callback. Used for sending a method call's response back to the
  * Flutter engine. The result must be serializable by the codec used to encode the message.
@@ -21,7 +25,58 @@
 typedef void (^FLEMethodResult)(id _Nullable result);
 
 /**
+ * A handler for receiving a method call. Implementations should asynchronously call |result|
+ * exactly once with the result of handling method the call, with one of:
+ * - FLEMethodNotImplemented, if the method call is unknown.
+ * - An FLEMethodError, if the method call was understood but there was a
+ *   problem handling it.
+ * - Any other value (including nil) to indicate success. The value will
+ *   be returned to the Flutter caller.
+ */
+typedef void (^FLEMethodCallHandler)(FLEMethodCall *_Nonnull call, FLEMethodResult _Nonnull result);
+
+/**
  * A constant that can be passed to an FLEMethodResult to indicate that the message is not handled
  * (e.g., the method name is unknown).
  */
 extern NSString const *_Nonnull FLEMethodNotImplemented;
+
+/**
+ * A channel for communicating with the Flutter engine using invocation of asynchronous methods.
+ */
+@interface FLEMethodChannel : NSObject
+
+// TODO: support +methodChannelWithName:binaryMessenger: once the standard codec is supported
+// (Issue #67).
+
+/**
+ * Returns a new channel that sends and receives method calls on the channel name |name|, encoded
+ * with |codec| and dispatched via |messenger|.
+ */
++ (nonnull instancetype)methodChannelWithName:(nonnull NSString *)name
+                              binaryMessenger:(nonnull id<FLEBinaryMessenger>)messenger
+                                        codec:(nonnull id<FLEMethodCodec>)codec;
+/**
+ * Initializes a channel to send and receive method calls on the channel name |name|, encoded
+ * with |codec| and dispatched via |messenger|.
+ */
+- (nonnull instancetype)initWithName:(nonnull NSString *)name
+                     binaryMessenger:(nonnull id<FLEBinaryMessenger>)messenger
+                               codec:(nonnull id<FLEMethodCodec>)codec;
+
+/**
+ * Sends a platform message to the Flutter engine on this channel.
+ *
+ * The arguments, if any, must be encodable using this channel's codec.
+ */
+- (void)invokeMethod:(nonnull NSString *)method arguments:(id _Nullable)arguments;
+
+// TODO: Support invokeMethod:arguments:result: once
+// https://github.com/flutter/flutter/issues/18852 is resolved
+
+/**
+ * Registers a handler that should be called any time a method call is received on this channel.
+ */
+- (void)setMethodCallHandler:(FLEMethodCallHandler _Nullable)handler;
+
+@end

--- a/macos/library/FLEChannels.m
+++ b/macos/library/FLEChannels.m
@@ -15,3 +15,70 @@
 #import "FLEChannels.h"
 
 NSString const *FLEMethodNotImplemented = @"notimplemented";
+
+@implementation FLEMethodChannel {
+  NSString *_name;
+  __weak id<FLEBinaryMessenger> _messenger;
+  id<FLEMethodCodec> _codec;
+}
+
++ (instancetype)methodChannelWithName:(nonnull NSString *)name
+                      binaryMessenger:(nonnull id<FLEBinaryMessenger>)messenger
+                                codec:(nonnull NSObject<FLEMethodCodec> *)codec {
+  return [[[self class] alloc] initWithName:name binaryMessenger:messenger codec:codec];
+}
+
+- (instancetype)initWithName:(nonnull NSString *)name
+             binaryMessenger:(nonnull id<FLEBinaryMessenger>)messenger
+                       codec:(nonnull id<FLEMethodCodec>)codec {
+  self = [super init];
+  if (self) {
+    _name = [name copy];
+    _messenger = messenger;
+    _codec = codec;
+  }
+  return self;
+}
+
+- (void)invokeMethod:(NSString *)method arguments:(id _Nullable)arguments {
+  FLEMethodCall *methodCall = [[FLEMethodCall alloc] initWithMethodName:method arguments:arguments];
+  NSData *message = [_codec encodeMethodCall:methodCall];
+  if (!message) {
+    NSLog(@"Error: Unable to construct a message to call %@ on %@", method, _name);
+    return;
+  }
+  [_messenger sendOnChannel:_name message:message];
+}
+
+- (void)setMethodCallHandler:(FLEMethodCallHandler _Nullable)handler {
+  if (!handler) {
+    [_messenger setMessageHandlerOnChannel:_name binaryMessageHandler:nil];
+    return;
+  }
+
+  // Don't capture the channel in the callback, since that makes lifetimes harder to reason about.
+  id<FLEMethodCodec> codec = _codec;
+  NSString *channelName = _name;
+
+  FLEBinaryMessageHandler messageHandler = ^(NSData *message, FLEBinaryReply callback) {
+    FLEMethodCall *methodCall = [codec decodeMethodCall:message];
+    if (!methodCall) {
+      NSLog(@"Received invalid method call on channel %@", channelName);
+      callback(nil);
+      return;
+    }
+    handler(methodCall, ^(id result) {
+      if (result == FLEMethodNotImplemented) {
+        callback(nil);
+      } else if ([result isKindOfClass:[FLEMethodError class]]) {
+        callback([codec encodeErrorEnvelope:(FLEMethodError *)result]);
+      } else {
+        callback([codec encodeSuccessEnvelope:result]);
+      }
+    });
+  };
+
+  [_messenger setMessageHandlerOnChannel:_name binaryMessageHandler:messageHandler];
+}
+
+@end

--- a/macos/library/FLEViewController.h
+++ b/macos/library/FLEViewController.h
@@ -26,7 +26,7 @@
  * Can be launched headless (no managed view), at which point a Dart executable will be run on the
  * Flutter engine in non-interactive mode, or with a drawable Flutter canvas.
  */
-@interface FLEViewController : NSViewController <FLEReshapeListener>
+@interface FLEViewController : NSViewController <FLEBinaryMessenger, FLEReshapeListener>
 
 /**
  * The view this controller manages when launched in interactive mode (headless set to false). Must
@@ -80,7 +80,7 @@
  */
 - (void)invokeMethod:(nonnull NSString *)method
            arguments:(nullable id)arguments
-           onChannel:(nonnull NSString *)channel
+           onChannel:(nonnull NSString *)channelName
            withCodec:(nonnull id<FLEMethodCodec>)codec;
 
 /**
@@ -89,6 +89,6 @@
  */
 - (void)invokeMethod:(nonnull NSString *)method
            arguments:(nullable id)arguments
-           onChannel:(nonnull NSString *)channel;
+           onChannel:(nonnull NSString *)channelName;
 
 @end

--- a/macos/library/FlutterEmbedderMac.h
+++ b/macos/library/FlutterEmbedderMac.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "FLEBinaryMessenger.h"
 #import "FLEChannels.h"
 #import "FLECodecs.h"
 #import "FLEMethods.h"

--- a/macos/library/FlutterEmbedderMac.xcodeproj/project.pbxproj
+++ b/macos/library/FlutterEmbedderMac.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		1E2492411FCF50BE00DD3BBB /* FlutterEmbedderMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E2492371FCF50BE00DD3BBB /* FlutterEmbedderMac.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1EEF8E071FD1F0C300DD563C /* FLEView.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EEF8E051FD1F0C300DD563C /* FLEView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1EEF8E081FD1F0C300DD563C /* FLEView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EEF8E061FD1F0C300DD563C /* FLEView.m */; };
+		3389A6872159359200A27898 /* FLEBinaryMessenger.h in Headers */ = {isa = PBXBuildFile; fileRef = 3389A6862159359200A27898 /* FLEBinaryMessenger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3389A68D215949CB00A27898 /* FLEMethods.m in Sources */ = {isa = PBXBuildFile; fileRef = 3389A68C215949CB00A27898 /* FLEMethods.m */; };
 		3389A68F215949D600A27898 /* FLEMethods.h in Headers */ = {isa = PBXBuildFile; fileRef = 3389A68E215949D600A27898 /* FLEMethods.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		33A87EB620F6BCDB0086D21D /* FLECodecs.h in Headers */ = {isa = PBXBuildFile; fileRef = 33A87EB420F6BCDB0086D21D /* FLECodecs.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -82,6 +83,7 @@
 		1E2492381FCF50BE00DD3BBB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		1EEF8E051FD1F0C300DD563C /* FLEView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEView.h; sourceTree = "<group>"; };
 		1EEF8E061FD1F0C300DD563C /* FLEView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEView.m; sourceTree = "<group>"; };
+		3389A6862159359200A27898 /* FLEBinaryMessenger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEBinaryMessenger.h; sourceTree = "<group>"; };
 		3389A68C215949CB00A27898 /* FLEMethods.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEMethods.m; sourceTree = "<group>"; };
 		3389A68E215949D600A27898 /* FLEMethods.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEMethods.h; sourceTree = "<group>"; };
 		33A87EB420F6BCDB0086D21D /* FLECodecs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FLECodecs.h; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 		1E2492451FCF536200DD3BBB /* Public */ = {
 			isa = PBXGroup;
 			children = (
+				3389A6862159359200A27898 /* FLEBinaryMessenger.h */,
 				33D7B59720A4F54400296EFC /* FLEChannels.h */,
 				33A87EB420F6BCDB0086D21D /* FLECodecs.h */,
 				3389A68E215949D600A27898 /* FLEMethods.h */,
@@ -173,12 +176,14 @@
 			files = (
 				33E202A6212BC0ED00337F48 /* FLEKeyEventPlugin.h in Headers */,
 				1E24923B1FCF50BE00DD3BBB /* FLEPlugin.h in Headers */,
+				3389A6872159359200A27898 /* FLEBinaryMessenger.h in Headers */,
 				33D7B59920A4F54400296EFC /* FLEChannels.h in Headers */,
 				1E24923F1FCF50BE00DD3BBB /* FLEViewController.h in Headers */,
 				33E202A5212BC0A800337F48 /* FLETextInputPlugin.h in Headers */,
 				1E2492411FCF50BE00DD3BBB /* FlutterEmbedderMac.h in Headers */,
 				1E2492391FCF50BE00DD3BBB /* FLEOpenGLContextHandling.h in Headers */,
 				1E24923C1FCF50BE00DD3BBB /* FLEReshapeListener.h in Headers */,
+				3389A689215935A100A27898 /* FLEMethods.h in Headers */,
 				33E202A7212BC0F100337F48 /* FLEViewController+Internal.h in Headers */,
 				AA8AE8B81FD948AC00B6FB31 /* FLETextInputModel.h in Headers */,
 				1EEF8E071FD1F0C300DD563C /* FLEView.h in Headers */,


### PR DESCRIPTION
Adds the MethodChannel class, and the accompanying BinaryMessegener
protocol, for parity with the existing iOS Flutter plugin/channel
structure.

This lays the foundation for a future breaking change that makes plugin
creation and registration match the iOS structure, but for now makes the
method channel an internal implementation detail of the existing plugin
messaging design to preserve compatibiility.