### PR TITLE
add support for shift, option (alt), control and command (meta) modifier keys

### DIFF
--- a/library/macos/FLEViewController.m
+++ b/library/macos/FLEViewController.m
@@ -34,10 +34,10 @@ static NSString *const kICUBundlePath = @"icudtl.dat";
 static const int kDefaultWindowFramebuffer = 0;
 
 // Android KeyEvent constants from https://developer.android.com/reference/android/view/KeyEvent
-static const int kAndroidMetaStateShift = 1;
-static const int kAndroidMetaStateAlt = 2;
-static const int kAndroidMetaStateCtrl = 4096;
-static const int kAndroidMetaStateMeta = 65536;
+static const int kAndroidMetaStateShift = 1 << 0;
+static const int kAndroidMetaStateAlt = 1 << 1;
+static const int kAndroidMetaStateCtrl = 1 << 12;
+static const int kAndroidMetaStateMeta = 1 << 16;
 
 #pragma mark - Private interface declaration.
 

--- a/library/macos/FLEViewController.m
+++ b/library/macos/FLEViewController.m
@@ -33,6 +33,12 @@ static NSString *const kICUBundlePath = @"icudtl.dat";
 
 static const int kDefaultWindowFramebuffer = 0;
 
+// Android KeyEvent constants from https://developer.android.com/reference/android/view/KeyEvent
+static const int kAndroidMetaStateShift = 1;
+static const int kAndroidMetaStateAlt = 2;
+static const int kAndroidMetaStateCtrl = 4096;
+static const int kAndroidMetaStateMeta = 65536;
+
 #pragma mark - Private interface declaration.
 
 /**
@@ -376,6 +382,12 @@ static void CommonInit(FLEViewController *controller) {
     @"keymap" : @"android",
     @"type" : type,
     @"keyCode" : @(event.keyCode),
+    @"metaState" : @(
+      ((event.modifierFlags & NSEventModifierFlagShift) ? kAndroidMetaStateShift : 0) |
+      ((event.modifierFlags & NSEventModifierFlagOption) ? kAndroidMetaStateAlt : 0) |
+      ((event.modifierFlags & NSEventModifierFlagControl) ? kAndroidMetaStateCtrl : 0) |
+      ((event.modifierFlags & NSEventModifierFlagCommand) ? kAndroidMetaStateMeta : 0)
+    )
   }];
 }
 


### PR DESCRIPTION
Passes through the `NSEventModifierFlag` values for shift, option, control and command as Android `metaState` flags.