### PR TITLE
Initial Linux GN build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+out/
 .DS_Store

--- a/.gn
+++ b/.gn
@@ -1,0 +1,1 @@
+buildconfig = "//build/BUILDCONFIG.gn"

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,22 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+group("gn_all") {
+  deps = [
+    "//library:flutter_embedder",
+    "//plugins/color_panel:color_panel",
+    "//plugins/file_chooser:file_chooser",
+    "//plugins/menubar:menubar",
+  ]
+}

--- a/build/BUILD.gn
+++ b/build/BUILD.gn
@@ -1,0 +1,32 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+config("defaults") {
+  cflags = [
+    "-std=c++14",
+    "-Wall",
+    "-Werror",
+    "-pthread",
+  ]
+  include_dirs = [
+    "//"
+  ]
+}
+
+config("shared_library_defaults") {
+  cflags = [
+    "-shared",
+    "-fPIC",
+  ]
+}

--- a/build/BUILDCONFIG.gn
+++ b/build/BUILDCONFIG.gn
@@ -1,0 +1,42 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set_default_toolchain("//third_party/chromium/build/toolchain:gcc")
+
+set_defaults("executable") {
+  configs = [ "//build:defaults" ]
+}
+set_defaults("static_library") {
+  configs = [ "//build:defaults" ]
+}
+set_defaults("shared_library") {
+  configs = [ "//build:defaults", "//build:shared_library_defaults" ]
+}
+set_defaults("published_shared_library") {
+  configs = [ "//build:defaults", "//build:shared_library_defaults" ]
+}
+
+if (host_os == "linux") {
+  is_linux = true
+  is_mac = false
+  is_win = false
+} else if (host_os == "mac") {
+  is_linux = false
+  is_mac = true
+  is_win = false
+} else if (host_os == "win") {
+  is_linux = false
+  is_mac = false
+  is_win = true
+}

--- a/build/flutter.gni
+++ b/build/flutter.gni
@@ -1,0 +1,21 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare_args() {
+  # The path to the Flutter tree to use for any Flutter operations or assets.
+  # If empty, assumes a directory called 'flutter' that is a sibling of this
+  # repository (like tools/flutter_location; this duplication avoids shelling
+  # out).
+  flutter_tree_path = rebase_path("../../flutter")
+}

--- a/build/linux/config/BUILD.gn
+++ b/build/linux/config/BUILD.gn
@@ -1,0 +1,31 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//third_party/chromium/build/config/linux/pkg_config.gni")
+
+pkg_config("gtk3") {
+  packages = [ "gtk+-3.0" ]
+}
+
+pkg_config("epoxy") {
+  packages = [ "epoxy" ]
+}
+
+pkg_config("x11") {
+  packages = [ "x11" ]
+}
+
+pkg_config("jsoncpp") {
+  packages = [ "jsoncpp" ]
+}

--- a/build/packaging.gni
+++ b/build/packaging.gni
@@ -1,0 +1,60 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Puts the public headers of the invoker in public_header_subdir
+# under the top-level include/ directory in the build output.
+#
+# This is intended to make consuming public headers of all the libraries built
+# by GN easy for outside build systems on Linux, by requiring only a single
+# include directory.
+if (is_linux) {
+  template("copy_includes") {
+    copy(target_name) {
+      assert(defined(invoker.sources),
+            "|sources| must be provided for copy_includes.")
+      forward_variables_from(invoker, [ "deps", "sources", "subdir" ])
+      output_dir = "$root_out_dir/include"
+      if (defined(subdir)) {
+        output_dir = "$output_dir/$subdir"
+      }
+      outputs = [ "$output_dir/{{source_file_part}}"]
+    }
+  }
+}
+
+# An abstraction for a shared library with associated headers that is intended
+# to be consumed from the build output.
+#
+# On Linux, this performs a copy_includes in addition to building the library.
+template("published_shared_library") {
+  template_target_name = target_name
+
+  if (is_linux) {
+    copy_includes("_publish_${template_target_name}_headers") {
+      sources = invoker.public
+      subdir = invoker.public_header_subdir
+    }
+
+    shared_library(template_target_name) {
+      forward_variables_from(invoker, "*")
+      assert(defined(public),
+            "|public| must be provided for published_shared_library.")
+
+      if (!defined(deps)) {
+        deps = []
+      }
+      deps += [ ":_publish_${template_target_name}_headers" ]
+    }
+  }
+}

