### PR TITLE
[linux] Add MethodChannel

### DIFF
--- a/library/linux/include/flutter_desktop_embedding/binary_messenger.h
+++ b/library/linux/include/flutter_desktop_embedding/binary_messenger.h
@@ -14,9 +14,25 @@
 #ifndef LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_BINARY_MESSENGER_H_
 #define LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_BINARY_MESSENGER_H_
 
+#include <functional>
 #include <string>
 
+// TODO: Consider adding absl as a dependency and using absl::Span for all of
+// the message/message_size pairs.
 namespace flutter_desktop_embedding {
+
+// A message reply callback.
+//
+// Used for submitting a reply back to a Flutter message sender.
+typedef std::function<void(const uint8_t *reply, const size_t reply_size)>
+    BinaryReply;
+
+// A message handler callback.
+//
+// Used for receiving messages from Flutter and providing an asynchronous reply.
+typedef std::function<void(const uint8_t *message, const size_t message_size,
+                           BinaryReply reply)>
+    BinaryMessageHandler;
 
 // A protocol for a class that handles communication of binary data on named
 // channels to and from the Flutter engine.
@@ -32,7 +48,13 @@ class BinaryMessenger {
   // TODO: Add support for a version of Send expecting a reply once
   // https://github.com/flutter/flutter/issues/18852 is fixed.
 
-  // TODO: Add SetMessageHandler. See Issue #102.
+  // Registers a message handler for incoming binary messages from the Flutter
+  // side on the specified channel.
+  //
+  // Replaces any existing handler. Provide a null handler to unregister the
+  // existing handler.
+  virtual void SetMessageHandler(const std::string &channel,
+                                 BinaryMessageHandler handler) = 0;
 };
 
 }  // namespace flutter_desktop_embedding

--- a/library/linux/include/flutter_desktop_embedding/json_plugin.h
+++ b/library/linux/include/flutter_desktop_embedding/json_plugin.h
@@ -14,7 +14,11 @@
 #ifndef LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_PLUGIN_H_
 #define LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_PLUGIN_H_
 
+#include <memory>
+#include <string>
+
 #include "json_method_call.h"
+#include "method_channel.h"
 #include "plugin.h"
 
 namespace flutter_desktop_embedding {
@@ -38,16 +42,24 @@ class JsonPlugin : public Plugin {
                         std::unique_ptr<MethodResult> result) override;
 
  protected:
+  // Plugin implementation:
+  void RegisterMethodChannels(BinaryMessenger *messenger) override;
+
   // Identical to HandleMethodCall, except that the call has been cast to the
   // more specific type. Subclasses must implement this instead of
   // HandleMethodCall.
   virtual void HandleJsonMethodCall(const JsonMethodCall &method_call,
                                     std::unique_ptr<MethodResult> result) = 0;
 
-  // Calls InvokeMethodCall with a JsonMethodCall constructed from the given
-  // values.
+  // Calls InvokeMethodCall on |method_channel_| with a JsonMethodCall
+  // constructed from the given values.
   void InvokeMethod(const std::string &method,
                     const Json::Value &arguments = Json::Value());
+
+ private:
+  // The MethodChannel used by this plugin for communication with the Flutter
+  // engine.
+  std::unique_ptr<MethodChannel> method_channel_;
 };
 
 }  // namespace flutter_desktop_embedding

--- a/library/linux/include/flutter_desktop_embedding/method_channel.h
+++ b/library/linux/include/flutter_desktop_embedding/method_channel.h
@@ -1,0 +1,72 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_METHOD_CHANNEL_H_
+#define LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_METHOD_CHANNEL_H_
+
+#include <string>
+
+#include "binary_messenger.h"
+#include "method_call.h"
+#include "method_codec.h"
+#include "method_result.h"
+
+namespace flutter_desktop_embedding {
+
+// A handler for receiving a method call from the Flutter engine.
+//
+// Implementations must asynchronously call exactly one of the methods on
+// |result| to indicate the resust of the method call.
+typedef std::function<void(const MethodCall &call,
+                           std::unique_ptr<MethodResult> result)>
+    MethodCallHandler;
+
+// A channel for communicating with the Flutter engine using invocation of
+// asynchronous methods.
+class MethodChannel {
+ public:
+  // Creates an instance that sends and receives method calls on the channel
+  // named |name|, encoded with |codec| and dispatched via |messenger|.
+  //
+  // TODO: Make codec optional once the standard codec is supported (Issue #67).
+  MethodChannel(BinaryMessenger *messenger, const std::string &name,
+                const MethodCodec *codec);
+  ~MethodChannel();
+
+  // Prevent copying.
+  MethodChannel(MethodChannel const &) = delete;
+  MethodChannel &operator=(MethodChannel const &) = delete;
+
+  // Sends |method_call| to the Flutter engine on this channel.
+  //
+  // TODO: Implement InovkeMethod and remove this. This is a temporary
+  // implementation, since supporting InvokeMethod involves significant changes
+  // to other classes.
+  void InvokeMethodCall(const MethodCall &method_call) const;
+
+  // TODO: Add support for a version expecting a reply once
+  // https://github.com/flutter/flutter/issues/18852 is fixed.
+
+  // Registers a handler that should be called any time a method call is
+  // received on this channel.
+  void SetMethodCallHandler(MethodCallHandler handler) const;
+
+ private:
+  BinaryMessenger *messenger_;
+  std::string name_;
+  const MethodCodec *codec_;
+};
+
+}  // namespace flutter_desktop_embedding
+
+#endif  // LIBRARY_LINUX_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_METHOD_CHANNEL_H_

