### PR TITLE
Revert incorrect change in update_flutter_engine.dart

### DIFF
--- a/tools/dart_tools/bin/update_flutter_engine.dart
+++ b/tools/dart_tools/bin/update_flutter_engine.dart
@@ -84,9 +84,9 @@ Future<void> main(List<String> arguments) async {
     exit(1);
   }
 
-  if (parsedArguments['help'] != null || parsedArguments.rest.length != 1) {
+  if (parsedArguments['help'] || parsedArguments.rest.length != 1) {
     printUsage(parser);
-    exit(parsedArguments['help'] != null ? 0 : 1);
+    exit(parsedArguments['help'] ? 0 : 1);
   }
 
   try {


### PR DESCRIPTION
update_flutter_engine was broken by an incorrect change to try to fix an
analyzer warning that didn't end up getting turned on; the default value
is false, not null, for the help flag, so the test always passed.