### PR TITLE
Simplify the API for launching Flutter

### DIFF
--- a/example/linux/flutter_embedder_example.cc
+++ b/example/linux/flutter_embedder_example.cc
@@ -68,14 +68,11 @@ int main(int argc, char **argv) {
 
   // Arguments for the Flutter Engine.
   std::vector<std::string> arguments;
-  // First argument is argv[0] since the engine is expecting real command line
-  // args.
-  arguments.push_back(argv[0]);
 #ifdef NDEBUG
   arguments.push_back("--disable-dart-asserts");
 #endif
   // Start the engine.
-  auto window = flutter_desktop_embedding::CreateFlutterWindowInSnapshotMode(
+  auto window = flutter_desktop_embedding::CreateFlutterWindow(
       640, 480, assets_path, icu_data_path, arguments);
   if (window == nullptr) {
     flutter_desktop_embedding::FlutterTerminate();

--- a/example/macos/ExampleWindow.swift
+++ b/example/macos/ExampleWindow.swift
@@ -26,15 +26,12 @@ class ExampleWindow: NSWindow {
       with: flutterViewController.registrar(forPlugin: "FLEMenubarPlugin"))
 
     let assets = NSURL.fileURL(withPath: "flutter_assets", relativeTo: Bundle.main.resourceURL)
-    // Pass through argument zero, since the Flutter engine expects to be processing a full
-    // command line string.
-    var arguments = [CommandLine.arguments[0]];
+    var arguments: [String] = [];
 #if !DEBUG
     arguments.append("--disable-dart-asserts");
 #endif
     flutterViewController.launchEngine(
       withAssetsPath: assets,
-      asHeadless: false,
       commandLineArguments: arguments)
 
     super.awakeFromNib()

--- a/example/windows/flutter_embedder_example.cpp
+++ b/example/windows/flutter_embedder_example.cpp
@@ -23,15 +23,12 @@ int main(int argc, char **argv) {
   }
   // Arguments for the Flutter Engine.
   std::vector<std::string> arguments;
-  // First argument is argv[0] since the engine is expecting real command line
-  // args.
-  arguments.push_back(argv[0]);
 #ifndef _DEBUG
   arguments.push_back("--disable-dart-asserts");
 #endif
   // Start the engine.
   // TODO: Make paths relative to the executable so it can be run from anywhere.
-  auto window = flutter_desktop_embedding::CreateFlutterWindowInSnapshotMode(
+  auto window = flutter_desktop_embedding::CreateFlutterWindow(
       640, 480, "..\\..\\example\\flutter_app\\build\\flutter_assets",
       "..\\..\\library\\windows\\dependencies\\engine\\icudtl.dat", arguments);
   if (window == nullptr) {

--- a/library/common/glfw/embedder.cc
+++ b/library/common/glfw/embedder.cc
@@ -250,7 +250,7 @@ static FlutterEngine RunFlutterEngine(
     const std::string &icu_data_path,
     const std::vector<std::string> &arguments) {
   // FlutterProjectArgs is expecting a full argv, so when processing it for
-  // flags the first item treated as the executable and ignored. Add a dummy
+  // flags the first item is treated as the executable and ignored. Add a dummy
   // value so that all provided arguments are used.
   std::vector<const char *> argv = {"placeholder"};
   std::transform(

--- a/library/common/glfw/embedder.cc
+++ b/library/common/glfw/embedder.cc
@@ -246,11 +246,13 @@ static void *GLFWProcResolver(void *user_data, const char *name) {
 //
 // Returns a caller-owned pointer to the engine.
 static FlutterEngine RunFlutterEngine(
-    GLFWwindow *window, const std::string &main_path,
-    const std::string &assets_path, const std::string &packages_path,
+    GLFWwindow *window, const std::string &assets_path,
     const std::string &icu_data_path,
     const std::vector<std::string> &arguments) {
-  std::vector<const char *> argv;
+  // FlutterProjectArgs is expecting a full argv, so when processing it for
+  // flags the first item treated as the executable and ignored. Add a dummy
+  // value so that all provided arguments are used.
+  std::vector<const char *> argv = {"placeholder"};
   std::transform(
       arguments.begin(), arguments.end(), std::back_inserter(argv),
       [](const std::string &arg) -> const char * { return arg.c_str(); });
@@ -266,8 +268,6 @@ static FlutterEngine RunFlutterEngine(
   FlutterProjectArgs args = {};
   args.struct_size = sizeof(FlutterProjectArgs);
   args.assets_path = assets_path.c_str();
-  args.main_path = main_path.c_str();
-  args.packages_path = packages_path.c_str();
   args.icu_data_path = icu_data_path.c_str();
   args.command_line_argc = argv.size();
   args.command_line_argv = &argv[0];
@@ -298,18 +298,8 @@ PluginRegistrar *GetRegistrarForPlugin(GLFWwindow *flutter_window,
   return state->plugin_handler.get();
 }
 
-GLFWwindow *CreateFlutterWindowInSnapshotMode(
-    size_t initial_width, size_t initial_height, const std::string &assets_path,
-    const std::string &icu_data_path,
-    const std::vector<std::string> &arguments) {
-  return CreateFlutterWindow(initial_width, initial_height, "", assets_path, "",
-                             icu_data_path, arguments);
-}
-
 GLFWwindow *CreateFlutterWindow(size_t initial_width, size_t initial_height,
-                                const std::string &main_path,
                                 const std::string &assets_path,
-                                const std::string &packages_path,
                                 const std::string &icu_data_path,
                                 const std::vector<std::string> &arguments) {
 #ifdef __linux__
@@ -321,8 +311,7 @@ GLFWwindow *CreateFlutterWindow(size_t initial_width, size_t initial_height,
     return nullptr;
   }
   GLFWClearCanvas(window);
-  auto engine = RunFlutterEngine(window, main_path, assets_path, packages_path,
-                                 icu_data_path, arguments);
+  auto engine = RunFlutterEngine(window, assets_path, icu_data_path, arguments);
   if (engine == nullptr) {
     glfwDestroyWindow(window);
     return nullptr;

--- a/library/include/flutter_desktop_embedding/glfw/embedder.h
+++ b/library/include/flutter_desktop_embedding/glfw/embedder.h
@@ -50,32 +50,17 @@ FDE_EXPORT void FlutterTerminate();
 //
 // FlutterInit() must be called prior to this function.
 //
-// The arguments are to configure the paths when launching the engine. See:
-// https://github.com/flutter/engine/wiki/Custom-Flutter-Engine-Embedders for
-// more details on Flutter Engine embedding.
+// The |assets_path| is the path to the flutter_assets folder for the Flutter
+// application to be run. |icu_data_path| is the path to the icudtl.dat file
+// for the version of Flutter you are using.
+//
+// The |arguments| are passed to the Flutter engine. See:
+// https://github.com/flutter/engine/blob/master/shell/common/switches.h for
+// for details. Not all arguments will apply to embedding mode.
 //
 // Returns a null pointer in the event of an error. The caller owns the pointer
 // when it is non-null.
 FDE_EXPORT GLFWwindow *CreateFlutterWindow(
-    size_t initial_width, size_t initial_height, const std::string &main_path,
-    const std::string &assets_path, const std::string &packages_path,
-    const std::string &icu_data_path,
-    const std::vector<std::string> &arguments);
-
-// Creates a GLFW Window running a Flutter Application in snapshot mode.
-//
-// FlutterInit() must be called prior to this function.
-//
-// In snapshot mode the assets directory snapshot is used to run the application
-// instead of the sources.
-//
-// The arguments are to configure the paths when launching the engine. See:
-// https://github.com/flutter/engine/wiki/Custom-Flutter-Engine-Embedders for
-// more details on Flutter Engine embedding.
-//
-// Returns a null pointer in the event of an error. The caller owns the pointer
-// when it is non-null.
-FDE_EXPORT GLFWwindow *CreateFlutterWindowInSnapshotMode(
     size_t initial_width, size_t initial_height, const std::string &assets_path,
     const std::string &icu_data_path,
     const std::vector<std::string> &arguments);

--- a/library/macos/FLEViewController.h
+++ b/library/macos/FLEViewController.h
@@ -38,34 +38,27 @@
 @property(nullable) NSView<FLEOpenGLContextHandling> *view;
 
 /**
- * Launches the Flutter engine in snapshot mode with the provided configuration. The path argument
- * is used to identify the Flutter application the engine should be configured with. See
- * https://github.com/flutter/engine/wiki/Custom-Flutter-Engine-Embedders for more information
- * on embedding, including the meaning of various possible arguments.
+ * Launches the Flutter engine with the provided configuration.
  *
- * In snapshot mode, the snapshot in the assets directory will be used instead of the original
- * dart sources.
+ * @param assets The path to the flutter_assets folder for the Flutter application to be run.
+ * @param arguments Arguments to pass to the Flutter engine. See
+ *               https://github.com/flutter/engine/blob/master/shell/common/switches.h
+ *               for details. Not all arguments will apply to embedding mode.
+ *               Note: This API layer will likely abstract arguments in the future, instead of
+ *               providing a direct passthrough.
+ * @return YES if the engine launched successfully.
  */
 - (BOOL)launchEngineWithAssetsPath:(nonnull NSURL *)assets
-                        asHeadless:(BOOL)headless
-              commandLineArguments:(nonnull NSArray<NSString *> *)arguments;
+              commandLineArguments:(nullable NSArray<NSString *> *)arguments;
 
 /**
- * Launches the Flutter engine in source mode with the provided configuration. The path arguments
- * are used to identify the Flutter application the engine should be configured with. See
- * https://github.com/flutter/engine/wiki/Custom-Flutter-Engine-Embedders for more information
- * on embedding, including the meaning of various possible arguments.
+ * Launches the Flutter engine in headless mode with the provided configuration. In headless mode,
+ * this controller's view should not be displayed.
  *
- * In source mode, the Dart source and its dependencies will be read directly from their locations
- * on disk.
- * TODO: Evaluate whether this mode needs to be present in the long term, and if so reconsider this
- * API structure.
+ * See launcheEngineWithAssetsPath:commandLineArguments: for details.
  */
-- (BOOL)launchEngineWithMainPath:(nonnull NSURL *)main
-                      assetsPath:(nonnull NSURL *)assets
-                    packagesPath:(nonnull NSURL *)packages
-                      asHeadless:(BOOL)headless
-            commandLineArguments:(nonnull NSArray<NSString *> *)arguments;
+- (BOOL)launchHeadlessEngineWithAssetsPath:(nonnull NSURL *)assets
+                      commandLineArguments:(nullable NSArray<NSString *> *)arguments;
 
 /**
  * Returns the FLEPluginRegistrar that should be used to register the plugin with the given name.

--- a/library/macos/FLEViewController.m
+++ b/library/macos/FLEViewController.m
@@ -264,7 +264,7 @@ static void CommonInit(FLEViewController *controller) {
   [self addInternalPlugins];
 
   // FlutterProjectArgs is expecting a full argv, so when processing it for flags the first
-  // item treated as the executable and ignored. Add a dummy value so that all provided arguments
+  // item is treated as the executable and ignored. Add a dummy value so that all provided arguments
   // are used.
   const unsigned long argc = arguments.count + 1;
   const char **argv = (const char **)malloc(argc * sizeof(const char *));


### PR DESCRIPTION
- Eliminate the distinction between source mode and snapshot mode;
  source mode hasn't worked since the switch to Dart2, and the relevant
  engine arguments are deprecated in
  https://github.com/flutter/engine/pull/7497
- Hide the need for the first argument to be the executable from clients
  of the library; this is an implementation detail of the engine API,
  and not something that each client application should need to handle
  given that the expected use case is to provide a constructed argument
  array, rather than pass through argc/argv directly.
  (As part of this change, removes the macOS code to strip Xcode-added
  arguments, for the same reason.)

This is a breaking change; clients will need to update the call to the
primary entry point, including removing the dummy first argument they
were likely providing in the arguments array.