### PR TITLE
Fix Windows VS build

### DIFF
--- a/library/windows/scripts/build_jsonlib.bat
+++ b/library/windows/scripts/build_jsonlib.bat
@@ -12,4 +12,10 @@
 :: See the License for the specific language governing permissions and
 :: limitations under the License.
 @echo off
-%~dp0..\..\..\tools\run_dart_tool.bat build_jsoncpp %~dp0..\third_party\jsoncpp %~dp0..\dependencies\JSON %*
+
+set RUN_DART_TOOL=%~dp0..\..\..\tools\run_dart_tool.bat
+set CHECKOUT_DIR=%~dp0..\third_party\jsoncpp
+set ARTIFACT_DIR=%~dp0..\dependencies\JSON
+
+call %RUN_DART_TOOL% fetch_jsoncpp %CHECKOUT_DIR%
+call %RUN_DART_TOOL% build_jsoncpp %CHECKOUT_DIR% %ARTIFACT_DIR% %*

--- a/tools/dart_tools/bin/fetch_jsoncpp.dart
+++ b/tools/dart_tools/bin/fetch_jsoncpp.dart
@@ -38,11 +38,15 @@ Future<void> main(List<String> arguments) async {
 
   final downloadDirectory = arguments[0];
 
-  await runCommand('git', [
-    'clone',
-    gitRepo,
-    downloadDirectory,
-  ]);
+  if (Directory(downloadDirectory).existsSync()) {
+    print('$downloadDirectory already exists; skipping clone');
+  } else {
+    await runCommand('git', [
+      'clone',
+      gitRepo,
+      downloadDirectory,
+    ]);
+  }
 
   await runCommand(
       'git',


### PR DESCRIPTION
Re-adds checkout of jsoncpp to build_jsonlib.bat, so that a clean VS
build on Windows build will succeed. Makes fetch_jsoncpp.dart
handle the case where the clone has already been run, so that
it can be called unconditionally from build_json.bat.

Fixes a regression from PR #191