### PR TITLE
Update the source for fetch_jsoncpp

### DIFF
--- a/library/GN.md
+++ b/library/GN.md
@@ -32,7 +32,7 @@ e.g.:
 Windows requires jsoncpp to be downloaded to
 `library/windows/third_party/jsoncpp`. Use
 `tools/dart_tools/bin/fetch_jsoncpp.dart` to automatically download `jsoncpp`
-with Visual Studio 2017 support as shown below:
+as shown below:
 
 ```
 > tools\run_dart_tool.bat fetch_jsoncpp library\windows\third_party\jsoncpp

--- a/tools/dart_tools/bin/fetch_jsoncpp.dart
+++ b/tools/dart_tools/bin/fetch_jsoncpp.dart
@@ -12,25 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This script downloads a specific version of jsoncpp with Visual Studio 2017
-// support into a provided directory.
+// This script downloads a specific version of jsoncpp into a provided
+// directory.
 
 import 'dart:io';
 
 import '../lib/run_command.dart';
 
-// For the fork containing V2017 support. Once
-// https://github.com/open-source-parsers/jsoncpp/pull/853
-// has landed, this should use the jsoncpp repository.
-const String gitRepo = 'https://github.com/clarkezone/jsoncpp.git';
-const String pinnedVersion = '3ae7e8073a425c93329c8577a3c813c206322ca4';
+const String gitRepo = 'https://github.com/open-source-parsers/jsoncpp.git';
+const String pinnedVersion = '21a418563406acb42484eff33da0a354a671effc';
 
 Future<void> main(List<String> arguments) async {
-  if (!Platform.isWindows) {
-    throw new Exception('Fetching jsoncpp libraries is only available on '
-        'windows.');
-  }
-
   if (arguments.length != 1) {
     throw new Exception('One argument should be passed, the directory to '
         'download jsoncpp to.');
@@ -38,7 +30,8 @@ Future<void> main(List<String> arguments) async {
 
   final downloadDirectory = arguments[0];
 
-  if (Directory(downloadDirectory).existsSync()) {
+  final checkoutExisted = Directory(downloadDirectory).existsSync();
+  if (checkoutExisted) {
     print('$downloadDirectory already exists; skipping clone');
   } else {
     await runCommand('git', [
@@ -48,11 +41,62 @@ Future<void> main(List<String> arguments) async {
     ]);
   }
 
-  await runCommand(
+  final checkoutExitCode =
+      await pinVersion(downloadDirectory, allowFail: checkoutExisted);
+
+  if (checkoutExitCode != 0 && checkoutExisted) {
+    // The tree may be from before the switch to the actual jsoncpp repo.
+    // If that's the case, fix it and try again.
+    // TODO: Remove this sometime after 2019-03-15. By that point most
+    // existing checkouts will likely have been updated.
+    final originChanged = await fixOriginIfNecessary(downloadDirectory);
+    if (originChanged) {
+      print('Updated jsoncpp to point to main repository. Re-syncing...');
+      // Pull from the new origin, then re-pin.
+      await runCommand(
+          'git',
+          [
+            'fetch',
+          ],
+          workingDirectory: downloadDirectory);
+      await pinVersion(downloadDirectory);
+    }
+  }
+}
+
+/// Checks out pinnedVersion in the existing checkout in [repositoryRoot].
+Future<int> pinVersion(String repositoryRoot, {bool allowFail = false}) async {
+  return await runCommand(
       'git',
       [
         'checkout',
         pinnedVersion,
       ],
-      workingDirectory: downloadDirectory);
+      workingDirectory: repositoryRoot,
+      allowFail: allowFail);
+}
+
+/// If 'origin' in [repositoryRoot] points to the previous remote, switch it
+/// to the actual jsoncpp repository.
+///
+/// Returns true if the origin was incorrect and has been successfully changed.
+Future<bool> fixOriginIfNecessary(String checkoutDirectory,
+    {bool allowFail = false}) async {
+  // If origin's URL doesn't match the regex, set-url will print an error and
+  // fail, so run it silently to avoid confusing log messages if this is run
+  // when it's not needed (which is a no-op).
+  final exitCode = await runCommand(
+      'git',
+      [
+        'remote',
+        'set-url',
+        'origin',
+        gitRepo,
+        '.*clarkezone.*',
+      ],
+      workingDirectory: checkoutDirectory,
+      allowFail: true,
+      suppressOutput: true);
+
+  return exitCode == 0;
 }

--- a/tools/dart_tools/lib/run_command.dart
+++ b/tools/dart_tools/lib/run_command.dart
@@ -17,21 +17,30 @@ import 'dart:io';
 /// Runs a [command] on the command line with some logging and error handling
 ///
 /// Takes a [command] and [arguments] to pass to the [command] that will be run
-/// on the command line. Stdout and stderr will be printed. An exception
-/// thrown if the exit code is not 0 and [allowFail] is false. An optional
-/// [workingDirectory] can be passed for the directory of the [command] to be
-/// executed in, and [runInShell] can be passed to run the command via a shell.
+/// on the command line.
+///
+/// Stdout and stderr will be printed, unless [suppressOutput] is true.
+/// An exception thrown if the exit code is not 0 and [allowFail] is false.
+///
+/// An optional [workingDirectory] can be passed for the directory that
+/// [command] should be executed in, and [runInShell] can be passed to run the
+/// command via a shell.
 Future<int> runCommand(String command, List<String> arguments,
     {String workingDirectory,
     bool allowFail = false,
-    bool runInShell = false}) async {
+    bool runInShell = false,
+    bool suppressOutput = false}) async {
   final fullCommand = '$command ${arguments.join(" ")}';
-  print('Running $fullCommand');
+  if (!suppressOutput) {
+    print('Running $fullCommand');
+  }
 
   final process = await Process.start(command, arguments,
       workingDirectory: workingDirectory, runInShell: runInShell);
-  await stdout.addStream(process.stdout);
-  await stderr.addStream(process.stderr);
+  if (!suppressOutput) {
+    await stdout.addStream(process.stdout);
+    await stderr.addStream(process.stderr);
+  }
 
   final exitCode = await process.exitCode;
   if (!allowFail && exitCode != 0) {


### PR DESCRIPTION
Changes fetch_jsoncpp to use the main jsoncpp repository instead of the
clarkezone fork, now that the necessary VS support has landed in the
main repo.

Fixes current Windows build errors due to the previously-pinned commit
no longer existing due to a force-push in the forked repository.

Adds temporary logic to fetch_jsoncpp to try to fix up existing
checkouts. (Also removes the assertions that fetch_jsoncpp is being run
on Windows since it's not Windows-specific, and it's easier to maintain
if it can be run on any platform.)