### PR TITLE
Unify the GLFW event loop code

### DIFF
--- a/library/common/glfw/embedder.cc
+++ b/library/common/glfw/embedder.cc
@@ -532,13 +532,11 @@ void FlutterEmbedderRunWindowLoop(FlutterWindowRef flutter_window) {
   XInitThreads();
 #endif
   while (!glfwWindowShouldClose(window)) {
-#ifdef __linux__
     glfwPollEvents();
+#ifdef __linux__
     if (gtk_events_pending()) {
       gtk_main_iteration();
     }
-#else
-    glfwWaitEvents();
 #endif
     // TODO(awdavies): This will be deprecated soon.
     __FlutterEngineFlushPendingTasksNow();


### PR DESCRIPTION
The use of glfwWaitEvents() on Windows was incorrect, since there are
event sources such as plugin messages that GLFW is unaware of.

This will cause Windows to have the same high CPU usage as Linux, but
resolving that is a longer-term issue.