### PR TITLE
[macos] Fix script handling of spaces in paths

### DIFF
--- a/tools/build_flutter_assets
+++ b/tools/build_flutter_assets
@@ -30,6 +30,6 @@ readonly flutter_binary="$flutter_dir/bin/flutter"
 #readonly build_type=host_debug_unopt
 #readonly extra_flags=(--local-engine-src-path $engine_src_path --local-engine=$build_type)
 
-cd $1
+cd "$1"
 echo Running "$flutter_binary" ${extra_flags[*]} build bundle
 exec "$flutter_binary" ${extra_flags[*]} build bundle

--- a/tools/update_flutter_engine
+++ b/tools/update_flutter_engine
@@ -21,4 +21,4 @@ readonly dart_bin_dir="$flutter_bin_dir/cache/dart-sdk/bin"
 if [[ ! -e $dart_bin_dir ]]; then
   "$flutter_bin_dir/flutter" precache
 fi
-exec "$dart_bin_dir/dart" "$base_dir/dart_tools/bin/update_flutter_engine.dart" $@
+exec "$dart_bin_dir/dart" "$base_dir/dart_tools/bin/update_flutter_engine.dart" "$@"


### PR DESCRIPTION
Currently building is broken when there are spaces in the path
containing the local checkout of the repository.