### PR TITLE
Add error logging to GLFW and Flutter setup

### DIFF
--- a/example/linux_fde/flutter_embedder_example.cc
+++ b/example/linux_fde/flutter_embedder_example.cc
@@ -54,7 +54,8 @@ std::string GetExecutableDirectory() {
 
 int main(int argc, char **argv) {
   if (!flutter_desktop_embedding::FlutterInit()) {
-    std::cerr << "Couldn't init GLFW" << std::endl;
+    std::cerr << "Unable to init GLFW; exiting." << std::endl;
+    return EXIT_FAILURE;
   }
 
   // Resources are located relative to the executable.
@@ -76,6 +77,7 @@ int main(int argc, char **argv) {
       640, 480, assets_path, icu_data_path, arguments);
   if (window == nullptr) {
     flutter_desktop_embedding::FlutterTerminate();
+    std::cerr << "Unable to create Flutter window; exiting." << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/example/windows_fde/flutter_embedder_example.cpp
+++ b/example/windows_fde/flutter_embedder_example.cpp
@@ -19,7 +19,8 @@
 
 int main(int argc, char **argv) {
   if (!flutter_desktop_embedding::FlutterInit()) {
-    std::cout << "Couldn't init GLFW" << std::endl;
+    std::cerr << "Unable to init GLFW; exiting." << std::endl;
+    return EXIT_FAILURE;
   }
   // Arguments for the Flutter Engine.
   std::vector<std::string> arguments;
@@ -33,6 +34,7 @@ int main(int argc, char **argv) {
       "..\\..\\library\\windows\\dependencies\\engine\\icudtl.dat", arguments);
   if (window == nullptr) {
     flutter_desktop_embedding::FlutterTerminate();
+    std::cerr << "Unable to create Flutter window; exiting." << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/library/common/glfw/embedder.cc
+++ b/library/common/glfw/embedder.cc
@@ -239,6 +239,10 @@ static void *GLFWProcResolver(void *user_data, const char *name) {
   return reinterpret_cast<void *>(glfwGetProcAddress(name));
 }
 
+static void GLFWErrorCallback(int error_code, const char *description) {
+  std::cerr << "GLFW error " << error_code << ": " << description << std::endl;
+}
+
 // Spins up an instance of the Flutter Engine.
 //
 // This function launches the Flutter Engine in a background thread, supplying
@@ -276,6 +280,8 @@ static FlutterEngine RunFlutterEngine(
   auto result =
       FlutterEngineRun(FLUTTER_ENGINE_VERSION, &config, &args, window, &engine);
   if (result != kSuccess || engine == nullptr) {
+    std::cerr << "Failed to start Flutter engine: error " << result
+              << std::endl;
     return nullptr;
   }
   return engine;
@@ -283,10 +289,12 @@ static FlutterEngine RunFlutterEngine(
 
 namespace flutter_desktop_embedding {
 
-// Initialize glfw
-bool FlutterInit() { return glfwInit(); }
+bool FlutterInit() {
+  // Before making any GLFW calls, set up a logging error handler.
+  glfwSetErrorCallback(GLFWErrorCallback);
+  return glfwInit();
+}
 
-// Tear down glfw
 void FlutterTerminate() { glfwTerminate(); }
 
 PluginRegistrar *GetRegistrarForPlugin(GLFWwindow *flutter_window,

--- a/library/macos/FLEViewController.m
+++ b/library/macos/FLEViewController.m
@@ -297,10 +297,14 @@ static void CommonInit(FLEViewController *controller) {
   flutterArguments.command_line_argv = argv;
   flutterArguments.platform_message_callback = (FlutterPlatformMessageCallback)OnPlatformMessage;
 
-  BOOL result = FlutterEngineRun(FLUTTER_ENGINE_VERSION, &config, &flutterArguments,
-                                 (__bridge void *)(self), &_engine) == kSuccess;
+  FlutterResult result = FlutterEngineRun(FLUTTER_ENGINE_VERSION, &config, &flutterArguments,
+                                 (__bridge void *)(self), &_engine);
   free(argv);
-  return result;
+  if (result != kSuccess) {
+    NSLog(@"Failed to start Flutter engine: error %d", result);
+    return NO;
+  }
+  return YES;
 }
 
 + (FlutterRendererConfig)createRenderConfigHeadless:(BOOL)headless {


### PR DESCRIPTION
Add error logging when starting the Flutter engine fails (on all
platforms), and on GLFW errors. Also exit early with error logging for
unrecoverable errors in the GLFW implementation.

Fixes #241.