--- a/library/linux/include/flutter_desktop_embedding/plugin.h
+++ b/library/linux/include/flutter_desktop_embedding/plugin.h
@@ -59,21 +59,26 @@ class Plugin {
   // while waiting for this plugin to handle its platform message.
   virtual bool input_blocking() const { return input_blocking_; }
 
-  // Sets the pointer to the caller-owned binary messenger.
+  // Binds this plugin to the given caller-owned binary messenger. It must
+  // remain valid for the life of the plugin.
   //
   // The embedder typically sets this pointer rather than the client.
-  virtual void set_binary_messenger(BinaryMessenger *messenger) {
-    messenger_ = messenger;
-  }
+  void SetBinaryMessenger(BinaryMessenger *messenger);
 
  protected:
+  // Implementers should register any MethodChannels that should receive
+  // messages from Flutter with |messenger| when this is called.
+  virtual void RegisterMethodChannels(BinaryMessenger *messenger) = 0;
+
   // Calls a method in the Flutter engine on this Plugin's channel.
+  //
+  // Deprecated. Use MethodChannel's InvokeMethodCall instead.
   void InvokeMethodCall(const MethodCall &method_call);
 
  private:
   std::string channel_;
   // Caller-owned instance of the binary messenger used to message the engine.
-  BinaryMessenger *messenger_;
+  const BinaryMessenger *messenger_;
   bool input_blocking_;
 };
 

--- a/library/linux/src/embedder.cc
+++ b/library/linux/src/embedder.cc
@@ -242,7 +242,6 @@ namespace flutter_desktop_embedding {
 
 bool AddPlugin(GLFWwindow *flutter_window, std::unique_ptr<Plugin> plugin) {
   auto state = GetSavedEmbedderState(flutter_window);
-  plugin->set_binary_messenger(state->plugin_handler.get());
   return state->plugin_handler->AddPlugin(std::move(plugin));
 }
 

--- a/library/linux/src/internal/engine_method_result.h
+++ b/library/linux/src/internal/engine_method_result.h
@@ -17,8 +17,7 @@
 #include <string>
 #include <vector>
 
-#include <flutter_embedder.h>
-
+#include "library/linux/include/flutter_desktop_embedding/binary_messenger.h"
 #include "library/linux/include/flutter_desktop_embedding/method_codec.h"
 #include "library/linux/include/flutter_desktop_embedding/method_result.h"
 
@@ -27,15 +26,12 @@ namespace flutter_desktop_embedding {
 // Implemention of MethodResult that sends responses to the Flutter egnine.
 class EngineMethodResult : public MethodResult {
  public:
-  // Creates a result object that will send results to |engine|, tagged as
-  // associated with |response_handle|, encoded using |codec|. The |engine|
-  // and |codec| pointers must remain valid for as long as this object exists.
+  // Creates a result object that will send results to |reply_handler|, encoded
+  // using |codec|. The |codec| pointer must remain valid for as long as this
+  // object exists.
   //
   // If the codec is null, only NotImplemented() may be called.
-  EngineMethodResult(
-      FlutterEngine engine,
-      const FlutterPlatformMessageResponseHandle *response_handle,
-      const MethodCodec *codec);
+  EngineMethodResult(BinaryReply reply_handler, const MethodCodec *codec);
   ~EngineMethodResult();
 
  protected:
@@ -52,8 +48,7 @@ class EngineMethodResult : public MethodResult {
   // the engine.
   void SendResponseData(const std::vector<uint8_t> *data);
 
-  FlutterEngine engine_;
-  const FlutterPlatformMessageResponseHandle *response_handle_;
+  BinaryReply reply_handler_;
   const MethodCodec *codec_;
 };
 

--- a/library/linux/src/internal/plugin_handler.h
+++ b/library/linux/src/internal/plugin_handler.h
@@ -63,10 +63,13 @@ class PluginHandler : public BinaryMessenger {
   // BinaryMessenger implementation:
   void Send(const std::string &channel, const uint8_t *message,
             const size_t message_size) const override;
+  void SetMessageHandler(const std::string &channel,
+                         BinaryMessageHandler handler) override;
 
  private:
   FlutterEngine engine_;
   std::map<std::string, std::unique_ptr<Plugin>> plugins_;
+  std::map<std::string, BinaryMessageHandler> handlers_;
 };
 
 }  // namespace flutter_desktop_embedding

--- a/library/linux/src/json_plugin.cc
+++ b/library/linux/src/json_plugin.cc
@@ -32,9 +32,20 @@ void JsonPlugin::HandleMethodCall(const MethodCall &method_call,
                        std::move(result));
 }
 
+void JsonPlugin::RegisterMethodChannels(BinaryMessenger *messenger) {
+  method_channel_ =
+      std::make_unique<MethodChannel>(messenger, channel(), &GetCodec());
+
+  MethodCallHandler handler = [this](const MethodCall &call,
+                                     std::unique_ptr<MethodResult> result) {
+    HandleMethodCall(call, std::move(result));
+  };
+  method_channel_->SetMethodCallHandler(std::move(handler));
+}
+
 void JsonPlugin::InvokeMethod(const std::string &method,
                               const Json::Value &arguments) {
-  InvokeMethodCall(JsonMethodCall(method, arguments));
+  method_channel_->InvokeMethodCall(JsonMethodCall(method, arguments));
 }
 
 }  // namespace flutter_desktop_embedding

