### PR TITLE
[linux] Use pkg-config for libglfw

### DIFF
--- a/build/linux/config/BUILD.gn
+++ b/build/linux/config/BUILD.gn
@@ -14,18 +14,22 @@
 
 import("//third_party/chromium/build/config/linux/pkg_config.gni")
 
-pkg_config("gtk3") {
-  packages = [ "gtk+-3.0" ]
-}
-
 pkg_config("epoxy") {
   packages = [ "epoxy" ]
 }
 
-pkg_config("x11") {
-  packages = [ "x11" ]
+pkg_config("glfw3") {
+  packages = [ "glfw3" ]
+}
+
+pkg_config("gtk3") {
+  packages = [ "gtk+-3.0" ]
 }
 
 pkg_config("jsoncpp") {
   packages = [ "jsoncpp" ]
+}
+
+pkg_config("x11") {
+  packages = [ "x11" ]
 }

--- a/example/linux/Makefile
+++ b/example/linux/Makefile
@@ -83,14 +83,13 @@ endif
 
 # Build settings
 CXX=g++ -std=c++14
-CXXFLAGS=-Wall -Werror $(shell pkg-config --cflags jsoncpp)
+CXXFLAGS=-Wall -Werror $(shell pkg-config --cflags jsoncpp glfw3)
 CPPFLAGS=$(patsubst %,-I%,$(INCLUDE_DIRS))
 ifdef USE_GN
 CPPFLAGS+=-DUSE_FLATTENED_INCLUDES
 endif
 LDFLAGS=-L$(OUT_LIB_DIR) \
-	-lglfw \
-	$(shell pkg-config --libs jsoncpp) \
+	$(shell pkg-config --libs jsoncpp glfw3) \
 	-l$(FLUTTER_EMBEDDER_LIB_NAME) \
 	-l$(FLUTTER_ENGINE_LIB_NAME) \
 	$(patsubst %,-l$(PLUGIN_LIB_NAME_PREFIX)%,$(PLUGIN_NAMES)) \

--- a/library/BUILD.gn
+++ b/library/BUILD.gn
@@ -73,7 +73,6 @@ published_shared_library("flutter_embedder") {
 
   if (is_linux) {
     libs = [
-      "glfw",
       "GL",
     ]
 
@@ -83,6 +82,7 @@ published_shared_library("flutter_embedder") {
 
     configs += [
       "//build/linux/config:epoxy",
+      "//build/linux/config:glfw3",
       "//build/linux/config:gtk3",
       "//build/linux/config:jsoncpp",
       "//build/linux/config:x11",

--- a/library/linux/Makefile
+++ b/library/linux/Makefile
@@ -27,10 +27,10 @@ CXXFLAGS= -Wall -Werror -shared -fPIC -fvisibility=hidden \
 	-I$(PROJECT_ROOT)/library/include \
 	-I$(FLUTTER_ENGINE_HEADER_DIR) \
 	-DFLUTTER_DESKTOP_EMBEDDING_IMPL \
-	$(shell pkg-config --cflags gtk+-3.0 epoxy x11 jsoncpp)
+	$(shell pkg-config --cflags gtk+-3.0 epoxy x11 jsoncpp glfw3)
 LDFLAGS= -L$(CURDIR) \
-	$(shell pkg-config --libs gtk+-3.0 epoxy x11 jsoncpp) \
-	-lglfw -lGL -l$(FLUTTER_ENGINE_LIB_NAME) \
+	$(shell pkg-config --libs gtk+-3.0 epoxy x11 jsoncpp glfw3) \
+	-lGL -l$(FLUTTER_ENGINE_LIB_NAME) \
 	-Wl,-rpath=$(CURDIR)
 
 


### PR DESCRIPTION
The makes libglfw added via pkg-config calls, rather than manually, for
consistency with other similar dependencies.