### PR TITLE
Split JsonMessageCodec out from JsonMethodCodec

### DIFF
--- a/library/linux/include/flutter_desktop_embedding/json_method_codec.h
+++ b/library/linux/include/flutter_desktop_embedding/json_method_codec.h
@@ -14,8 +14,6 @@
 #ifndef LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_METHOD_CODEC_H_
 #define LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_METHOD_CODEC_H_
 
-#include <json/json.h>
-
 #include "method_codec.h"
 
 namespace flutter_desktop_embedding {
@@ -49,11 +47,6 @@ class JsonMethodCodec : public MethodCodec {
   std::unique_ptr<std::vector<uint8_t>> EncodeErrorEnvelopeInternal(
       const std::string &error_code, const std::string &error_message,
       const void *error_details) const override;
-
- private:
-  // Serializes |json| into a byte stream.
-  std::unique_ptr<std::vector<uint8_t>> EncodeJsonObject(
-      const Json::Value &json) const;
 };
 
 }  // namespace flutter_desktop_embedding

--- a/library/linux/src/internal/json_message_codec.cc
+++ b/library/linux/src/internal/json_message_codec.cc
@@ -1,0 +1,55 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "library/linux/src/internal/json_message_codec.h"
+
+#include <iostream>
+#include <string>
+
+namespace flutter_desktop_embedding {
+
+// static
+const JsonMessageCodec &JsonMessageCodec::GetInstance() {
+  static JsonMessageCodec sInstance;
+  return sInstance;
+}
+
+std::unique_ptr<std::vector<uint8_t>> JsonMessageCodec::EncodeMessage(
+    const Json::Value &message) const {
+  Json::StreamWriterBuilder writer_builder;
+  std::string serialization = Json::writeString(writer_builder, message);
+
+  return std::make_unique<std::vector<uint8_t>>(serialization.begin(),
+                                                serialization.end());
+}
+
+std::unique_ptr<Json::Value> JsonMessageCodec::DecodeMessage(
+    const uint8_t *message, const size_t message_size) const {
+  Json::CharReaderBuilder reader_builder;
+  std::unique_ptr<Json::CharReader> parser(reader_builder.newCharReader());
+
+  auto raw_message = reinterpret_cast<const char *>(message);
+  auto json_message = std::make_unique<Json::Value>();
+  std::string parse_errors;
+  bool parsing_successful =
+      parser->parse(raw_message, raw_message + message_size, json_message.get(),
+                    &parse_errors);
+  if (!parsing_successful) {
+    std::cerr << "Unable to parse JSON message:" << std::endl
+              << parse_errors << std::endl;
+    return nullptr;
+  }
+  return json_message;
+}
+
+}  // namespace flutter_desktop_embedding

--- a/library/linux/src/internal/json_message_codec.h
+++ b/library/linux/src/internal/json_message_codec.h
@@ -1,0 +1,59 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_MESSAGE_CODEC_H_
+#define LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_MESSAGE_CODEC_H_
+
+#include <memory>
+#include <vector>
+
+#include <json/json.h>
+
+namespace flutter_desktop_embedding {
+
+// A message encoding/decoding mechanism for communications to/from the
+// Flutter engine via JSON channels.
+//
+// TODO: Make this public, once generalizing a MessageCodec parent interface is
+// addressed; this is complicated by the return type of EncodeMessage.
+// Part of issue #102.
+class JsonMessageCodec {
+ public:
+  // Returns the shared instance of the codec.
+  static const JsonMessageCodec &GetInstance();
+
+  ~JsonMessageCodec() = default;
+
+  // Prevent copying.
+  JsonMessageCodec(JsonMessageCodec const &) = delete;
+  JsonMessageCodec &operator=(JsonMessageCodec const &) = delete;
+
+  // Returns a binary encoding of the given message, or nullptr if the
+  // message cannot be serialized by this codec.
+  std::unique_ptr<std::vector<uint8_t>> EncodeMessage(
+      const Json::Value &message) const;
+
+  // Returns the MethodCall encoded in |message|, or nullptr if it cannot be
+  // decoded.
+  // TODO: Consider adding absl as a dependency and using absl::Span.
+  std::unique_ptr<Json::Value> DecodeMessage(const uint8_t *message,
+                                             const size_t message_size) const;
+
+ protected:
+  // Instances should be obtained via GetInstance.
+  JsonMessageCodec() = default;
+};
+
+}  // namespace flutter_desktop_embedding
+
+#endif  // LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_MESSAGE_CODEC_H_

--- a/library/linux/src/internal/json_message_codec.h
+++ b/library/linux/src/internal/json_message_codec.h
@@ -43,7 +43,7 @@ class JsonMessageCodec {
   std::unique_ptr<std::vector<uint8_t>> EncodeMessage(
       const Json::Value &message) const;
 
-  // Returns the MethodCall encoded in |message|, or nullptr if it cannot be
+  // Returns the JSON object encoded in |message|, or nullptr if it cannot be
   // decoded.
   // TODO: Consider adding absl as a dependency and using absl::Span.
   std::unique_ptr<Json::Value> DecodeMessage(const uint8_t *message,


### PR DESCRIPTION
Separates the basic JSON<->byte stream logic out into JsonMessageCodec,
which is an eventual part of the final channel interface.

Eventually this class will inherit from a generic MessageCodec
interface, but in order to make this functionality available for library
use while the type handling of the public interface is worked out, the
new class is internal for now.