### PR TITLE
Fixes dead link: Engine wiki URL has been moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ applications that use [Flutter](https://github.com/flutter/flutter)
 on Windows, macOS, and Linux.
 
 It consists of libraries that implement [Flutter's embedding
-API](https://github.com/flutter/engine/wiki/Custom-Flutter-Engine-Embedders),
+API](https://github.com/flutter/flutter/wiki/Custom-Flutter-Engine-Embedders),
 handling drawing and mouse/keyboard input, as well as
 optional plugins to access other native platform functionality.
 


### PR DESCRIPTION
Fixes dead WIKI docs link.

Awesome project btw