### PR TITLE
Update release mode flag

### DIFF
--- a/Debugging.md
+++ b/Debugging.md
@@ -30,7 +30,7 @@ There are two options:
 1. **Hard-code the port**. In your embedder code, add `--observatory-port=49494`
    (substituting a port of your choice) to the list of arguments passed to the
    engine. If you are using `example/`, or code based on it, look for the
-   line that adds `--dart-non-checked-mode` for an example of adding arguments.
+   line that adds `--disable-dart-asserts` for an example of adding arguments.
    (Be sure not to add the `observatory-port` argument inside the `#if`,
    however.)
 

--- a/example/linux/flutter_embedder_example.cc
+++ b/example/linux/flutter_embedder_example.cc
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
   // args.
   arguments.push_back(argv[0]);
 #ifdef NDEBUG
-  arguments.push_back("--dart-non-checked-mode");
+  arguments.push_back("--disable-dart-asserts");
 #endif
   // Start the engine.
   auto window = flutter_desktop_embedding::CreateFlutterWindowInSnapshotMode(

--- a/example/macos/ExampleWindow.swift
+++ b/example/macos/ExampleWindow.swift
@@ -27,7 +27,7 @@ class ExampleWindow: NSWindow {
     // command line string.
     var arguments = [CommandLine.arguments[0]];
 #if !DEBUG
-    arguments.append("--dart-non-checked-mode");
+    arguments.append("--disable-dart-asserts");
 #endif
     flutterViewController.launchEngine(
       withAssetsPath: assets,

--- a/example/windows/flutter_embedder_example.cpp
+++ b/example/windows/flutter_embedder_example.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
   // args.
   arguments.push_back(argv[0]);
 #ifndef _DEBUG
-  arguments.push_back("--dart-non-checked-mode");
+  arguments.push_back("--disable-dart-asserts");
 #endif
   // Start the engine.
   // TODO: Make paths relative to the executable so it can be run from anywhere.


### PR DESCRIPTION
The Flutter engine renamed the flag that controls the "Debug" banner
as part of the Dart 2 transition (Engine PR 6977). Update the example
apps to pass the new flag in release mode.