### PR TITLE
[macos] Adjust for embedding API type name change

### DIFF
--- a/library/macos/FLEViewController.mm
+++ b/library/macos/FLEViewController.mm
@@ -297,7 +297,8 @@ static void CommonInit(FLEViewController *controller) {
   flutterArguments.command_line_argv = argv;
   flutterArguments.platform_message_callback = (FlutterPlatformMessageCallback)OnPlatformMessage;
 
-  FlutterResult result = FlutterEngineRun(FLUTTER_ENGINE_VERSION, &config, &flutterArguments,
+  // TODO: Replace auto with FlutterEngineResult after next required Flutter update.
+  auto result = FlutterEngineRun(FLUTTER_ENGINE_VERSION, &config, &flutterArguments,
                                  (__bridge void *)(self), &_engine);
   free(argv);
   if (result != kSuccess) {
@@ -350,7 +351,8 @@ static void CommonInit(FLEViewController *controller) {
 
   FLEBinaryReply binaryResponseHandler = ^(NSData *response) {
     if (responseHandle) {
-      FlutterEngineSendPlatformMessageResponse(self->_engine, responseHandle, response.bytes,
+      FlutterEngineSendPlatformMessageResponse(self->_engine, responseHandle,
+                                               static_cast<const uint8_t *>(response.bytes),
                                                response.length);
       responseHandle = NULL;
     } else {
@@ -376,7 +378,7 @@ static void CommonInit(FLEViewController *controller) {
       .phase = phase,
       .x = locationInBackingCoordinates.x,
       .y = -locationInBackingCoordinates.y,  // convertPointToBacking makes this negative.
-      .timestamp = event.timestamp * NSEC_PER_MSEC,
+      .timestamp = static_cast<const size_t>(event.timestamp * NSEC_PER_MSEC),
   };
   FlutterEngineSendPointerEvent(_engine, &flutterEvent, 1);
 }
@@ -386,12 +388,11 @@ static void CommonInit(FLEViewController *controller) {
     @"keymap" : @"android",
     @"type" : type,
     @"keyCode" : @(event.keyCode),
-    @"metaState" : @(
-      ((event.modifierFlags & NSEventModifierFlagShift) ? kAndroidMetaStateShift : 0) |
-      ((event.modifierFlags & NSEventModifierFlagOption) ? kAndroidMetaStateAlt : 0) |
-      ((event.modifierFlags & NSEventModifierFlagControl) ? kAndroidMetaStateCtrl : 0) |
-      ((event.modifierFlags & NSEventModifierFlagCommand) ? kAndroidMetaStateMeta : 0)
-    )
+    @"metaState" :
+        @(((event.modifierFlags & NSEventModifierFlagShift) ? kAndroidMetaStateShift : 0) |
+          ((event.modifierFlags & NSEventModifierFlagOption) ? kAndroidMetaStateAlt : 0) |
+          ((event.modifierFlags & NSEventModifierFlagControl) ? kAndroidMetaStateCtrl : 0) |
+          ((event.modifierFlags & NSEventModifierFlagCommand) ? kAndroidMetaStateMeta : 0))
   }];
 }
 
@@ -404,8 +405,8 @@ static void CommonInit(FLEViewController *controller) {
   CGRect scaledBounds = [view convertRectToBacking:view.bounds];
   const FlutterWindowMetricsEvent event = {
       .struct_size = sizeof(event),
-      .width = scaledBounds.size.width,
-      .height = scaledBounds.size.height,
+      .width = static_cast<const size_t>(scaledBounds.size.width),
+      .height = static_cast<const size_t>(scaledBounds.size.height),
       .pixel_ratio = scaledBounds.size.width / view.bounds.size.width,
   };
   FlutterEngineSendWindowMetricsEvent(_engine, &event);
@@ -417,11 +418,12 @@ static void CommonInit(FLEViewController *controller) {
   FlutterPlatformMessage platformMessage = {
       .struct_size = sizeof(FlutterPlatformMessage),
       .channel = [channel UTF8String],
-      .message = message.bytes,
+      .message = static_cast<const uint8_t *>(message.bytes),
       .message_size = message.length,
   };
 
-  FlutterResult result = FlutterEngineSendPlatformMessage(_engine, &platformMessage);
+  // TODO: Replace auto with FlutterEngineResult after next required Flutter update.
+  auto result = FlutterEngineSendPlatformMessage(_engine, &platformMessage);
   if (result != kSuccess) {
     NSLog(@"Failed to send message to Flutter engine on channel '%@' (%d).", channel, result);
   }

--- a/library/macos/FlutterEmbedderMac.xcodeproj/project.pbxproj
+++ b/library/macos/FlutterEmbedderMac.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		1E24923C1FCF50BE00DD3BBB /* FLEReshapeListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E2492321FCF50BE00DD3BBB /* FLEReshapeListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1E24923E1FCF50BE00DD3BBB /* FLETextInputPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E2492341FCF50BE00DD3BBB /* FLETextInputPlugin.m */; };
 		1E24923F1FCF50BE00DD3BBB /* FLEViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E2492351FCF50BE00DD3BBB /* FLEViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1E2492401FCF50BE00DD3BBB /* FLEViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E2492361FCF50BE00DD3BBB /* FLEViewController.m */; };
+		1E2492401FCF50BE00DD3BBB /* FLEViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1E2492361FCF50BE00DD3BBB /* FLEViewController.mm */; };
 		1E2492411FCF50BE00DD3BBB /* FlutterEmbedderMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E2492371FCF50BE00DD3BBB /* FlutterEmbedderMac.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1EEF8E071FD1F0C300DD563C /* FLEView.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EEF8E051FD1F0C300DD563C /* FLEView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1EEF8E081FD1F0C300DD563C /* FLEView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EEF8E061FD1F0C300DD563C /* FLEView.m */; };
@@ -87,7 +87,7 @@
 		1E2492331FCF50BE00DD3BBB /* FLETextInputPlugin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLETextInputPlugin.h; sourceTree = "<group>"; };
 		1E2492341FCF50BE00DD3BBB /* FLETextInputPlugin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLETextInputPlugin.m; sourceTree = "<group>"; };
 		1E2492351FCF50BE00DD3BBB /* FLEViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEViewController.h; sourceTree = "<group>"; };
-		1E2492361FCF50BE00DD3BBB /* FLEViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEViewController.m; sourceTree = "<group>"; };
+		1E2492361FCF50BE00DD3BBB /* FLEViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FLEViewController.mm; sourceTree = "<group>"; };
 		1E2492371FCF50BE00DD3BBB /* FlutterEmbedderMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlutterEmbedderMac.h; sourceTree = "<group>"; };
 		1E2492381FCF50BE00DD3BBB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		1EEF8E051FD1F0C300DD563C /* FLEView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEView.h; sourceTree = "<group>"; };
@@ -148,7 +148,7 @@
 				1E2492341FCF50BE00DD3BBB /* FLETextInputPlugin.m */,
 				1EEF8E061FD1F0C300DD563C /* FLEView.m */,
 				6442F82C20EA6C5F00A393AE /* FLEViewController+Internal.h */,
-				1E2492361FCF50BE00DD3BBB /* FLEViewController.m */,
+				1E2492361FCF50BE00DD3BBB /* FLEViewController.mm */,
 				1E2492381FCF50BE00DD3BBB /* Info.plist */,
 				33B1650E201A5F7400732DC9 /* Dependencies */,
 				1E2492251FCF504200DD3BBB /* Products */,
@@ -316,7 +316,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				33D7B59A20A4F54400296EFC /* FLEMethodChannel.m in Sources */,
-				1E2492401FCF50BE00DD3BBB /* FLEViewController.m in Sources */,
+				1E2492401FCF50BE00DD3BBB /* FLEViewController.mm in Sources */,
 				3389A68D215949CB00A27898 /* FLEMethodError.m in Sources */,
 				33C0FA2721B84AA4008F8959 /* FLEMethodCall.m in Sources */,
 				33C0FA2021B84810008F8959 /* FLEJSONMessageCodec.m in Sources */,


### PR DESCRIPTION
https://github.com/flutter/engine/pull/7567 renamed the type of the
result for embedding API calls. Rather than force a Flutter upgrade by
using the new type name, temporarily use 'auto' for the type (with a
TODO to change it later, since auto is arguably less readable here).

This requires converting the file to ObjC++, which required a few
explicit casts in places that were previously being silently recast.