### PR TITLE
Add a generic run_dart_tool command

### DIFF
--- a/library/linux/Makefile
+++ b/library/linux/Makefile
@@ -51,7 +51,7 @@ $(LIBRARY_OUT): $(SOURCES) $(HEADERS) $(LIBRARIES)
 # avoiding unnecessary relinks.
 $(FLUTTER_ENGINE_LIB_FILE) $(FLUTTER_ENGINE_HEADER_DIR)/$(FLUTTER_ENGINE_HEADER): \
 		$(FLUTTER_DIR)/bin/internal/engine.version
-	$(ENGINE_UPDATER) --flutter_root=$(FLUTTER_DIR) ./
+	$(ENGINE_UPDATER) ./
 	if [ -f $(FLUTTER_ENGINE_HEADER) ]; then \
 		mkdir -p $(FLUTTER_ENGINE_HEADER_DIR) && \
 		mv $(FLUTTER_ENGINE_HEADER) $(FLUTTER_ENGINE_HEADER_DIR)/; \

--- a/library/macos/FlutterEmbedderMac.xcodeproj/project.pbxproj
+++ b/library/macos/FlutterEmbedderMac.xcodeproj/project.pbxproj
@@ -302,7 +302,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "readonly TOOLS_DIR=\"$PROJECT_DIR\"/../../tools\n\"$TOOLS_DIR\"/update_flutter_engine --flutter_root=\"$(\"$TOOLS_DIR\"/flutter_location)\" \"$PROJECT_DIR\"/../../../flutter_engine_framework/macos";
+			shellScript = "readonly TOOLS_DIR=\"$PROJECT_DIR\"/../../tools\n\"$TOOLS_DIR\"/update_flutter_engine \"$PROJECT_DIR\"/../../../flutter_engine_framework/macos";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/tools/run_dart_tool
+++ b/tools/run_dart_tool
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Takes the name of a tool in dart_tools/bin (without the .dart extension),
+# as well as any parameters to that tool, then runs it with those parameters
+# using the version of Dart from the Flutter tree.
+
+readonly base_dir="$(dirname "$0")"
+readonly flutter_dir="$("${base_dir}/flutter_location")"
+readonly flutter_bin_dir="${flutter_dir}/bin"
+readonly dart_bin_dir="${flutter_bin_dir}/cache/dart-sdk/bin"
+
+# Ensure that the Dart SDK has been downloaded.
+if [[ ! -e ${dart_bin_dir} ]]; then
+  "${flutter_bin_dir}/flutter" precache
+fi
+
+readonly tool_script="${base_dir}/dart_tools/bin/$1.dart"
+exec "${dart_bin_dir}/dart" "${tool_script}" "${@:2}"

--- a/tools/run_dart_tool.bat
+++ b/tools/run_dart_tool.bat
@@ -1,4 +1,4 @@
-:: Copyright 2018 Google LLC
+:: Copyright 2019 Google LLC
 ::
 :: Licensed under the Apache License, Version 2.0 (the "License");
 :: you may not use this file except in compliance with the License.
@@ -14,5 +14,13 @@
 @echo off
 
 for /f "delims=" %%i in ('%~dp0flutter_location') do set FLUTTER_DIR=%%i
+set FLUTTER_BIN_DIR=%FLUTTER_DIR%\bin
+set DART_BIN_DIR=%FLUTTER_BIN_DIR%\cache\dart-sdk\bin
 
-call %~dp0.\run_dart_tool update_flutter_engine --flutter_root %FLUTTER_DIR% %*
+:: Ensure that the Dart SDK has been downloaded.
+if not exist %DART_BIN_DIR%\ call %FLUTTER_BIN_DIR%\flutter precache
+
+set DART_TOOL=%1
+for /f "tokens=1,*" %%a in ("%*") do set TOOL_PARAMS=%%b
+
+call %DART_BIN_DIR%\dart %~dp0.\dart_tools\bin\%DART_TOOL%.dart %TOOL_PARAMS%

--- a/tools/update_flutter_engine
+++ b/tools/update_flutter_engine
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# 
+#
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,11 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 readonly base_dir="$(dirname "$0")"
-readonly flutter_dir="$("$base_dir/flutter_location")"
-readonly flutter_bin_dir="$flutter_dir/bin"
-readonly dart_bin_dir="$flutter_bin_dir/cache/dart-sdk/bin"
-# Ensure that the Dart SDK has been downloaded.
-if [[ ! -e $dart_bin_dir ]]; then
-  "$flutter_bin_dir/flutter" precache
-fi
-exec "$dart_bin_dir/dart" "$base_dir/dart_tools/bin/update_flutter_engine.dart" "$@"
+exec "${base_dir}/run_dart_tool" update_flutter_engine "$@"

--- a/tools/update_flutter_engine
+++ b/tools/update_flutter_engine
@@ -13,5 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Runs update_flutter_engine.dart, using the output of flutter_location as
+# --flutter_root
+
 readonly base_dir="$(dirname "$0")"
-exec "${base_dir}/run_dart_tool" update_flutter_engine "$@"
+readonly flutter_dir="$("${base_dir}/flutter_location")"
+exec "${base_dir}/run_dart_tool" update_flutter_engine \
+	--flutter_root="${flutter_dir}" "$@"

--- a/tools/update_flutter_engine.bat
+++ b/tools/update_flutter_engine.bat
@@ -11,6 +11,9 @@
 :: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 :: See the License for the specific language governing permissions and
 :: limitations under the License.
+
+:: Runs update_flutter_engine.dart, using the output of flutter_location.bat as
+:: --flutter_root
 @echo off
 
 for /f "delims=" %%i in ('%~dp0flutter_location') do set FLUTTER_DIR=%%i


### PR DESCRIPTION
This is a generic version of the existing update_flutter_engine wrappers,
so that as more dart tools are added they don't each need a wrapper.

update_flutter_engine remains for now, but may be removed in the future
in favor of calling 'run_dart_tool update_flutter_engine' instead. The shell
script version has been changed to match the existing batch script
behavior of automatically providing --flutter_root (since now there's an
easy way for a caller who wants to provide something else to do so).
This may simplify future changes to provide a project-level engine
override (#160)