### PR TITLE
Make the Windows example build self-contained

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -70,10 +70,9 @@ Open the `Example Embedder` Visual Studio solution file under `windows_fde\` to
 build and run the GLFW Example project.
 
 The resulting binary will be in
-`example\build\windows_fde\x64\$(Configuration)\GLFW Example\`. It currently
-uses relative paths so if you run it manually it must be run from the
-`example\windows_fde\` directory. E.g.:
+`example\build\windows_fde\x64\$(Configuration)\GLFW Example\`. It can be run
+manually from there. E.g.:
 
 ```
-> "..\build\windows_fde\x64\Debug\GLFW Example\GLFW Example.exe"
+> .\"example\build\windows_fde\x64\Debug\GLFW Example\GLFW Example.exe"
 ```

--- a/example/windows_fde/GLFW Example.vcxproj
+++ b/example/windows_fde/GLFW Example.vcxproj
@@ -78,11 +78,22 @@
       </Message>
     </PreLinkEvent>
     <PostBuildEvent>
-      <Command>$(ProjectDir)scripts\build_example_app "$(OutputPath)"</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
     <PostBuildEvent>
-      <Message>Construct a runnable example from the various outputs</Message>
+      <Message>
+      </Message>
     </PostBuildEvent>
+    <CustomBuildStep>
+      <Command>$(ProjectDir)scripts\build_example_app "$(OutputPath)"</Command>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Message>Bundling dependencies</Message>
+      <Outputs>Dummy_Run_Always</Outputs>
+      <Inputs>
+      </Inputs>
+    </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -112,11 +123,22 @@
       </Message>
     </PreLinkEvent>
     <PostBuildEvent>
-      <Command>$(ProjectDir)scripts\build_example_app "$(OutputPath)"</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
     <PostBuildEvent>
-      <Message>Construct a runnable example from the various outputs</Message>
+      <Message>
+      </Message>
     </PostBuildEvent>
+    <CustomBuildStep>
+      <Command>$(ProjectDir)scripts\build_example_app "$(OutputPath)"</Command>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Message>Bundling dependencies</Message>
+      <Outputs>Dummy_Run_Always</Outputs>
+      <Inputs>
+      </Inputs>
+    </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\out\fde_cpp_wrapper\engine_method_result.cc" />

--- a/example/windows_fde/flutter_embedder_example.cpp
+++ b/example/windows_fde/flutter_embedder_example.cpp
@@ -18,10 +18,43 @@
 
 #include "flutter_desktop_embedding/flutter_window_controller.h"
 
+// Include windows.h last, to minimize potential conflicts. The CreateWindow
+// macro needs to be undefined because it prevents calling
+// FlutterWindowController's method.
+#include <windows.h>
+#undef CreateWindow
+
+namespace {
+
+// Returns the path of the directory containing this executable, or an empty
+// string if the directory cannot be found.
+std::string GetExecutableDirectory() {
+  char buffer[MAX_PATH];
+  if (GetModuleFileName(nullptr, buffer, MAX_PATH) == 0) {
+    std::cerr << "Couldn't locate executable" << std::endl;
+    return "";
+  }
+  std::string executable_path(buffer);
+  size_t last_separator_position = executable_path.find_last_of('\\');
+  if (last_separator_position == std::string::npos) {
+    std::cerr << "Unabled to find parent directory of " << executable_path
+              << std::endl;
+    return "";
+  }
+  return executable_path.substr(0, last_separator_position);
+}
+
+}  // namespace
+
 int main(int argc, char **argv) {
-  // TODO: Make paths relative to the executable so it can be run from anywhere.
-  std::string assets_path = "..\\build\\flutter_assets";
-  std::string icu_data_path = "..\\build\\windows_fde\\icudtl.dat";
+  // Resources are located relative to the executable.
+  std::string base_directory = GetExecutableDirectory();
+  if (base_directory.empty()) {
+    base_directory = ".";
+  }
+  std::string data_directory = base_directory + "\\data";
+  std::string assets_path = data_directory + "\\flutter_assets";
+  std::string icu_data_path = data_directory + "\\icudtl.dat";
 
   // Arguments for the Flutter Engine.
   std::vector<std::string> arguments;


### PR DESCRIPTION
Copies the necessary Flutter data to a known location relative to the
executable, and uses executable-relative paths rather than
working-directory-relative paths.

This allows the executable to be run from any location, and makes it
clear what must be bundled as part of a working example. Follows the
same basic structure as the Linux example's bundling.