### PR TITLE
Dart analysis-related fixes

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,10 +4,6 @@
 
 # Root analysis options shared among all Dart code in the respository. Based
 # on the Fuchsia standard analysis options, with some changes.
-analyzer:
-  strong-mode: true
-  language:
-    enableSuperMixins: true
 linter:
   # Full list available at http://dart-lang.github.io/linter/lints/options/options.html.
   rules:
@@ -75,7 +71,6 @@ linter:
     - parameter_assignments
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
-    - prefer_bool_in_asserts
     - prefer_collection_literals
     - prefer_conditional_assignment
     # Disabled until bug is fixed

--- a/example/flutter_app/analysis_options.yaml
+++ b/example/flutter_app/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: ../analysis_options.yaml
+include: ../../analysis_options.yaml

--- a/example/flutter_app/lib/keyboard_test_page.dart
+++ b/example/flutter_app/lib/keyboard_test_page.dart
@@ -30,11 +30,6 @@ class _KeyboardTestPageState extends State<KeyboardTestPage> {
   final ScrollController _scrollController = new ScrollController();
 
   @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     FocusScope.of(context).requestFocus(_focusNode);

--- a/example/flutter_app/lib/main.dart
+++ b/example/flutter_app/lib/main.dart
@@ -140,18 +140,18 @@ class _AppState extends State<MyApp> {
 }
 
 class _MyHomePage extends StatelessWidget {
+  const _MyHomePage({this.title, this.counter = 0});
+
   final String title;
   final int counter;
-
-  const _MyHomePage({this.title, this.counter = 0});
 
   void _changePrimaryThemeColor(BuildContext context) {
     final colorPanel = ColorPanel.instance;
     if (!colorPanel.showing) {
       colorPanel.show((color) {
         _AppState.of(context).setPrimaryColor(color);
-      // Setting the primary color to a non-opaque color raises an exception.
-      }, showAlpha: false); 
+        // Setting the primary color to a non-opaque color raises an exception.
+      }, showAlpha: false);
     }
   }
 

