### PR TITLE
[gn] Add key_event_handler sources

### DIFF
--- a/library/BUILD.gn
+++ b/library/BUILD.gn
@@ -23,6 +23,8 @@ published_shared_library("flutter_embedder") {
       "linux/src/internal/engine_method_result.h",
       "linux/src/internal/json_message_codec.cc",
       "linux/src/internal/json_message_codec.h",
+      "linux/src/internal/key_event_handler.cc",
+      "linux/src/internal/key_event_handler.h",
       "linux/src/internal/keyboard_hook_handler.h",
       "linux/src/internal/plugin_handler.cc",
       "linux/src/internal/plugin_handler.h",


### PR DESCRIPTION
Two sources that are missing from the GN build.