### PR TITLE
[linux/windows] Add BasicMessageChannel

### DIFF
--- a/library/BUILD.gn
+++ b/library/BUILD.gn
@@ -36,19 +36,21 @@ published_shared_library("flutter_embedder") {
   if (is_linux || is_win) {
     sources += [
       "common/engine_method_result.cc",
-      "common/internal/json_message_codec.cc",
-      "common/internal/json_message_codec.h",
       "common/internal/plugin_handler.cc",
       "common/internal/plugin_handler.h",
       "common/internal/text_input_model.cc",
       "common/internal/text_input_model.h",
+      "common/json_message_codec.cc",
       "common/json_method_codec.cc",
     ]
     public += [
+      "include/flutter_desktop_embedding/basic_message_channel.h",
       "include/flutter_desktop_embedding/binary_messenger.h",
       "include/flutter_desktop_embedding/engine_method_result.h",
       "include/flutter_desktop_embedding/fde_export.h",
+      "include/flutter_desktop_embedding/json_message_codec.h",
       "include/flutter_desktop_embedding/json_method_codec.h",
+      "include/flutter_desktop_embedding/message_codec.h",
       "include/flutter_desktop_embedding/method_call.h",
       "include/flutter_desktop_embedding/method_channel.h",
       "include/flutter_desktop_embedding/method_codec.h",

--- a/library/common/glfw/key_event_handler.h
+++ b/library/common/glfw/key_event_handler.h
@@ -14,7 +14,12 @@
 #ifndef LIBRARY_COMMON_GLFW_KEY_EVENT_HANDLER_H_
 #define LIBRARY_COMMON_GLFW_KEY_EVENT_HANDLER_H_
 
+#include <memory>
+
+#include <json/json.h>
+
 #include "library/common/glfw/keyboard_hook_handler.h"
+#include "library/include/flutter_desktop_embedding/basic_message_channel.h"
 #include "library/include/flutter_desktop_embedding/binary_messenger.h"
 
 namespace flutter_desktop_embedding {
@@ -24,7 +29,7 @@ namespace flutter_desktop_embedding {
 // Handles key events and forwards them to the Flutter engine.
 class KeyEventHandler : public KeyboardHookHandler {
  public:
-  explicit KeyEventHandler(const BinaryMessenger *messenger);
+  explicit KeyEventHandler(BinaryMessenger *messenger);
   virtual ~KeyEventHandler();
 
   // KeyboardHookHandler.
@@ -33,10 +38,8 @@ class KeyEventHandler : public KeyboardHookHandler {
   void CharHook(GLFWwindow *window, unsigned int code_point) override;
 
  private:
-  // Binds this plugin to the given caller-owned binary messenger. It must
-  // remain valid for the life of the plugin.
-  const BinaryMessenger *messenger_;
-  std::string channel_;
+  // The Flutter system channel for key event messages.
+  std::unique_ptr<BasicMessageChannel<Json::Value>> channel_;
 };
 
 }  // namespace flutter_desktop_embedding

--- a/library/common/json_message_codec.cc
+++ b/library/common/json_message_codec.cc
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "library/common/internal/json_message_codec.h"
+#include "library/include/flutter_desktop_embedding/json_message_codec.h"
 
 #include <iostream>
 #include <string>
@@ -24,7 +24,7 @@ const JsonMessageCodec &JsonMessageCodec::GetInstance() {
   return sInstance;
 }
 
-std::unique_ptr<std::vector<uint8_t>> JsonMessageCodec::EncodeMessage(
+std::unique_ptr<std::vector<uint8_t>> JsonMessageCodec::EncodeMessageInternal(
     const Json::Value &message) const {
   Json::StreamWriterBuilder writer_builder;
   std::string serialization = Json::writeString(writer_builder, message);
@@ -33,12 +33,12 @@ std::unique_ptr<std::vector<uint8_t>> JsonMessageCodec::EncodeMessage(
                                                 serialization.end());
 }
 
-std::unique_ptr<Json::Value> JsonMessageCodec::DecodeMessage(
-    const uint8_t *message, const size_t message_size) const {
+std::unique_ptr<Json::Value> JsonMessageCodec::DecodeMessageInternal(
+    const uint8_t *binary_message, const size_t message_size) const {
   Json::CharReaderBuilder reader_builder;
   std::unique_ptr<Json::CharReader> parser(reader_builder.newCharReader());
 
-  auto raw_message = reinterpret_cast<const char *>(message);
+  auto raw_message = reinterpret_cast<const char *>(binary_message);
   auto json_message = std::make_unique<Json::Value>();
   std::string parse_errors;
   bool parsing_successful =

--- a/library/common/json_method_codec.cc
+++ b/library/common/json_method_codec.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include "library/include/flutter_desktop_embedding/json_method_codec.h"
 
-#include "library/common/internal/json_message_codec.h"
+#include "library/include/flutter_desktop_embedding/json_message_codec.h"
 
 namespace flutter_desktop_embedding {
 

--- a/library/include/flutter_desktop_embedding/basic_message_channel.h
+++ b/library/include/flutter_desktop_embedding/basic_message_channel.h
@@ -1,0 +1,106 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_BASIC_MESSAGE_CHANNEL_H_
+#define LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_BASIC_MESSAGE_CHANNEL_H_
+
+#include <iostream>
+#include <string>
+
+#include "binary_messenger.h"
+#include "fde_export.h"
+#include "message_codec.h"
+
+namespace flutter_desktop_embedding {
+
+// A message reply callback.
+//
+// Used for submitting a reply back to a Flutter message sender.
+template <typename T>
+using MessageReply = std::function<void(const T &reply)>;
+
+// A handler for receiving a message from the Flutter engine.
+//
+// Implementations must asynchronously call reply exactly once with the reply
+// to the message.
+template <typename T>
+using MessageHandler =
+    std::function<void(const T &message, MessageReply<T> reply)>;
+
+// A channel for communicating with the Flutter engine by sending asynchronous
+// messages.
+template <typename T>
+class FDE_EXPORT BasicMessageChannel {
+ public:
+  // Creates an instance that sends and receives method calls on the channel
+  // named |name|, encoded with |codec| and dispatched via |messenger|.
+  //
+  // TODO: Make codec optional once the standard codec is supported (Issue #67).
+  BasicMessageChannel(BinaryMessenger *messenger, const std::string &name,
+                      const MessageCodec<T> *codec)
+      : messenger_(messenger), name_(name), codec_(codec) {}
+  ~BasicMessageChannel() {}
+
+  // Prevent copying.
+  BasicMessageChannel(BasicMessageChannel const &) = delete;
+  BasicMessageChannel &operator=(BasicMessageChannel const &) = delete;
+
+  // Sends a message to the Flutter engine on this channel.
+  void Send(const T &message) {
+    std::unique_ptr<std::vector<uint8_t>> raw_message =
+        codec_->EncodeMessage(message);
+    messenger_->Send(name_, raw_message->data(), raw_message->size());
+  }
+
+  // TODO: Add support for a version of Send expecting a reply once
+  // https://github.com/flutter/flutter/issues/18852 is fixed.
+
+  // Registers a handler that should be called any time a message is
+  // received on this channel.
+  void SetMessageHandler(MessageHandler<T> handler) const {
+    const auto *codec = codec_;
+    std::string channel_name = name_;
+    BinaryMessageHandler binary_handler = [handler, codec, channel_name](
+                                              const uint8_t *binary_message,
+                                              const size_t binary_message_size,
+                                              BinaryReply binary_reply) {
+      // Use this channel's codec to decode the message and build a reply
+      // handler.
+      std::unique_ptr<T> message =
+          codec->DecodeMessage(binary_message, binary_message_size);
+      if (!message) {
+        std::cerr << "Unable to decode message on channel " << channel_name
+                  << std::endl;
+        binary_reply(nullptr, 0);
+        return;
+      }
+
+      MessageReply<T> unencoded_reply = [binary_reply,
+                                         codec](const T &unencoded_response) {
+        auto binary_response = codec->EncodeMessage(unencoded_response);
+        binary_reply(binary_response->data(), binary_response->size());
+      };
+      handler(*message, std::move(unencoded_reply));
+    };
+    messenger_->SetMessageHandler(name_, std::move(binary_handler));
+  }
+
+ private:
+  BinaryMessenger *messenger_;
+  std::string name_;
+  const MessageCodec<T> *codec_;
+};
+
+}  // namespace flutter_desktop_embedding
+
+#endif  // LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_BASIC_MESSAGE_CHANNEL_H_

--- a/library/include/flutter_desktop_embedding/binary_messenger.h
+++ b/library/include/flutter_desktop_embedding/binary_messenger.h
@@ -23,9 +23,9 @@
 // the message/message_size pairs.
 namespace flutter_desktop_embedding {
 
-// A message reply callback.
+// A binary message reply callback.
 //
-// Used for submitting a reply back to a Flutter message sender.
+// Used for submitting a binary reply back to a Flutter message sender.
 typedef std::function<void(const uint8_t *reply, const size_t reply_size)>
     BinaryReply;
 

--- a/library/include/flutter_desktop_embedding/json_message_codec.h
+++ b/library/include/flutter_desktop_embedding/json_message_codec.h
@@ -11,23 +11,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef LIBRARY_COMMON_INTERNAL_JSON_MESSAGE_CODEC_H_
-#define LIBRARY_COMMON_INTERNAL_JSON_MESSAGE_CODEC_H_
-
-#include <memory>
-#include <vector>
+#ifndef LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_MESSAGE_CODEC_H_
+#define LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_MESSAGE_CODEC_H_
 
 #include <json/json.h>
+
+#include "fde_export.h"
+#include "message_codec.h"
 
 namespace flutter_desktop_embedding {
 
 // A message encoding/decoding mechanism for communications to/from the
 // Flutter engine via JSON channels.
-//
-// TODO: Make this public, once generalizing a MessageCodec parent interface is
-// addressed; this is complicated by the return type of EncodeMessage.
-// Part of issue #102.
-class JsonMessageCodec {
+class JsonMessageCodec : public MessageCodec<Json::Value> {
  public:
   // Returns the shared instance of the codec.
   static const JsonMessageCodec &GetInstance();
@@ -38,22 +34,17 @@ class JsonMessageCodec {
   JsonMessageCodec(JsonMessageCodec const &) = delete;
   JsonMessageCodec &operator=(JsonMessageCodec const &) = delete;
 
-  // Returns a binary encoding of the given message, or nullptr if the
-  // message cannot be serialized by this codec.
-  std::unique_ptr<std::vector<uint8_t>> EncodeMessage(
-      const Json::Value &message) const;
-
-  // Returns the JSON object encoded in |message|, or nullptr if it cannot be
-  // decoded.
-  // TODO: Consider adding absl as a dependency and using absl::Span.
-  std::unique_ptr<Json::Value> DecodeMessage(const uint8_t *message,
-                                             const size_t message_size) const;
-
  protected:
   // Instances should be obtained via GetInstance.
   JsonMessageCodec() = default;
+
+  // MessageCodec:
+  std::unique_ptr<Json::Value> DecodeMessageInternal(
+      const uint8_t *binary_message, const size_t message_size) const override;
+  std::unique_ptr<std::vector<uint8_t>> EncodeMessageInternal(
+      const Json::Value &message) const override;
 };
 
 }  // namespace flutter_desktop_embedding
 
-#endif  // LIBRARY_COMMON_INTERNAL_JSON_MESSAGE_CODEC_H_
+#endif  // LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_JSON_MESSAGE_CODEC_H_

--- a/library/include/flutter_desktop_embedding/message_codec.h
+++ b/library/include/flutter_desktop_embedding/message_codec.h
@@ -1,0 +1,61 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_MESSAGE_CODEC_H_
+#define LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_MESSAGE_CODEC_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "fde_export.h"
+
+namespace flutter_desktop_embedding {
+
+// Translates between a binary message and higher-level method call and
+// response/error objects.
+template <typename T>
+class FDE_EXPORT MessageCodec {
+ public:
+  MessageCodec() = default;
+  virtual ~MessageCodec() = default;
+
+  // Prevent copying.
+  MessageCodec(MessageCodec<T> const &) = delete;
+  MessageCodec &operator=(MessageCodec<T> const &) = delete;
+
+  // Returns the message encoded in |binary_message|, or nullptr if it cannot be
+  // decoded by this codec.
+  // TODO: Consider adding absl as a dependency and using absl::Span.
+  std::unique_ptr<T> DecodeMessage(const uint8_t *binary_message,
+                                   const size_t message_size) const {
+    return std::move(DecodeMessageInternal(binary_message, message_size));
+  }
+
+  // Returns a binary encoding of the given |message|, or nullptr if the
+  // message cannot be serialized by this codec.
+  std::unique_ptr<std::vector<uint8_t>> EncodeMessage(const T &message) const {
+    return std::move(EncodeMessageInternal(message));
+  }
+
+ protected:
+  // Implementations of the public interface, to be provided by subclasses.
+  virtual std::unique_ptr<T> DecodeMessageInternal(
+      const uint8_t *binary_message, const size_t message_size) const = 0;
+  virtual std::unique_ptr<std::vector<uint8_t>> EncodeMessageInternal(
+      const T &message) const = 0;
+};
+
+}  // namespace flutter_desktop_embedding
+
+#endif  // LIBRARY_INCLUDE_FLUTTER_DESKTOP_EMBEDDING_MESSAGE_CODEC_H_

--- a/library/windows/GLFW Library.vcxproj
+++ b/library/windows/GLFW Library.vcxproj
@@ -150,9 +150,9 @@
     <ClCompile Include="..\common\glfw\embedder.cc" />
     <ClCompile Include="..\common\glfw\key_event_handler.cc" />
     <ClCompile Include="..\common\glfw\text_input_plugin.cc" />
-    <ClCompile Include="..\common\internal\json_message_codec.cc" />
     <ClCompile Include="..\common\internal\plugin_handler.cc" />
     <ClCompile Include="..\common\internal\text_input_model.cc" />
+    <ClCompile Include="..\common\json_message_codec.cc" />
     <ClCompile Include="..\common\json_method_codec.cc" />
   </ItemGroup>
   <ItemGroup>

--- a/library/windows/GLFW Library.vcxproj.filters
+++ b/library/windows/GLFW Library.vcxproj.filters
@@ -24,7 +24,7 @@
     <ClCompile Include="..\common\engine_method_result.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\common\internal\json_message_codec.cc">
+    <ClCompile Include="..\common\json_message_codec.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\common\internal\text_input_model.cc">


### PR DESCRIPTION
Implements BasicMessageChannel, adds MessageCodec, and makes
JsonMessageCodec public.

Converts the key event handler from using BinaryMessenger directly to
using a BasicMessageChannel to send events now that it's available.