### PR TITLE
[linux] Add the beginning of BinaryMessenger

### DIFF
--- a/library/linux/include/flutter_desktop_embedding/binary_messenger.h
+++ b/library/linux/include/flutter_desktop_embedding/binary_messenger.h
@@ -1,0 +1,40 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_BINARY_MESSENGER_H_
+#define LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_BINARY_MESSENGER_H_
+
+#include <string>
+
+namespace flutter_desktop_embedding {
+
+// A protocol for a class that handles communication of binary data on named
+// channels to and from the Flutter engine.
+class BinaryMessenger {
+ public:
+  // Sends a binary message to the Flutter side on the specified channel,
+  // expecting no reply.
+  //
+  // TODO: Consider adding absl as a dependency and using absl::Span.
+  virtual void Send(const std::string &channel, const uint8_t *message,
+                    const size_t message_size) const = 0;
+
+  // TODO: Add support for a version of Send expecting a reply once
+  // https://github.com/flutter/flutter/issues/18852 is fixed.
+
+  // TODO: Add SetMessageHandler. See Issue #102.
+};
+
+}  // namespace flutter_desktop_embedding
+
+#endif  // LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_BINARY_MESSENGER_H_

--- a/library/linux/include/flutter_desktop_embedding/plugin.h
+++ b/library/linux/include/flutter_desktop_embedding/plugin.h
@@ -18,8 +18,7 @@
 #include <memory>
 #include <string>
 
-#include <flutter_embedder.h>
-
+#include "binary_messenger.h"
 #include "method_call.h"
 #include "method_codec.h"
 #include "method_result.h"
@@ -60,10 +59,12 @@ class Plugin {
   // while waiting for this plugin to handle its platform message.
   virtual bool input_blocking() const { return input_blocking_; }
 
-  // Sets the pointer to the caller-owned Flutter Engine.
+  // Sets the pointer to the caller-owned binary messenger.
   //
   // The embedder typically sets this pointer rather than the client.
-  virtual void set_flutter_engine(FlutterEngine engine) { engine_ = engine; }
+  virtual void set_binary_messenger(BinaryMessenger *messenger) {
+    messenger_ = messenger;
+  }
 
  protected:
   // Calls a method in the Flutter engine on this Plugin's channel.
@@ -71,8 +72,8 @@ class Plugin {
 
  private:
   std::string channel_;
-  // Caller-owned instance of the Flutter Engine.
-  FlutterEngine engine_;
+  // Caller-owned instance of the binary messenger used to message the engine.
+  BinaryMessenger *messenger_;
   bool input_blocking_;
 };
 

--- a/library/linux/src/embedder.cc
+++ b/library/linux/src/embedder.cc
@@ -242,7 +242,7 @@ namespace flutter_desktop_embedding {
 
 bool AddPlugin(GLFWwindow *flutter_window, std::unique_ptr<Plugin> plugin) {
   auto state = GetSavedEmbedderState(flutter_window);
-  plugin->set_flutter_engine(state->engine);
+  plugin->set_binary_messenger(state->plugin_handler.get());
   return state->plugin_handler->AddPlugin(std::move(plugin));
 }
 

--- a/library/linux/src/internal/plugin_handler.cc
+++ b/library/linux/src/internal/plugin_handler.cc
@@ -70,4 +70,15 @@ void PluginHandler::HandleMethodCallMessage(
   }
 }
 
+void PluginHandler::Send(const std::string &channel, const uint8_t *message,
+                         const size_t message_size) const {
+  FlutterPlatformMessage platform_message = {
+      .struct_size = sizeof(FlutterPlatformMessage),
+      .channel = channel.c_str(),
+      .message = message,
+      .message_size = message_size,
+  };
+  FlutterEngineSendPlatformMessage(engine_, &platform_message);
+}
+
 }  // namespace flutter_desktop_embedding

--- a/library/linux/src/internal/plugin_handler.h
+++ b/library/linux/src/internal/plugin_handler.h
@@ -20,6 +20,7 @@
 
 #include <flutter_embedder.h>
 
+#include "library/linux/include/flutter_desktop_embedding/binary_messenger.h"
 #include "library/linux/include/flutter_desktop_embedding/plugin.h"
 
 namespace flutter_desktop_embedding {
@@ -27,7 +28,7 @@ namespace flutter_desktop_embedding {
 // A class for managing a set of plugins.
 //
 // The plugins all map from a unique channel name to an actual plugin.
-class PluginHandler {
+class PluginHandler : public BinaryMessenger {
  public:
   // Creates a new PluginHandler. |engine| must remain valid as long as this
   // object exists.
@@ -58,6 +59,10 @@ class PluginHandler {
                                std::function<void(void)> input_block_cb = [] {},
                                std::function<void(void)> input_unblock_cb =
                                    [] {});
+
+  // BinaryMessenger implementation:
+  void Send(const std::string &channel, const uint8_t *message,
+            const size_t message_size) const override;
 
  private:
   FlutterEngine engine_;

--- a/library/linux/src/plugin.cc
+++ b/library/linux/src/plugin.cc
@@ -18,23 +18,17 @@
 namespace flutter_desktop_embedding {
 
 Plugin::Plugin(const std::string &channel, bool input_blocking)
-    : channel_(channel), engine_(nullptr), input_blocking_(input_blocking) {}
+    : channel_(channel), messenger_(nullptr), input_blocking_(input_blocking) {}
 
 Plugin::~Plugin() {}
 
 void Plugin::InvokeMethodCall(const MethodCall &method_call) {
-  if (!engine_) {
+  if (!messenger_) {
     return;
   }
   std::unique_ptr<std::vector<uint8_t>> message =
       GetCodec().EncodeMethodCall(method_call);
-  FlutterPlatformMessage platform_message_response = {
-      .struct_size = sizeof(FlutterPlatformMessage),
-      .channel = channel_.c_str(),
-      .message = message->data(),
-      .message_size = message->size(),
-  };
-  FlutterEngineSendPlatformMessage(engine_, &platform_message_response);
+  messenger_->Send(channel_, message->data(), message->size());
 }
 
 }  // namespace flutter_desktop_embedding


### PR DESCRIPTION
Adds the BinaryMessanger interface, containing only the send API for
now. This eliminates the engine pointer from a public header, and is a
small step toward moving toward supporting MessageChannel/MethodChannel.

Technically this is a breaking change, but there's no expectation that
any code outside of the library would be using set_engine, so should not
actually impact anyone.

Part of issue #102.