--- a/library/linux/src/method_channel.cc
+++ b/library/linux/src/method_channel.cc
@@ -1,0 +1,56 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "library/linux/include/flutter_desktop_embedding/method_channel.h"
+
+#include <iostream>
+
+#include "library/linux/src/internal/engine_method_result.h"
+
+namespace flutter_desktop_embedding {
+
+MethodChannel::MethodChannel(BinaryMessenger *messenger,
+                             const std::string &name, const MethodCodec *codec)
+    : messenger_(messenger), name_(name), codec_(codec) {}
+
+MethodChannel::~MethodChannel() {}
+
+void MethodChannel::InvokeMethodCall(const MethodCall &method_call) const {
+  std::unique_ptr<std::vector<uint8_t>> message =
+      codec_->EncodeMethodCall(method_call);
+  messenger_->Send(name_, message->data(), message->size());
+}
+
+void MethodChannel::SetMethodCallHandler(MethodCallHandler handler) const {
+  const auto *codec = codec_;
+  std::string channel_name = name_;
+  BinaryMessageHandler binary_handler = [handler, codec, channel_name](
+                                            const uint8_t *message,
+                                            const size_t message_size,
+                                            BinaryReply reply) {
+    // Use this channel's codec to decode the call and build a result handler.
+    auto result = std::make_unique<EngineMethodResult>(std::move(reply), codec);
+    std::unique_ptr<MethodCall> method_call =
+        codec->DecodeMethodCall(message, message_size);
+    if (!method_call) {
+      std::cerr << "Unable to construct method call from message on channel "
+                << channel_name << std::endl;
+      result->NotImplemented();
+      return;
+    }
+    handler(*method_call, std::move(result));
+  };
+  messenger_->SetMessageHandler(name_, std::move(binary_handler));
+}
+
+}  // namespace flutter_desktop_embedding

--- a/library/linux/src/plugin.cc
+++ b/library/linux/src/plugin.cc
@@ -22,6 +22,11 @@ Plugin::Plugin(const std::string &channel, bool input_blocking)
 
 Plugin::~Plugin() {}
 
+void Plugin::SetBinaryMessenger(BinaryMessenger *messenger) {
+  messenger_ = messenger;
+  RegisterMethodChannels(messenger);
+}
+
 void Plugin::InvokeMethodCall(const MethodCall &method_call) {
   if (!messenger_) {
     return;


### PR DESCRIPTION
This adds the MethodChannel and related APIs on Linux, further aligning
with the Flutter APIs. As with the current state on macOS, this is
implemented as an implementation detail of the existing plugin classes,
so that there's no plugin API breakage at this stage.

This currently deviates from the MethodChannel API on other platforms by
using InvokeMethodCall instead of InvokeMethod. Addressing this will be
done in a follow-up change.

Part of issue #102