### PR TITLE
Add restat to Windows solink command

### DIFF
--- a/build/win/toolchain/BUILD.gn
+++ b/build/win/toolchain/BUILD.gn
@@ -69,6 +69,9 @@ toolchain("msvc") {
 
     lib_dir_switch = "/LIBPATH:"
 
+    # Avoid unnecessary rebuilds due to .lib not always changing.
+    restat = true
+
     outputs = [
       dllfile,
       libfile,


### PR DESCRIPTION
The link step includes the .lib file as output, but the link tool only
updates that file if something has changed, so it's possible to get into
situations where the .lib file is always older than the inputs, causing
the (expensive) link step to run every time.

This enabled ninja's 'restat' mode for the link step, so that it detects
the files that don't change and ignores them for the purposes of
determining what needs a rebuild.