### PR TITLE
Move Windows PATH instructions

### DIFF
--- a/library/GN.md
+++ b/library/GN.md
@@ -12,21 +12,6 @@ In addition to the normal dependencies, you will need to install:
 
 Ensure that both binaries are in your path.
 
-### Path setup
-
-Windows also requires the 64 bit compiler, linker and setup scripts to be in
-your path. They are found under:
-
-```
-> Visual Studio Install Path\2017\Version\VC\Auxiliary\Build
-```
-
-e.g.:
-
-```
-> C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
-```
-
 ### jsoncpp
 
 jsoncpp must be manually downloaded to

--- a/library/README.md
+++ b/library/README.md
@@ -107,7 +107,18 @@ so you do not need to include that framework in your project directly.
 
 #### Dependencies
 
-You must have a copy of Visual Studio installed.
+You must have a copy of Visual Studio installed, and the command line build
+tools, such as `vcvars64.bat`, must be in your path. They are found under:
+
+```
+<Visual Studio Install Path>\2017\<Version>\VC\Auxiliary\Build
+```
+
+e.g.:
+
+```
+C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
+```
 
 #### Using the Library
 


### PR DESCRIPTION
The VS build also requires the VC build tools to be in the path (due to
running jsoncpp's build via script), so move the instructions from the
GN readme to the main readme.