--- a/example/linux/Makefile
+++ b/example/linux/Makefile
@@ -58,6 +58,29 @@ BIN_OUT=$(OUT_DIR)/flutter_embedder_example
 ICU_DATA_OUT=$(OUT_DATA_DIR)/$(ICU_DATA_NAME)
 ALL_LIBS_OUT=$(foreach lib,$(ALL_LIBS),$(OUT_LIB_DIR)/$(notdir $(lib)))
 
+# Overrides for the optional GN build.
+ifdef USE_GN
+GN_OUT_DIR=$(PROJECT_ROOT)/out
+# Use GN's out dir even though this isn't a GN build, to group build output.
+OUT_DIR=$(GN_OUT_DIR)/example
+
+# The GN build places all libraries at the top level of the output directory.
+FLUTTER_EMBEDDER_LIB=$(GN_OUT_DIR)/lib$(FLUTTER_EMBEDDER_LIB_NAME).so
+FLUTTER_ENGINE_LIB=$(GN_OUT_DIR)/lib$(FLUTTER_ENGINE_LIB_NAME).so
+PLUGIN_LIBS=$(foreach plugin,$(PLUGIN_NAMES)\
+	,$(GN_OUT_DIR)/lib$(PLUGIN_LIB_NAME_PREFIX)$(plugin).so)
+
+# The GN build places all published headers in a top-level include/.
+INCLUDE_DIRS=$(GN_OUT_DIR)/include
+
+# Override LIBRARY_DIRS since it's used for controlling the external build.
+LIBRARY_DIRS=$(GN_OUT_DIR)
+
+# Additional tools
+GN_WRAPPER=$(TOOLS_DIR)/gn_dart
+NINJA_BIN=ninja
+endif
+
 # Build settings
 CXX=g++ -std=c++14
 CXXFLAGS=-Wall -Werror $(shell pkg-config --cflags jsoncpp)
@@ -85,6 +108,12 @@ $(BIN_OUT): $(SOURCES) $(ALL_LIBS_OUT)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(SOURCES) $(LDFLAGS) -o $@
 
 # Depedency directories are used as phony targets to invoke their builds.
