### PR TITLE
Add Flutter tree min version check

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,10 @@ image: Visual Studio 2017
 platform: x64
 
 install:
-  - ps: build\ci\install_flutter.ps1 $env:APPVEYOR_BUILD_FOLDER\..
+  # None of the packaged channels are new enough for the current state
+  # of FDE, so for now clone master instead.
+  #- ps: build\ci\install_flutter.ps1 $env:APPVEYOR_BUILD_FOLDER\..
+  - git clone -b master https://github.com/flutter/flutter.git %APPVEYOR_BUILD_FOLDER%\..\flutter
 
 build_script:
   - msbuild "example\windows_fde\Example Embedder.sln"

--- a/build/ci/install_flutter
+++ b/build/ci/install_flutter
@@ -16,8 +16,8 @@
 
 set -e
 
-readonly CHANNEL="stable"
-readonly VERSION="1.0.0"
+readonly CHANNEL="dev"
+readonly VERSION="1.1.8"
 
 if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
   readonly FLUTTER_OS="linux"

--- a/tools/dart_tools/lib/flutter_utils.dart
+++ b/tools/dart_tools/lib/flutter_utils.dart
@@ -19,6 +19,14 @@ import 'dart:io';
 
 import 'package:path/path.dart' as path;
 
+/// The last Flutter hash that's known to be required; a branch that doesn't
+/// contain this commit will either fail to build, or fail to run.
+///
+/// This should be updated whenever a new dependency is introduced (e.g., a
+/// required embedder API addition or implementation fix).
+const String lastKnownRequiredFlutterCommit =
+    '390ded9340e529b8475fefd1afdbe59c5b8d4081';
+
 /// Returns the path to the root of this repository.
 ///
 /// Relies on the known location of dart_tools/bin within the repo, and the fact

--- a/tools/dart_tools/lib/git_utils.dart
+++ b/tools/dart_tools/lib/git_utils.dart
@@ -1,0 +1,33 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Wrappers for git commands used by the tools.
+
+import 'run_command.dart';
+
+/// Returns true if the current
+Future<bool> gitHeadContainsCommit(
+    String repositoryRoot, String commitHash) async {
+  final exitCode = await runCommand(
+      'git',
+      [
+        'merge-base',
+        '--is-ancestor',
+        commitHash,
+        'HEAD',
+      ],
+      workingDirectory: repositoryRoot,
+      allowFail: true);
+  return exitCode == 0;
+}


### PR DESCRIPTION
To minimize confusion, and reduce unnecessary issue reports, add a check
during builds that the Flutter tree being used is not older than the
last known point where there was a compatibility break. Instead of a
runtime error, or an unexplained build error, this will fail out during
the engine update step with a clear message to use a newer version of
Flutter.

Currently, this will ensure that people who aren't on Flutter master
will get an error message that's as clear as possible.