### PR TITLE
Fix header guard

### DIFF
--- a/library/common/glfw/key_event_handler.h
+++ b/library/common/glfw/key_event_handler.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #ifndef LIBRARY_COMMON_GLFW_KEY_EVENT_HANDLER_H_
-#define LIBRARY_COMMON_GLFW_kEY_EVENT_HANDLER_H_
+#define LIBRARY_COMMON_GLFW_KEY_EVENT_HANDLER_H_
 
 #include "library/common/glfw/keyboard_hook_handler.h"
 #include "library/include/flutter_desktop_embedding/binary_messenger.h"


### PR DESCRIPTION
The header guard for key_event_handler.h didn't actually work due to a
typo (k instead of K).