+ifdef USE_GN
+.PHONY: $(LIBRARY_DIRS)
+$(LIBRARY_DIRS):
+	$(GN_WRAPPER) gen $(GN_OUT_DIR)
+	$(NINJA_BIN) -C $(GN_OUT_DIR) $(FLUTTER_EMBEDDER_LIB_NAME) $(PLUGIN_NAMES)
+else
 .PHONY: $(LIBRARY_DIRS)
 $(LIBRARY_DIRS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
@@ -93,6 +122,7 @@ $(LIBRARY_DIRS):
 # in parallel in the event that someone supplies the -j flag to `make`.
 # TODO: Fix this in the plugin builds so that it's not necessary at this layer.
 $(PLUGIN_DIRS): $(FLUTTER_EMBEDDER_LIB_DIR)
+endif
 
 # Require that all the library builds run for anything depending on the
 # libraries, but use order-only so that the phony build targets don't trigger

--- a/library/BUILD.gn
+++ b/library/BUILD.gn
@@ -1,0 +1,89 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build/flutter.gni")
+import("//build/packaging.gni")
+import("//library/engine.gni")
+
+published_shared_library("flutter_embedder") {
+  if (is_linux) {
+    sources = [
+      "linux/src/internal/engine_method_result.cc",
+      "linux/src/internal/engine_method_result.h",
+      "linux/src/internal/keyboard_hook_handler.h",
+      "linux/src/internal/plugin_handler.cc",
+      "linux/src/internal/plugin_handler.h",
+      "linux/src/internal/text_input_model.cc",
+      "linux/src/internal/text_input_model.h",
+      "linux/src/internal/text_input_plugin.cc",
+      "linux/src/internal/text_input_plugin.h",
+      "linux/src/embedder.cc",
+      "linux/src/json_method_call.cc",
+      "linux/src/json_method_codec.cc",
+      "linux/src/json_plugin.cc",
+      "linux/src/method_call.cc",
+      "linux/src/method_codec.cc",
+      "linux/src/method_result.cc",
+      "linux/src/plugin.cc",
+    ]
+    public = [
+      "linux/include/flutter_desktop_embedding/embedder.h",
+      "linux/include/flutter_desktop_embedding/json_method_call.h",
+      "linux/include/flutter_desktop_embedding/json_method_codec.h",
+      "linux/include/flutter_desktop_embedding/json_plugin.h",
+      "linux/include/flutter_desktop_embedding/method_call.h",
+      "linux/include/flutter_desktop_embedding/method_codec.h",
+      "linux/include/flutter_desktop_embedding/method_result.h",
+      "linux/include/flutter_desktop_embedding/plugin.h",
+    ]
+  }
+
+  deps = [
+    ":fetch_flutter_engine",
+  ]
+
+  if (is_linux) {
+    public_header_subdir = "flutter_desktop_embedding"
+
+    deps += [
+      "//library/linux:publish_flutter_engine",
+    ]
+
+    libs = [
+      "glfw",
+      "GL",
+    ]
+
+    configs += [
+      "//build/linux/config:epoxy",
+      "//build/linux/config:gtk3",
+      "//build/linux/config:jsoncpp",
+      "//build/linux/config:x11",
+    ]
+
+    public_configs = [
+      "//library/linux:relative_public_headers",
+    ]
+  }
+}
+
+action("fetch_flutter_engine") {
+  script = "//tools/dart_tools/bin/update_flutter_engine.dart"
+  inputs = [ "$flutter_tree_path/bin/internal/engine.version" ]
+  outputs = engine_files
+  args = [
+    "--flutter_root=$flutter_tree_path",
+    rebase_path(engine_download_dir, root_build_dir),
+  ]
+}

--- a/library/BUILD.gn
+++ b/library/BUILD.gn
@@ -21,6 +21,8 @@ published_shared_library("flutter_embedder") {
     sources = [
       "linux/src/internal/engine_method_result.cc",
       "linux/src/internal/engine_method_result.h",
+      "linux/src/internal/json_message_codec.cc",
+      "linux/src/internal/json_message_codec.h",
       "linux/src/internal/keyboard_hook_handler.h",
       "linux/src/internal/plugin_handler.cc",
       "linux/src/internal/plugin_handler.h",
@@ -33,16 +35,19 @@ published_shared_library("flutter_embedder") {
       "linux/src/json_method_codec.cc",
       "linux/src/json_plugin.cc",
       "linux/src/method_call.cc",
+      "linux/src/method_channel.cc",
       "linux/src/method_codec.cc",
       "linux/src/method_result.cc",
       "linux/src/plugin.cc",
     ]
     public = [
+      "linux/include/flutter_desktop_embedding/binary_messenger.h",
       "linux/include/flutter_desktop_embedding/embedder.h",
       "linux/include/flutter_desktop_embedding/json_method_call.h",
       "linux/include/flutter_desktop_embedding/json_method_codec.h",
       "linux/include/flutter_desktop_embedding/json_plugin.h",
       "linux/include/flutter_desktop_embedding/method_call.h",
+      "linux/include/flutter_desktop_embedding/method_channel.h",
       "linux/include/flutter_desktop_embedding/method_codec.h",
       "linux/include/flutter_desktop_embedding/method_result.h",
       "linux/include/flutter_desktop_embedding/plugin.h",

--- a/library/GN.md
+++ b/library/GN.md
@@ -1,0 +1,53 @@
+# Using GN
+
+If you are building on Linux, you can use GN instead of Make.
+
+This is currently optional and is under evaluation, but in the future it may
+become the build system used on all platforms.
+
+## Dependencies
+
+In addition to the normal dependencies, you will need to install:
+* [ninja](https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages)
+* [gn](https://gn.googlesource.com/gn/) 
+
+Ensure that both binaries are in your path.
+
+## Building
+
+### Library
+
+To build the library, run the following at the root of this repository:
+
+```
+$ tools/gn_dart gen out
+$ ninja -C out flutter_embedder
+```
+
+The build results will be in the top-level `out/` directory.
+
+Subsequent builds only require the `ninja` step, as the build will automatically
+re-run GN generation if necessary.
+
+### Plugins
+
+You can build individual plugins by replacing `flutter_embedder` with the name
+of the desired plugin target. Alternately, you can build the library and all
+supported plugins with:
+
+```
+$ ninja -C out
+```
+
+### Example
+
+To use the GN build for the depedencies of the example application, when
+running `make` for the example add `USE_GN=1` to the end of the command.
+
+The resulting binary will be in `out/example/` rather than `example/linux/out/`.
+
+## Feedback
+
+If you encounter issues with the GN build, please test with Make before filing
+a bug so that the report can include whether the issue is specific to GN, or
+a general build issue.

--- a/library/README.md
+++ b/library/README.md
@@ -54,6 +54,8 @@ for details on calling into the library.
 
 You will also need to link `libflutter_engine.so` into your binary.
 
+_Note: There is also a [GN build](GN.md) available as an alternative to Make._
+
 ### macOS
 
 #### Dependencies

--- a/library/engine.gni
+++ b/library/engine.gni
@@ -15,6 +15,7 @@
 # The location for downloading the engine library/headers.
 engine_download_dir = "$root_gen_dir/flutter_engine"
 
+# The files that make up the downloaded engine library on Linux.
 if (is_linux) {
   engine_files = [
     "$engine_download_dir/libflutter_engine.so",

--- a/library/engine.gni
+++ b/library/engine.gni
@@ -1,0 +1,23 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The location for downloading the engine library/headers.
+engine_download_dir = "$root_gen_dir/flutter_engine"
+
+if (is_linux) {
+  engine_files = [
+    "$engine_download_dir/libflutter_engine.so",
+    "$engine_download_dir/flutter_embedder.h",
+  ]
+}

--- a/library/linux/BUILD.gn
+++ b/library/linux/BUILD.gn
@@ -1,0 +1,43 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build/packaging.gni")
+import("//library/engine.gni")
+
+# The files that make up the download engine library on Linux.
+
+# Allows targets depending on this library to use library-style
+# inculdes for its header rather than project-relative.
+config("relative_public_headers") {
+  include_dirs = [
+    "include",
+  ]
+}
+
+copy_includes("_publish_engine_headers") {
+  sources = [ engine_files[1] ]
+  deps = [ "//library:fetch_flutter_engine" ]
+}
+
+# Places the downloaded Flutter engine library at the top level of the
+# output directory where built libraries go, so that it doesn't require
+# special link handling, and publishes its header.
+copy("publish_flutter_engine") {
+  sources = [ engine_files[0] ]
+  outputs = [ "$root_out_dir/{{source_file_part}}" ]
+  deps = [
+    ":_publish_engine_headers",
+    "//library:fetch_flutter_engine"
+  ]
+}

--- a/library/linux/BUILD.gn
+++ b/library/linux/BUILD.gn
@@ -15,8 +15,6 @@
 import("//build/packaging.gni")
 import("//library/engine.gni")
 
-# The files that make up the download engine library on Linux.
-
 # Allows targets depending on this library to use library-style
 # inculdes for its header rather than project-relative.
 config("relative_public_headers") {

--- a/plugins/color_panel/BUILD.gn
+++ b/plugins/color_panel/BUILD.gn
@@ -1,0 +1,45 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build/packaging.gni")
+
+published_shared_library("color_panel") {
+  output_name = "flutter_embedder_$target_name"
+
+  sources = [
+    "common/channel_constants.cc",
+    "common/channel_constants.h",
+  ]
+  if (is_linux) {
+    sources += [
+      "linux/src/color_panel_plugin.cc",
+    ]
+    public = [
+      "linux/include/color_panel/color_panel_plugin.h",
+    ]
+  }
+
+  deps = [
+    "//library:flutter_embedder",
+  ]
+
+  if (is_linux) {
+    public_header_subdir = "color_panel"
+
+    configs += [
+      "//build/linux/config:gtk3",
+      "//build/linux/config:jsoncpp",
+    ]
+  }
+}

--- a/plugins/file_chooser/BUILD.gn
+++ b/plugins/file_chooser/BUILD.gn
@@ -1,0 +1,45 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build/packaging.gni")
+
+published_shared_library("file_chooser") {
+  output_name = "flutter_embedder_$target_name"
+
+  sources = [
+    "common/channel_constants.cc",
+    "common/channel_constants.h",
+  ]
+  if (is_linux) {
+    sources += [
+      "linux/src/file_chooser_plugin.cc",
+    ]
+    public = [
+      "linux/include/file_chooser/file_chooser_plugin.h",
+    ]
+  }
+
+  deps = [
+    "//library:flutter_embedder",
+  ]
+
+  if (is_linux) {
+    public_header_subdir = "file_chooser"
+
+    configs += [
+      "//build/linux/config:gtk3",
+      "//build/linux/config:jsoncpp",
+    ]
+  }
+}

--- a/plugins/menubar/BUILD.gn
+++ b/plugins/menubar/BUILD.gn
@@ -1,0 +1,45 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build/packaging.gni")
+
+published_shared_library("menubar") {
+  output_name = "flutter_embedder_$target_name"
+
+  sources = [
+    "common/channel_constants.cc",
+    "common/channel_constants.h",
+  ]
+  if (is_linux) {
+    sources += [
+      "linux/src/menubar_plugin.cc",
+    ]
+    public = [
+      "linux/include/menubar/menubar_plugin.h",
+    ]
+  }
+
+  deps = [
+    "//library:flutter_embedder",
+  ]
+
+  if (is_linux) {
+    public_header_subdir = "menubar"
+
+    configs += [
+      "//build/linux/config:gtk3",
+      "//build/linux/config:jsoncpp",
+    ]
+  }
+}

--- a/third_party/chromium/LICENSE
+++ b/third_party/chromium/LICENSE
@@ -1,0 +1,27 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/chromium/build/config/linux/pkg_config.gni
+++ b/third_party/chromium/build/config/linux/pkg_config.gni
@@ -1,0 +1,89 @@
+# Copyright (c) 2013 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Defines a config specifying the result of running pkg-config for the given
+# packages. Put the package names you want to query in the "packages" variable
+# inside the template invocation.
+#
+# You can also add defines via the "defines" variable. This can be useful to
+# add this to the config to pass defines that the library expects to get by
+# users of its headers.
+#
+# Example:
+#   pkg_config("mything") {
+#     packages = [ "mything1", "mything2" ]
+#     defines = [ "ENABLE_AWESOME" ]
+#   }
+#
+# You can also use "extra args" to filter out results (see pkg-config.py):
+#   extra_args = [ "-v, "foo" ]
+# To ignore libs and ldflags (only cflags/defines will be set, which is useful
+# when doing manual dynamic linking), set:
+#   ignore_libs = true
+
+declare_args() {
+  # A pkg-config wrapper to call instead of trying to find and call the right
+  # pkg-config directly. Wrappers like this are common in cross-compilation
+  # environments.
+  # Leaving it blank defaults to searching PATH for 'pkg-config' and relying on
+  # the sysroot mechanism to find the right .pc files.
+  pkg_config = ""
+
+  # A optional pkg-config wrapper to use for tools built on the host.
+  host_pkg_config = ""
+}
+
+pkg_config_script = "//tools/dart_tools/bin/pkg_config.dart"
+
+# Define the args we pass to the pkg-config script for other build files that
+# need to invoke it manually.
+pkg_config_args = []
+
+if (pkg_config != "") {
+  pkg_config_args += [
+    "-p",
+    pkg_config,
+  ]
+}
+
+if (host_pkg_config != "") {
+  host_pkg_config_args = [
+    "-p",
+    host_pkg_config,
+  ]
+} else {
+  host_pkg_config_args = pkg_config_args
+}
+
+template("pkg_config") {
+  assert(defined(invoker.packages),
+         "Variable |packages| must be defined to be a list in pkg_config.")
+  config(target_name) {
+    args = host_pkg_config_args + invoker.packages
+    if (defined(invoker.extra_args)) {
+      args += invoker.extra_args
+    }
+
+    pkgresult = exec_script(pkg_config_script, args, "value")
+    cflags = pkgresult[1]
+
+    # We want the system include paths to use -isystem instead of -I to suppress
+    # warnings in those headers.
+    foreach(include, pkgresult[0]) {
+      include_relativized = rebase_path(include, root_build_dir)
+      cflags += [ "-isystem$include_relativized" ]
+    }
+
+    if (!defined(invoker.ignore_libs) || !invoker.ignore_libs) {
+      libs = pkgresult[2]
+      lib_dirs = pkgresult[3]
+    }
+
+    forward_variables_from(invoker,
+                           [
+                             "defines",
+                             "visibility",
+                           ])
+  }
+}

--- a/third_party/chromium/build/toolchain/BUILD.gn
+++ b/third_party/chromium/build/toolchain/BUILD.gn
@@ -1,0 +1,94 @@
+# Copyright 2014 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This is based on the example toolchain definition from the gn respository's
+# example, with changes.
+
+toolchain("gcc") {
+  tool("cc") {
+    depfile = "{{output}}.d"
+    command = "gcc -MMD -MF $depfile {{defines}} {{include_dirs}} {{cflags}} {{cflags_c}} -c {{source}} -o {{output}}"
+    depsformat = "gcc"
+    description = "CC {{output}}"
+    outputs = [
+      "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o",
+    ]
+  }
+
+  tool("cxx") {
+    depfile = "{{output}}.d"
+    command = "g++ -MMD -MF $depfile {{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}} -c {{source}} -o {{output}}"
+    depsformat = "gcc"
+    description = "CXX {{output}}"
+    outputs = [
+      "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o",
+    ]
+  }
+
+  tool("alink") {
+    rspfile = "{{output}}.rsp"
+    command = "rm -f {{output}} && ar rcs {{output}} @$rspfile"
+    description = "AR {{target_output_name}}{{output_extension}}"
+    rspfile_content = "{{inputs}}"
+    outputs = [
+      "{{target_out_dir}}/{{target_output_name}}{{output_extension}}",
+    ]
+    default_output_extension = ".a"
+    output_prefix = "lib"
+  }
+
+  tool("solink") {
+    soname = "{{target_output_name}}{{output_extension}}"  # e.g. "libfoo.so".
+    sofile = "{{output_dir}}/$soname"
+    rspfile = soname + ".rsp"
+
+    command = "g++ -shared {{ldflags}} -o $sofile -Wl,-soname=$soname @$rspfile"
+    rspfile_content = "-Wl,--whole-archive {{inputs}} {{solibs}} -Wl,--no-whole-archive {{libs}}"
+
+    description = "SOLINK $soname"
+
+    # Use this for {{output_extension}} expansions unless a target manually
+    # overrides it (in which case {{output_extension}} will be what the target
+    # specifies).
+    default_output_extension = ".so"
+
+    # Use this for {{output_dir}} expansions unless a target manually overrides
+    # it (in which case {{output_dir}} will be what the target specifies).
+    default_output_dir = "{{root_out_dir}}"
+
+    lib_switch = "-l"
+    lib_dir_switch = "-L"
+
+    outputs = [
+      sofile,
+    ]
+    link_output = sofile
+    depend_output = sofile
+    output_prefix = "lib"
+  }
+
+  tool("link") {
+    outfile = "{{target_output_name}}{{output_extension}}"
+    rspfile = "$outfile.rsp"
+    command = "g++ {{ldflags}} -o $outfile -Wl,--start-group @$rspfile {{solibs}} -Wl,--end-group {{libs}}"
+    description = "LINK $outfile"
+    default_output_dir = "{{root_out_dir}}"
+    rspfile_content = "{{inputs}}"
+    lib_switch = "-l"
+    lib_dir_switch = "-L"
+    outputs = [
+      outfile,
+    ]
+  }
+
+  tool("stamp") {
+    command = "touch {{output}}"
+    description = "STAMP {{output}}"
+  }
+
+  tool("copy") {
+    command = "cp -af {{source}} {{output}}"
+    description = "COPY {{source}} {{output}}"
+  }
+}

--- a/tools/dart_tools/bin/pkg_config.dart
+++ b/tools/dart_tools/bin/pkg_config.dart
@@ -1,0 +1,65 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This script wraps pkg-config, parsing out the different types of flags and
+// outputing them in a form directly consumable by GN. It is modeled on
+// Chromium's pkg-config.py, pared down for the needs of this project.
+
+import 'dart:convert';
+import 'dart:io';
+
+void main(List<String> arguments) {
+  final pkgConfigArguments = ['--cflags', '--libs']..addAll(arguments);
+  List<String> allFlags;
+  Process.run('pkg-config', pkgConfigArguments).then((results) {
+    exitCode = results.exitCode;
+    if (exitCode == 0) {
+      allFlags = results.stdout.toString().trim().split(' ');
+      // JSON.encode's output for lists of strings is compatible with GN's
+      // parsing.
+      print(json.encode(parseFlags(allFlags)));
+    } else {
+      print(results.stderr);
+    }
+  });
+}
+
+/// Parses [flags], and returns them in an array suitable for output to GN:
+/// [includes, cflags, libraries, library directories]
+List<List<String>> parseFlags(List<String> flags) {
+  final includes = <String>[];
+  final cflags = <String>[];
+  final libs = <String>[];
+  final libDirs = <String>[];
+  for (final flag in flags) {
+    if (flag.startsWith('-l')) {
+      libs.add(flag.substring(2));
+    } else if (flag.startsWith('-L')) {
+      libDirs.add(flag.substring(2));
+    } else if (flag.startsWith('-I')) {
+      includes.add(flag.substring(2));
+    } else if (flag.startsWith('-Wl')) {
+      // Don't allow libraries to control ld flags.  These should be specified
+      // only in build files.
+      continue;
+    } else if (flag == '-pthread') {
+      // Remove pthread since it's always set for libraries at the GN level
+      // anyway.
+      continue;
+    } else {
+      cflags.add(flag);
+    }
+  }
+  return [includes, cflags, libs, libDirs];
+}

--- a/tools/gn_dart
+++ b/tools/gn_dart
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script wraps GN with a --script-executable pointing at the Dart binary
+# packaged with the Flutter tree.
+readonly base_dir="$(dirname "$0")"
+readonly flutter_dir="$("$base_dir/flutter_location")"
+readonly flutter_bin_dir="$flutter_dir/bin"
+readonly dart_bin_dir="$flutter_bin_dir/cache/dart-sdk/bin"
+# Ensure that the Dart SDK has been downloaded.
+if [[ ! -e $dart_bin_dir ]]; then
+  "$flutter_bin_dir/flutter" precache
+fi
+exec gn --script-executable="$dart_bin_dir/dart" $@


### PR DESCRIPTION
Adds an experimental GN-based build as an alternative to the Make-based
build on Linux.

The example application does not use GN for its own build since it is
intended to serve as an example of using the embedding library, so it
continues to use the more common Make as clients are unlikely to be
using GN.

First step toward possible approach to #114