### PR TITLE
[linux/windows] Cap the minimum pixel ratio to 1

### DIFF
--- a/library/common/glfw/embedder.cc
+++ b/library/common/glfw/embedder.cc
@@ -98,7 +98,9 @@ static void GLFWFramebufferSizeCallback(GLFWwindow *window, int width_px,
 
   double dpi = state->window_pixels_per_screen_coordinate *
                state->monitor_screen_coordinates_per_inch;
-  double pixel_ratio = std::max(dpi/ kDpPerInch, 1.0);
+  // Limit the ratio to 1 to avoid rendering a smaller UI in standard resolution
+  // monitors.
+  double pixel_ratio = std::max(dpi / kDpPerInch, 1.0);
 
   FlutterWindowMetricsEvent event = {};
   event.struct_size = sizeof(event);

--- a/library/common/glfw/embedder.cc
+++ b/library/common/glfw/embedder.cc
@@ -98,12 +98,13 @@ static void GLFWFramebufferSizeCallback(GLFWwindow *window, int width_px,
 
   double dpi = state->window_pixels_per_screen_coordinate *
                state->monitor_screen_coordinates_per_inch;
+  double pixel_ratio = std::max(dpi/ kDpPerInch, 1.0);
 
   FlutterWindowMetricsEvent event = {};
   event.struct_size = sizeof(event);
   event.width = width_px;
   event.height = height_px;
-  event.pixel_ratio = dpi / kDpPerInch;
+  event.pixel_ratio = pixel_ratio;
   FlutterEngineSendWindowMetricsEvent(state->engine, &event);
 }
 


### PR DESCRIPTION
Avoids generating a UI that is too small in standard resolution monitors. #222 