### PR TITLE
[linux/windows] Separate out a C channel API

### DIFF
--- a/library/BUILD.gn
+++ b/library/BUILD.gn
@@ -38,6 +38,8 @@ published_shared_library("flutter_embedder") {
   if (is_linux || is_win) {
     sources += [
       "common/engine_method_result.cc",
+      "common/internal/incoming_message_dispatcher.cc",
+      "common/internal/incoming_message_dispatcher.h",
       "common/internal/plugin_handler.cc",
       "common/internal/plugin_handler.h",
       "common/internal/text_input_model.cc",

--- a/library/common/glfw/flutter_window_controller.cc
+++ b/library/common/glfw/flutter_window_controller.cc
@@ -16,6 +16,8 @@
 
 #include <iostream>
 
+#include "library/common/internal/plugin_handler.h"
+
 namespace flutter_desktop_embedding {
 
 FlutterWindowController::FlutterWindowController(std::string &icu_data_path)
@@ -56,8 +58,14 @@ PluginRegistrar *FlutterWindowController::GetRegistrarForPlugin(
   if (!window_) {
     return nullptr;
   }
-  return flutter_desktop_embedding::GetRegistrarForPlugin(window_, plugin_name);
-}
+  if (!plugin_handler_) {
+    plugin_handler_ = std::make_unique<PluginHandler>(window_);
+  }
+  // Currently, PluginHandler acts as the registrar for all plugins, so the
+  // name is ignored. It is part of the API to reduce churn in the future when
+  // aligning more closely with the Flutter registrar system.
+  return plugin_handler_.get();
+}  // namespace flutter_desktop_embedding
 
 void FlutterWindowController::RunEventLoop() {
   if (window_) {

--- a/library/common/internal/incoming_message_dispatcher.cc
+++ b/library/common/internal/incoming_message_dispatcher.cc
@@ -1,0 +1,64 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "library/common/internal/incoming_message_dispatcher.h"
+
+namespace flutter_desktop_embedding {
+
+IncomingMessageDispatcher::IncomingMessageDispatcher(FlutterWindowRef window)
+    : window_(window) {}
+
+IncomingMessageDispatcher::~IncomingMessageDispatcher() {}
+
+void IncomingMessageDispatcher::HandleMessage(
+    const FlutterEmbedderMessage &message,
+    std::function<void(void)> input_block_cb,
+    std::function<void(void)> input_unblock_cb) {
+  std::string channel(message.channel);
+
+  // Find the handler for the channel; if there isn't one, report the failure.
+  if (callbacks_.find(channel) == callbacks_.end()) {
+    FlutterEmbedderSendMessageResponse(window_, message.response_handle,
+                                       nullptr, 0);
+    return;
+  }
+  auto &callback_info = callbacks_[channel];
+  FlutterEmbedderMessageCallback message_callback = callback_info.first;
+
+  // Process the call, handling input blocking if requested.
+  bool block_input = input_blocking_channels_.count(channel) > 0;
+  if (block_input) {
+    input_block_cb();
+  }
+  message_callback(window_, &message, callback_info.second);
+  if (block_input) {
+    input_unblock_cb();
+  }
+}
+
+void IncomingMessageDispatcher::SetMessageCallback(
+    const std::string &channel, FlutterEmbedderMessageCallback callback,
+    void *user_data) {
+  if (!callback) {
+    callbacks_.erase(channel);
+    return;
+  }
+  callbacks_[channel] = std::make_pair(callback, user_data);
+}
+
+void IncomingMessageDispatcher::EnableInputBlockingForChannel(
+    const std::string &channel) {
+  input_blocking_channels_.insert(channel);
+}
+
+}  // namespace flutter_desktop_embedding

--- a/library/common/internal/incoming_message_dispatcher.h
+++ b/library/common/internal/incoming_message_dispatcher.h
@@ -1,0 +1,86 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LIBRARY_COMMON_INTERNAL_INCOMING_MESSAGE_DISPATCHER_H_
+#define LIBRARY_COMMON_INTERNAL_INCOMING_MESSAGE_DISPATCHER_H_
+
+#include <functional>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+
+#include "library/include/flutter_desktop_embedding/glfw/embedder.h"
+
+namespace flutter_desktop_embedding {
+
+// Manages per-channel registration of callbacks for handling messages from the
+// Flutter engine, and dispatching incoming messages to those handlers.
+class IncomingMessageDispatcher {
+ public:
+  // Creates a new IncomingMessageDispatcher. |window| must remain valid as long
+  // as this object exists.
+  explicit IncomingMessageDispatcher(FlutterWindowRef window);
+  virtual ~IncomingMessageDispatcher();
+
+  // Prevent copying.
+  IncomingMessageDispatcher(IncomingMessageDispatcher const &) = delete;
+  IncomingMessageDispatcher &operator=(IncomingMessageDispatcher const &) =
+      delete;
+
+  // Routes |message| to to the registered handler for its channel, if any.
+  //
+  // If input blocking has been enabled on that channel, wraps the call to the
+  // handler with calls to the given callbacks to block and then unblock input.
+  //
+  // If no handler is registered for the message's channel, sends a
+  // NotImplemented response to the engine.
+  void HandleMessage(const FlutterEmbedderMessage &message,
+                     std::function<void(void)> input_block_cb = [] {},
+                     std::function<void(void)> input_unblock_cb = [] {});
+
+  // Registers a message callback for incoming messages from the Flutter
+  // side on the specified channel. |callback| will be called with the message
+  // and |user_data| any time a message arrives on that channel.
+  //
+  // Replaces any existing callback. Pass a null callback to unregister the
+  // existing callback.
+  void SetMessageCallback(const std::string &channel,
+                          FlutterEmbedderMessageCallback callback,
+                          void *user_data);
+
+  // Enables input blocking on the given channel name.
+  //
+  // If set, then the parent window should disable input callbacks
+  // while waiting for the handler for messages on that channel to run.
+  void EnableInputBlockingForChannel(const std::string &channel);
+
+ private:
+  // Handle for interacting with the embedding API.
+  // TODO: Provide an interface for the specific functionality needed.
+  FlutterWindowRef window_;
+
+  // A map from channel names to the FlutterEmbedderMessageCallback that should
+  // be called for incoming messages on that channel, along with the void* user
+  // data to pass to it.
+  std::map<std::string, std::pair<FlutterEmbedderMessageCallback, void *>>
+      callbacks_;
+
+  // Channel names for which input blocking should be enabled during the call to
+  // that channel's handler.
+  std::set<std::string> input_blocking_channels_;
+};
+
+}  // namespace flutter_desktop_embedding
+
+#endif  // LIBRARY_COMMON_INTERNAL_INCOMING_MESSAGE_DISPATCHER_H_

--- a/library/include/flutter_desktop_embedding/glfw/embedder.h
+++ b/library/include/flutter_desktop_embedding/glfw/embedder.h
@@ -21,14 +21,16 @@
 
 #ifdef USE_FLATTENED_INCLUDES
 #include "fde_export.h"
-#include "plugin_registrar.h"
 #else
 #include "../fde_export.h"
-#include "../plugin_registrar.h"
 #endif
 
 // Opaque reference to a Flutter window.
 typedef struct FlutterEmbedderState *FlutterWindowRef;
+
+// Opaque handle for tracking responses to messages.
+typedef struct _FlutterPlatformMessageResponseHandle
+    FlutterEmbedderMessageResponseHandle;
 
 namespace flutter_desktop_embedding {
 
@@ -64,19 +66,71 @@ FDE_EXPORT FlutterWindowRef CreateFlutterWindow(
     const std::string &icu_data_path,
     const std::vector<std::string> &arguments);
 
-// Returns the PluginRegistrar to register a plugin with the given name with
-// the flutter_window.
-//
-// The name must be unique across the application, so the recommended approach
-// is to use the fully namespace-qualified name of the plugin class.
-FDE_EXPORT PluginRegistrar *GetRegistrarForPlugin(
-    FlutterWindowRef flutter_window, const std::string &plugin_name);
-
 // Loops on Flutter window events until the window is closed.
 //
 // Once this function returns, FlutterWindowRef is no longer valid, and must
 // not be used again.
 FDE_EXPORT void FlutterWindowLoop(FlutterWindowRef flutter_window);
+
+// A received from Flutter.
+typedef struct {
+  // Size of this struct as created by Flutter.
+  size_t struct_size;
+  // The name of the channel used for this message.
+  const char *channel;
+  // The raw message data.
+  const uint8_t *message;
+  // The length of |message|.
+  size_t message_size;
+  // The response handle. If non-null, the receiver of this message must call
+  // FlutterEmbedderSendMessageResponse exactly once with this handle.
+  const FlutterEmbedderMessageResponseHandle *response_handle;
+} FlutterEmbedderMessage;
+
+// Function pointer type for message handler callback registration.
+//
+// The user data will whatever was passed to FlutterEmbedderSetMessageHandler
+// for the channel the message is received on.
+typedef void (*FlutterEmbedderMessageCallback)(
+    FlutterWindowRef flutter_window /*window*/,
+    const FlutterEmbedderMessage * /* message*/, void * /* user data */);
+
+// Sends a binary message to the Flutter side on the specified channel.
+FDE_EXPORT void FlutterEmbedderSendMessage(FlutterWindowRef flutter_window,
+                                           const char *channel,
+                                           const uint8_t *message,
+                                           const size_t message_size);
+
+// Sends a reply to a FlutterEmbedderMessage for the given response handle.
+//
+// Once this has been called, |handle| is invalid and must not be used again.
+FDE_EXPORT void FlutterEmbedderSendMessageResponse(
+    FlutterWindowRef flutter_window,
+    const FlutterEmbedderMessageResponseHandle *handle, const uint8_t *data,
+    size_t data_length);
+
+// Registers a callback function for incoming binary messages from the Flutter
+// side on the specified channel.
+//
+// Replaces any existing callback. Provide a null handler to unregister the
+// existing callback.
+//
+// If |user_data| is provided, it will be passed in |callback| calls.
+FDE_EXPORT void FlutterEmbedderSetMessageCallback(
+    FlutterWindowRef flutter_window, const char *channel,
+    FlutterEmbedderMessageCallback callback, void *user_data);
+
+// Enables input blocking on the given channel.
+//
+// If set, then the Flutter window will disable input callbacks
+// while waiting for the handler for messages on that channel to run. This is
+// useful if handling the message involves showing a modal window, for instance.
+//
+// This must be called after FlutterEmbedderSetMessageHandler, as setting a
+// handler on a channel will reset the input blocking state back to the default
+// of disabled.
+FDE_EXPORT void FlutterEmbedderEnableInputBlocking(
+    FlutterWindowRef flutter_window, const char *channel);
 
 }  // namespace flutter_desktop_embedding
 

--- a/library/include/flutter_desktop_embedding/glfw/flutter_window_controller.h
+++ b/library/include/flutter_desktop_embedding/glfw/flutter_window_controller.h
@@ -30,6 +30,8 @@
 
 namespace flutter_desktop_embedding {
 
+class PluginHandler;
+
 // A controller for a window displaying Flutter content.
 //
 // This is the primary wrapper class for the desktop embedding C API.
@@ -82,6 +84,9 @@ class FDE_EXPORT FlutterWindowController {
 
   // The curent Flutter window, if any.
   FlutterWindowRef window_ = nullptr;
+
+  // Plugin manager, to support GetRegistraryForPlugin.
+  std::unique_ptr<PluginHandler> plugin_handler_;
 };
 
 }  // namespace flutter_desktop_embedding

--- a/library/windows/GLFW Library.vcxproj
+++ b/library/windows/GLFW Library.vcxproj
@@ -151,6 +151,7 @@
     <ClCompile Include="..\common\glfw\flutter_window_controller.cc" />
     <ClCompile Include="..\common\glfw\key_event_handler.cc" />
     <ClCompile Include="..\common\glfw\text_input_plugin.cc" />
+    <ClCompile Include="..\common\internal\incoming_message_dispatcher.cc" />
     <ClCompile Include="..\common\internal\plugin_handler.cc" />
     <ClCompile Include="..\common\internal\text_input_model.cc" />
     <ClCompile Include="..\common\json_message_codec.cc" />

--- a/library/windows/GLFW Library.vcxproj.filters
+++ b/library/windows/GLFW Library.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClCompile Include="..\common\glfw\flutter_window_controller.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\common\internal\incoming_message_dispatcher.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\flutter_desktop_embedding\windows\embedder.h">


### PR DESCRIPTION
Eliminates PluginRegistrar and BinaryMessenger from the embedder.h API
surface, moving them up to the FlutterWindowController level. In their
place, adds new low-level messaging APIs, which are based closely on
the Flutter engine embedder APIs (including an equivalent message
struct), in some cases wrapping them directly. Unlike the engine APIs,
they allow per-channel callbacks, so individual plugins can use the API.

Since PluginHandler is no longer the source of truth for callback
registration, only an adaptor, it's now fine to have multiple instances
of them, all passing through to the underlying C API.

Part of #230