### PR TITLE
Add error handling to run_dart_tool.bat

### DIFF
--- a/tools/run_dart_tool.bat
+++ b/tools/run_dart_tool.bat
@@ -17,8 +17,15 @@ for /f "delims=" %%i in ('%~dp0flutter_location') do set FLUTTER_DIR=%%i
 set FLUTTER_BIN_DIR=%FLUTTER_DIR%\bin
 set DART_BIN_DIR=%FLUTTER_BIN_DIR%\cache\dart-sdk\bin
 
+if not exist %FLUTTER_DIR%\ (
+  echo No Flutter directory at %FLUTTER_DIR%.
+  echo Please see the setup instructions in the README.
+  exit /b
+)
+
 :: Ensure that the Dart SDK has been downloaded.
 if not exist %DART_BIN_DIR%\ call %FLUTTER_BIN_DIR%\flutter precache
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 set DART_TOOL=%1
 for /f "tokens=1,*" %%a in ("%*") do set TOOL_PARAMS=%%b


### PR DESCRIPTION
The error message from Windows when trying to run an executable that
doesn't exist isn't very helpful, so explicitly check that the Flutter
directory is actually there before trying to run flutter.