--- a/plugins/color_panel/lib/color_panel.dart
+++ b/plugins/color_panel/lib/color_panel.dart
@@ -40,12 +40,12 @@ typedef ColorPanelCallback = void Function(Color color);
 /// This class is a singleton, since the OS may not allow multiple color panels
 /// simultaneously.
 class ColorPanel {
-  ColorPanelCallback _callback;
-
   /// Private constructor.
   ColorPanel._() {
     _platformChannel.setMethodCallHandler(_wrappedColorPanelCallback);
   }
+
+  ColorPanelCallback _callback;
 
   /// The static instance of the panel.
   static ColorPanel instance = new ColorPanel._();

--- a/plugins/file_chooser/lib/src/channel_controller.dart
+++ b/plugins/file_chooser/lib/src/channel_controller.dart
@@ -37,15 +37,6 @@ enum FileChooserType {
 
 /// A set of configuration options for a file chooser.
 class FileChooserConfigurationOptions {
-  // See channel_constants.h for documentation; these correspond exactly to
-  // the configuration parameters defined in the channel protocol.
-  final String initialDirectory; // ignore: public_member_api_docs
-  final String initialFileName; // ignore: public_member_api_docs
-  final List<String> allowedFileTypes; // ignore: public_member_api_docs
-  final bool allowsMultipleSelection; // ignore: public_member_api_docs
-  final bool canSelectDirectories; // ignore: public_member_api_docs
-  final String confirmButtonText; // ignore: public_member_api_docs
-
   /// Creates a new configuration options object with the given settings.
   const FileChooserConfigurationOptions(
       {this.initialDirectory,
@@ -54,6 +45,15 @@ class FileChooserConfigurationOptions {
       this.allowsMultipleSelection,
       this.canSelectDirectories,
       this.confirmButtonText});
+
+  // See channel_constants.h for documentation; these correspond exactly to
+  // the configuration parameters defined in the channel protocol.
+  final String initialDirectory; // ignore: public_member_api_docs
+  final String initialFileName; // ignore: public_member_api_docs
+  final List<String> allowedFileTypes; // ignore: public_member_api_docs
+  final bool allowsMultipleSelection; // ignore: public_member_api_docs
+  final bool canSelectDirectories; // ignore: public_member_api_docs
+  final String confirmButtonText; // ignore: public_member_api_docs
 
   /// Returns the configuration as a map that can be passed as the
   /// arguments to invokeMethod for [_kShowOpenPanelMethod] or
@@ -87,10 +87,10 @@ class FileChooserConfigurationOptions {
 
 /// A singleton object that controls file-choosing interactions with macOS.
 class FileChooserChannelController {
+  FileChooserChannelController._();
+
   /// The platform channel used to manage native file chooser affordances.
   final _channel = new MethodChannel(_kChannelName, new JSONMethodCodec());
-
-  FileChooserChannelController._();
 
   /// A reference to the singleton instance of the class.
   static final FileChooserChannelController instance =

--- a/plugins/menubar/lib/src/menu_channel.dart
+++ b/plugins/menubar/lib/src/menu_channel.dart
@@ -30,6 +30,11 @@ const String _kDividerKey = 'isDivider';
 /// A singleton object that handles the interaction with the menu bar platform
 /// channel.
 class MenuChannel {
+  /// Private constructor.
+  MenuChannel._() {
+    _platformChannel.setMethodCallHandler(_callbackHandler);
+  }
+
   final MethodChannel _platformChannel =
       const MethodChannel(_kMenuChannelName, const JSONMethodCodec());
 
@@ -46,11 +51,6 @@ class MenuChannel {
   /// after a new call to setMenu, so that clients don't received unexpected
   /// stale callbacks.
   bool _updateInProgress;
-
-  /// Private constructor.
-  MenuChannel._() {
-    _platformChannel.setMethodCallHandler(_callbackHandler);
-  }
 
   /// The static instance of the menu channel.
   static final MenuChannel instance = new MenuChannel._();

--- a/plugins/menubar/lib/src/menu_item.dart
+++ b/plugins/menubar/lib/src/menu_item.dart
@@ -18,21 +18,15 @@ typedef MenuSelectedCallback = void Function();
 
 /// The base type for an individual menu item that can be shown in a menu.
 abstract class AbstractMenuItem {
-  /// The displayed label for the menu item.
-  final String label;
-
   /// Creates a new menu item with the give label.
   const AbstractMenuItem(this.label);
+
+  /// The displayed label for the menu item.
+  final String label;
 }
 
 /// A standard menu item, with no submenus.
 class MenuItem extends AbstractMenuItem {
-  /// The callback to call whenever the menu item is selected.
-  final MenuSelectedCallback onClicked;
-
-  /// Whether or not the menu item is enabled.
-  final bool enabled;
-
   /// Creates a new menu item with the given [label] and options.
   ///
   /// Note that onClicked should generally be set unless [enabled] is false,
@@ -42,18 +36,24 @@ class MenuItem extends AbstractMenuItem {
     this.enabled = true,
     this.onClicked,
   }) : super(label);
+
+  /// The callback to call whenever the menu item is selected.
+  final MenuSelectedCallback onClicked;
+
+  /// Whether or not the menu item is enabled.
+  final bool enabled;
 }
 
 /// A menu item continaing a submenu.
 ///
 /// The item itself can't be selected, it just displays the submenu.
 class Submenu extends AbstractMenuItem {
-  /// The menu items contained in the submenu.
-  final List<AbstractMenuItem> children;
-
   /// Creates a new submenu with the given [label] and [children].
   const Submenu({@required String label, @required this.children})
       : super(label);
+
+  /// The menu items contained in the submenu.
+  final List<AbstractMenuItem> children;
 }
 
 /// A menu item that serves as a divider, generally drawn as a line.


### PR DESCRIPTION
- Fixes the include path for the example app's analysis file, which
  broke during the repository restructure.
- Removes analysis options that are obsolete in recent Dart versions.
- Fix some new analysis issues (mostly constructor ordering).