### PR TITLE
Add a simpler way to use a local Flutter engine

### DIFF
--- a/LocalEngine.md
+++ b/LocalEngine.md
@@ -1,0 +1,35 @@
+# Running a Locally Built Flutter Engine
+
+It may be useful for debugging or development to run with a [locally built
+Flutter engine](https://github.com/flutter/flutter/wiki/Compiling-the-engine).
+To temporarily override the normal behavior of `update_flutter_engine` and
+`build_flutter_assets`, add a file called `engine_override` at the root of
+your `flutter_desktop_embedding` checkout. For instance, on macOS or Linux:
+```
+$ echo host_debug_unopt > engine_override
+```
+
+This will cause `update_flutter_engine` to copy your local engine instead of
+downloading a prebuilt engine, and `build_flutter_assets` to pass the
+`--local-engine` flag when building assets.
+
+**Important**: Your Flutter engine checkout must be in a folder called `engine`
+(as recommended in the [setup
+instructions](https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment)),
+which must be next to your `flutter` checkout, or `update_flutter_engine` will
+fail.
+
+## Dart Changes
+
+If you change any Dart code in your engine, be sure to follow the instructions
+[here](https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment)
+or
+[here](https://github.com/flutter/flutter/wiki/The-flutter-tool#using-a-locally-built-engine-with-the-flutter-tool)
+for adding a `dependency_overrides` section to your `pubspec.yaml`.
+
+## Switching Back to a Prebuilt Engine
+
+To stop using your local engine, just delete `engine_override` (and
+`dependency_overrides` if you added them to `pubspec.yaml`) and rebuild.
+`update_flutter_engine` will automatically re-download the correct prebuilt
+engine.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ with this library.
 Debugging of the Flutter side of a desktop application is possible, but requires
 [a modified workflow](Debugging.md).
 
+To debug the Flutter engine, you can [use a local engine build](LocalEngine.md).
+
 ## Feedback and Discussion
 
 For bug reports and specific feature requests, you can file GitHub issues. For

--- a/tools/build_flutter_assets
+++ b/tools/build_flutter_assets
@@ -14,22 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script runs the necessary Flutter commands to build the Flutter assets
-# than need to be packaged in an embedding application.
-# It should be called with one argument, which is the directory of the
-# Flutter application to build.
+# Runs build_flutter_assets.dart, using the output of flutter_location as
+# --flutter_root
 
 readonly base_dir="$(dirname "$0")"
-readonly flutter_dir="$("$base_dir/flutter_location")"
-readonly flutter_binary="$flutter_dir/bin/flutter"
-
-# To use a custom Flutter engine, uncomment the following variables, and set
-# engine_src_path to the path on your machine to your Flutter engine tree's
-# src/ directory (and build_type if your engine build is not debug).
-#readonly engine_src_path="/path/to/engine/src"
-#readonly build_type=host_debug_unopt
-#readonly extra_flags=(--local-engine-src-path $engine_src_path --local-engine=$build_type)
-
-cd "$1"
-echo Running "$flutter_binary" ${extra_flags[*]} build bundle
-exec "$flutter_binary" ${extra_flags[*]} build bundle
+readonly flutter_dir="$("${base_dir}/flutter_location")"
+exec "${base_dir}/run_dart_tool" build_flutter_assets \
+	--flutter_root="${flutter_dir}" "$@"

--- a/tools/build_flutter_assets.bat
+++ b/tools/build_flutter_assets.bat
@@ -11,24 +11,11 @@
 :: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 :: See the License for the specific language governing permissions and
 :: limitations under the License.
+
+:: Runs build_flutter_assets.dart, using the output of flutter_location.bat as
+:: --flutter_root
 @echo off
 
-:: This script runs the necessary Flutter commands to build the Flutter assets
-:: than need to be packaged in an embedding application.
-:: It should be called with one argument, which is the directory of the
-:: Flutter application to build.
-SETLOCAL ENABLEDELAYEDEXPANSION
-
 for /f "delims=" %%i in ('%~dp0flutter_location') do set FLUTTER_DIR=%%i
-set FLUTTER_BINARY=%FLUTTER_DIR%\bin\flutter
 
-:: To use a custom Flutter engine, uncomment the following variables, and set
-:: ENGINE_SRC_PATH to the path on your machine to your Flutter engine tree's
-:: src\ directory (and BUILD_TYPE if your engine build is not debug).
-::set ENGINE_SRC_PATH=path\to\engine\src
-::set BUILD_TYPE=host_debug_unopt
-::set EXTRA_FLAGS=--local-engine-src-path %ENGINE_SRC_PATH% --local-engine=%BUILD_TYPE%
-
-cd %1
-echo Running %FLUTTER_BINARY% %EXTRA_FLAGS% build bundle
-call %FLUTTER_BINARY% %EXTRA_FLAGS% build bundle
+call %~dp0.\run_dart_tool build_flutter_assets --flutter_root %FLUTTER_DIR% %*

--- a/tools/dart_tools/bin/build_flutter_assets.dart
+++ b/tools/dart_tools/bin/build_flutter_assets.dart
@@ -46,8 +46,9 @@ Future<void> main(List<String> arguments) async {
   }
   final flutterApplicationDir = parsedArguments.rest[0];
 
+  final flutterName = Platform.isWindows ? 'flutter.bat' : 'flutter';
   final flutterBinary =
-      path.join(parsedArguments['flutter_root'], 'bin', 'flutter');
+      path.join(parsedArguments['flutter_root'], 'bin', flutterName);
   if (!File(flutterBinary).existsSync()) {
     print("Error: No flutter binary at '$flutterBinary'");
     exit(1);

--- a/tools/dart_tools/bin/build_flutter_assets.dart
+++ b/tools/dart_tools/bin/build_flutter_assets.dart
@@ -1,0 +1,78 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This script runs the necessary Flutter commands to build the Flutter assets
+// that need to be packaged in an embedding application.
+// It should be called with one argument, which is the directory of the
+// Flutter application to build.
+
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:path/path.dart' as path;
+
+import '../lib/flutter_utils.dart';
+import '../lib/run_command.dart';
+
+Future<void> main(List<String> arguments) async {
+  final parser = new ArgParser()
+    ..addOption('flutter_root',
+        help: 'The root of the Flutter tree to run \'flutter\' from.\n'
+            'Defaults to a "flutter" directory next to this repository.',
+        defaultsTo: getDefaultFlutterRoot())
+    ..addFlag('help', help: 'Prints this usage message.', negatable: false);
+  ArgResults parsedArguments;
+
+  try {
+    parsedArguments = parser.parse(arguments);
+  } on ArgParserException {
+    printUsage(parser);
+    exit(1);
+  }
+  if (parsedArguments.rest.length != 1) {
+    printUsage(parser);
+    exit(1);
+  }
+  final flutterApplicationDir = parsedArguments.rest[0];
+
+  final flutterBinary =
+      path.join(parsedArguments['flutter_root'], 'bin', 'flutter');
+  if (!File(flutterBinary).existsSync()) {
+    print("Error: No flutter binary at '$flutterBinary'");
+    exit(1);
+  }
+
+  final buildArguments = ['build', 'bundle'];
+
+  // Add --local-engine if an override is specified. --local-engine-src-path
+  // isn't provided since per
+  // https://github.com/flutter/flutter/wiki/The-flutter-tool
+  // it's not required if the engine directory is next to the flutter directory,
+  // which is currently the only configuration this project supports for local
+  // engines.
+  final engineOverride = await getEngineOverrideBuildType();
+  if (engineOverride != null) {
+    buildArguments.insertAll(0, ['--local-engine', engineOverride]);
+  }
+
+  await runCommand(flutterBinary, buildArguments,
+      workingDirectory: flutterApplicationDir);
+}
+
+/// Prints usage info for this utility.
+void printUsage(ArgParser argParser) {
+  print('Usage: build_flutter_assets [options] '
+      '<fluter application directory>\n');
+  print(argParser.usage);
+}

--- a/tools/dart_tools/bin/build_jsoncpp.dart
+++ b/tools/dart_tools/bin/build_jsoncpp.dart
@@ -21,7 +21,7 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
 
-import '../lib/runCommand.dart';
+import '../lib/run_command.dart';
 
 Future<void> main(List<String> arguments) async {
   if (!Platform.isWindows) {
@@ -62,7 +62,7 @@ Future<void> buildLibrary(String buildDirectory, {bool debug}) async {
     arguments.add('/p:Configuration=Release');
   }
   await runCommand('vcvars64.bat 1> nul &&', arguments,
-      workingDirectory: buildDirectory);
+      workingDirectory: buildDirectory, runInShell: true);
 }
 
 Future<void> copyLibraryToOutputDirectory(

--- a/tools/dart_tools/bin/fetch_jsoncpp.dart
+++ b/tools/dart_tools/bin/fetch_jsoncpp.dart
@@ -17,7 +17,7 @@
 
 import 'dart:io';
 
-import '../lib/runCommand.dart';
+import '../lib/run_command.dart';
 
 // For the fork containing V2017 support. Once
 // https://github.com/open-source-parsers/jsoncpp/pull/853

--- a/tools/dart_tools/bin/update_flutter_engine.dart
+++ b/tools/dart_tools/bin/update_flutter_engine.dart
@@ -34,12 +34,16 @@ const String engineArchiveBaseUrlString =
 
 /// Simple container for platform-specific information.
 class PlatformInfo {
-  PlatformInfo(this.archiveSubpath, this.libraryFile);
+  PlatformInfo(this.archiveSubpath, this.libraryFiles);
 
-  // The subpath on storage.googleapis.com for a platform's engine archive.
+  /// The subpath on storage.googleapis.com for a platform's engine archive.
   final String archiveSubpath;
-  // The extracted engine library filename for a platform.
-  final String libraryFile;
+
+  /// The top-level extracted files for a platform.
+  ///
+  /// The first item in the array is the library itself, and any other items
+  /// are supporting files (headers, symbols, etc.).
+  final List<String> libraryFiles;
 }
 
 /// Exceptions for known error cases in updating the engine.
@@ -51,12 +55,20 @@ class EngineUpdateException implements Exception {
 
 /// PlatformInfo for each supported platform.
 final Map<String, PlatformInfo> platformInfo = {
-  'linux':
-      new PlatformInfo('linux-x64/linux-x64-embedder', 'libflutter_engine.so'),
-  'macos': new PlatformInfo(
-      'darwin-x64/FlutterEmbedder.framework.zip', 'FlutterEmbedder.framework'),
-  'windows': new PlatformInfo(
-      'windows-x64/windows-x64-embedder.zip', 'flutter_engine.dll'),
+  'linux': new PlatformInfo('linux-x64/linux-x64-embedder', [
+    'libflutter_engine.so',
+    'flutter_embedder.h',
+  ]),
+  'macos': new PlatformInfo('darwin-x64/FlutterEmbedder.framework.zip', [
+    'FlutterEmbedder.framework',
+  ]),
+  'windows': new PlatformInfo('windows-x64/windows-x64-embedder.zip', [
+    'flutter_engine.dll',
+    'flutter_engine.dll.exp',
+    'flutter_engine.dll.lib',
+    'flutter_engine.dll.pdb',
+    'flutter_embedder.h',
+  ]),
 };
 
 Future<void> main(List<String> arguments) async {
@@ -68,14 +80,19 @@ Future<void> main(List<String> arguments) async {
         defaultsTo: Platform.operatingSystem)
     ..addOption('flutter_root',
         help: 'The root of the Flutter tree to get the engine version from.\n'
-            'Ignored if --hash is provided.\n'
+            'Ignored if --hash is provided, or if an engine_override file '
+            'is present.\n'
             'Defaults to a "flutter" directory next to this repository.',
         defaultsTo: getDefaultFlutterRoot())
     ..addOption(
       'hash',
+      // Note: engine_override takes precedence over this flag so that
+      // individual developers can easily use engine_override for development
+      // even if the project is configured to use --hash.
       help: 'The hash of the engine version to use.\n'
           'This is only required if you want to override the version;\n'
-          'normally you should use flutter_root instead.',
+          'normally you should use flutter_root instead.\n'
+          'Ignored if an engine_override is present\n',
     )
     ..addFlag('help', help: 'Prints this usage message.', negatable: false);
   ArgResults parsedArguments;
@@ -91,25 +108,27 @@ Future<void> main(List<String> arguments) async {
     exit(parsedArguments['help'] ? 0 : 1);
   }
 
-  try {
-    final String platform = parsedArguments['platform'];
-    final outputRoot =
-        path.canonicalize(path.absolute(parsedArguments.rest[0]));
-    final String targetHash = parsedArguments['hash'] ??
-        await engineHashForFlutterTree(parsedArguments['flutter_root']);
-    final libraryFile = platformInfo[platform].libraryFile;
+  final String platform = parsedArguments['platform'];
+  final String flutterRoot = parsedArguments['flutter_root'];
+  final outputRoot = path.canonicalize(path.absolute(parsedArguments.rest[0]));
 
-    final currentHash = await lastDownloadedEngineHash(outputRoot, platform);
-    if (currentHash == null || targetHash != currentHash) {
-      await downloadEngine(targetHash, platform, outputRoot);
-      await setLastDownloadedEngineHash(outputRoot, targetHash);
-      print('Downloaded $libraryFile version $targetHash.');
-    } else {
-      print('$libraryFile version $targetHash already present.');
+  final engineOverrideBuildType = await getEngineOverrideBuildType();
+  if (engineOverrideBuildType == null) {
+    final String targetHash =
+        parsedArguments['hash'] ?? await engineHashForFlutterTree(flutterRoot);
+    if (!await syncPrebuiltEngine(targetHash, platform, outputRoot)) {
+      exit(1);
     }
-  } on EngineUpdateException catch (e) {
-    print(e.message);
-    exit(1);
+  } else {
+    // Currently the only configuration that is supported is a directory
+    // called 'engine' next to the 'flutter' directory (see
+    // https://github.com/flutter/flutter/wiki/The-flutter-tool#using-a-locally-built-engine-with-the-flutter-tool
+    // for context), so look there for the build output.
+    final buildOutputDirectory = path.join(path.dirname(flutterRoot), 'engine',
+        'src', 'out', engineOverrideBuildType);
+    if (!await copyLocalEngine(buildOutputDirectory, platform, outputRoot)) {
+      exit(1);
+    }
   }
 }
 
@@ -117,6 +136,68 @@ Future<void> main(List<String> arguments) async {
 void printUsage(ArgParser argParser) {
   print('Usage: update_flutter_engine [options] <output directory>\n');
   print(argParser.usage);
+}
+
+/// Checks [outputRoot] for an already-downloaded engine with the given
+/// [engineHash], and if it's either not present or not up-to-date, attempts
+/// to download the prebuilt engine for [platform] with that hash.
+///
+/// Returns true if the engine was successfully downloaded, or was already
+/// present with the correct hash.
+Future<bool> syncPrebuiltEngine(
+  String engineHash,
+  String platform,
+  String outputRoot,
+) async {
+  try {
+    final libraryFile = platformInfo[platform].libraryFiles[0];
+
+    final currentHash = await lastDownloadedEngineHash(outputRoot, platform);
+    if (currentHash == null || engineHash != currentHash) {
+      await downloadEngine(engineHash, platform, outputRoot);
+      await setLastDownloadedEngineHash(outputRoot, engineHash);
+      print('Downloaded $libraryFile version $engineHash.');
+    } else {
+      print('$libraryFile version $engineHash already present.');
+    }
+  } on EngineUpdateException catch (e) {
+    print(e.message);
+    return false;
+  }
+  return true;
+}
+
+/// Copies the locally built engine for [platform], as well as any supporting
+/// files that would be present in the prebuilt version, from
+/// [buildOutputDirectory] to [targetDirectory].
+///
+/// Returns true if successful, or false if any necessary files were missing or
+/// couldn't be copied.
+Future<bool> copyLocalEngine(String buildOutputDirectory, String platform,
+    String targetDirectory) async {
+  await new Directory(targetDirectory).create(recursive: true);
+
+  // On macOS, delete the existing framework if any before copying in the new
+  // one, since it's a directory. On the other platforms, where files are just
+  // individual files, this isn't necessary since copying over existing files
+  // will do the right thing.
+  if (platform == 'macos') {
+    await copyMacOSEngineFramework(
+        path.join(buildOutputDirectory, platformInfo[platform].libraryFiles[0]),
+        targetDirectory);
+  } else {
+    for (final filename in platformInfo[platform].libraryFiles) {
+      final sourceFile = File(path.join(buildOutputDirectory, filename));
+      await sourceFile.copy(path.join(targetDirectory, filename));
+    }
+  }
+
+  // Update the hash file to indicate that it's a local build, so that it's
+  // obvious where it came from.
+  await setLastDownloadedEngineHash(
+      targetDirectory, 'local engine: $buildOutputDirectory');
+
+  return true;
 }
 
 /// Returns the engine version hash for the Flutter tree at [flutterRoot],
@@ -138,7 +219,7 @@ File lastDownloadedHashEngineFile(String directory) {
 Future<String> lastDownloadedEngineHash(
     String downloadDirectory, String platform) async {
   final engineFilePath =
-      path.join(downloadDirectory, platformInfo[platform].libraryFile);
+      path.join(downloadDirectory, platformInfo[platform].libraryFiles[0]);
   final engineExists = (FileSystemEntity.typeSync(engineFilePath)) !=
       FileSystemEntityType.notFound;
   if (!engineExists) {
@@ -234,13 +315,9 @@ Future<void> unzipMacOSEngineFramework(
   final temporaryArchiveFile =
       new File(path.join(outputDirectory, 'engine_archive.zip'));
   final targetPath =
-      path.join(outputDirectory, platformInfo['macos'].libraryFile);
+      path.join(outputDirectory, platformInfo['macos'].libraryFiles[0]);
 
-  // Delete the framework if it is already present.
-  final frameworkFile = new Directory(targetPath);
-  if (frameworkFile.existsSync()) {
-    await frameworkFile.delete(recursive: true);
-  }
+  await deleteFrameworkIfPresent(targetPath);
 
   // Temporarily write the data to a file, since unzip doesn't accept piped
   // input, then delete the file.
@@ -252,5 +329,42 @@ Future<void> unzipMacOSEngineFramework(
     throw new EngineUpdateException(
         'Failed to unzip archive (exit ${result.exitCode}:\n'
         '${result.stdout}\n---\n${result.stderr}');
+  }
+}
+
+/// Copies the framework at [frameworkPath] to [targetDirectory]
+/// by invoking 'cp -R'.
+///
+/// The shelling out is done to avoid complications with preserving special
+/// files (e.g., symbolic links) in the framework structure.
+///
+/// Removes any previous version of the framework that already exists in the
+/// target directory.
+Future<void> copyMacOSEngineFramework(
+    String frameworkPath, String targetDirectory) async {
+  await deleteFrameworkIfPresent(
+      path.join(targetDirectory, path.basename(frameworkPath)));
+
+  final result =
+      await Process.run('cp', ['-R', frameworkPath, targetDirectory]);
+  if (result.exitCode != 0) {
+    throw new EngineUpdateException(
+        'Failed to copy framework (exit ${result.exitCode}:\n'
+        '${result.stdout}\n---\n${result.stderr}');
+  }
+}
+
+/// Recursively deletes the framework at [frameworkPath], if it exists.
+Future<void> deleteFrameworkIfPresent(String frameworkPath) async {
+  // Ensure that the path is a framework, to minimize the potential for
+  // catastrophic deletion bugs with bad arguments.
+  if (path.extension(frameworkPath) != '.framework') {
+    throw new EngineUpdateException(
+        'Attempted to delete a non-framework directory: $frameworkPath');
+  }
+
+  final directory = new Directory(frameworkPath);
+  if (directory.existsSync()) {
+    await directory.delete(recursive: true);
   }
 }

--- a/tools/dart_tools/bin/update_flutter_engine.dart
+++ b/tools/dart_tools/bin/update_flutter_engine.dart
@@ -22,6 +22,8 @@ import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
 import 'package:archive/archive.dart';
 
+import '../lib/flutter_utils.dart';
+
 /// The filename stored next to a downloaded engine library to indicate its
 /// version.
 const String lastDownloadedVersionFile = '.last_engine_version';
@@ -68,7 +70,7 @@ Future<void> main(List<String> arguments) async {
         help: 'The root of the Flutter tree to get the engine version from.\n'
             'Ignored if --hash is provided.\n'
             'Defaults to a "flutter" directory next to this repository.',
-        defaultsTo: path.join(path.dirname(getRepositoryParent()), 'flutter'))
+        defaultsTo: getDefaultFlutterRoot())
     ..addOption(
       'hash',
       help: 'The hash of the engine version to use.\n'
@@ -115,14 +117,6 @@ Future<void> main(List<String> arguments) async {
 void printUsage(ArgParser argParser) {
   print('Usage: update_flutter_engine [options] <output directory>\n');
   print(argParser.usage);
-}
-
-/// Returns the path to the parent directory of this project's repository.
-///
-/// Relies on the known location of this script within the repo.
-String getRepositoryParent() {
-  final scriptUri = Platform.script;
-  return new File.fromUri(scriptUri).parent.parent.parent.parent.path;
 }
 
 /// Returns the engine version hash for the Flutter tree at [flutterRoot],

--- a/tools/dart_tools/bin/update_flutter_engine.dart
+++ b/tools/dart_tools/bin/update_flutter_engine.dart
@@ -192,6 +192,8 @@ Future<bool> copyLocalEngine(String buildOutputDirectory, String platform,
     }
   }
 
+  print('Copied local engine from $buildOutputDirectory.');
+
   // Update the hash file to indicate that it's a local build, so that it's
   // obvious where it came from.
   await setLastDownloadedEngineHash(

--- a/tools/dart_tools/lib/flutter_utils.dart
+++ b/tools/dart_tools/lib/flutter_utils.dart
@@ -1,0 +1,49 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Utilities related to the Flutter tree and/or engine that are used by
+// multiple tools.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+/// Returns the path to the root of this repository.
+///
+/// Relies on the known location of dart_tools/bin within the repo, and the fact
+/// that all the tools are direct children of that directory.
+String getRepositoryRoot() {
+  final scriptUri = Platform.script;
+  return new File.fromUri(scriptUri).parent.parent.parent.parent.path;
+}
+
+/// Returns the path that should be assumed for the location of the Flutter
+/// tree if an explicit path is not provided.
+///
+/// This corresponds to the location suggested in the project documentation
+/// (currently, as a sibling of this repository).
+String getDefaultFlutterRoot() {
+  return path.join(path.dirname(getRepositoryRoot()), 'flutter');
+}
+
+/// If there is an engine override file, returns the engine build type given in
+/// the file, otherwise returns null.
+Future<String> getEngineOverrideBuildType() async {
+  final overrideFile =
+      File(path.join(path.dirname(getRepositoryRoot()), 'engine_override'));
+  if (!overrideFile.existsSync()) {
+    return null;
+  }
+  return (await overrideFile.readAsString()).trim();
+}

--- a/tools/dart_tools/lib/flutter_utils.dart
+++ b/tools/dart_tools/lib/flutter_utils.dart
@@ -40,8 +40,7 @@ String getDefaultFlutterRoot() {
 /// If there is an engine override file, returns the engine build type given in
 /// the file, otherwise returns null.
 Future<String> getEngineOverrideBuildType() async {
-  final overrideFile =
-      File(path.join(path.dirname(getRepositoryRoot()), 'engine_override'));
+  final overrideFile = File(path.join(getRepositoryRoot(), 'engine_override'));
   if (!overrideFile.existsSync()) {
     return null;
   }

--- a/tools/dart_tools/lib/run_command.dart
+++ b/tools/dart_tools/lib/run_command.dart
@@ -17,17 +17,19 @@ import 'dart:io';
 /// Runs a [command] on the command line with some logging and error handling
 ///
 /// Takes a [command] and [arguments] to pass to the [command] that will be run
-/// on the command line. Stdout and stderr will be printed and an exception
-/// thrown if the exit code is not 0 and [allowFail] is true. An optional
+/// on the command line. Stdout and stderr will be printed. An exception
+/// thrown if the exit code is not 0 and [allowFail] is false. An optional
 /// [workingDirectory] can be passed for the directory of the [command] to be
-/// executed in.
+/// executed in, and [runInShell] can be passed to run the command via a shell.
 Future<int> runCommand(String command, List<String> arguments,
-    {String workingDirectory, bool allowFail = false}) async {
+    {String workingDirectory,
+    bool allowFail = false,
+    bool runInShell = false}) async {
   final fullCommand = '$command ${arguments.join(" ")}';
   print('Running $fullCommand');
 
   final process = await Process.start(command, arguments,
-      workingDirectory: workingDirectory, runInShell: true);
+      workingDirectory: workingDirectory, runInShell: runInShell);
   await stdout.addStream(process.stdout);
   await stderr.addStream(process.stderr);
 


### PR DESCRIPTION
update_flutter_engine and build_flutter_assets now check for an
engine_override file at the root of the repository to trigger the
use of a local engine. Updates the README to link to instructions
on using it.

Since this adds more logic to build_flutter_assets, it has been
rewritten in Dart.

There are some obvious limitations (e.g., hard-coded name/location
requirement, copying every time instead of only when the
local build has changed), which can be addressed in the future if
there's sufficient demand. Since it is only intended for temporary use
when debugging, or testing engine changes, this may be sufficient,
and is a significant improvement over managing it manually.

Unlike .flutter_location_config this has no leading ., and is in the
repository rather than above it. This difference is intentional,
since unlike .flutter_location_config this is for temporary use,
so having it show up in directory listings and git status is
helpful as a reminder that it is enabled.

Fixes #160