### PR TITLE
Move macOS plugin registration to a separate file

### DIFF
--- a/example/macos/ExampleWindow.swift
+++ b/example/macos/ExampleWindow.swift
@@ -18,12 +18,7 @@ class ExampleWindow: NSWindow {
   @IBOutlet weak var flutterViewController: FLEViewController!
 
   override func awakeFromNib() {
-    FLEColorPanelPlugin.register(
-      with: flutterViewController.registrar(forPlugin: "FLEColorPanelPlugin"))
-    FLEFileChooserPlugin.register(
-      with: flutterViewController.registrar(forPlugin: "FLEFileChooserPlugin"))
-    FLEMenubarPlugin.register(
-      with: flutterViewController.registrar(forPlugin: "FLEMenubarPlugin"))
+    PluginRegistrant.register(with: flutterViewController)
 
     let assets = NSURL.fileURL(withPath: "flutter_assets", relativeTo: Bundle.main.resourceURL)
     var arguments: [String] = [];

--- a/example/macos/PluginRegistrant.h
+++ b/example/macos/PluginRegistrant.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,4 +13,7 @@
 // limitations under the License.
 
 #import <FlutterMacOS/FlutterMacOS.h>
-#import "PluginRegistrant.h"
+
+@interface PluginRegistrant : NSObject
++ (void)registerWithRegistry:(NSObject<FLEPluginRegistry>*)registry;
+@end

--- a/example/macos/PluginRegistrant.m
+++ b/example/macos/PluginRegistrant.m
@@ -1,0 +1,33 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This serves the same purpose as GeneratedPluginRegistrant in an iOS
+// Flutter project. However, since there is no tooling support for plugins
+// yet, adding a new plugin requires manually adding plugin registration.
+
+#import "PluginRegistrant.h"
+
+#import <FlutterEmbedderColorPanel/FlutterEmbedderColorPanel.h>
+#import <FlutterEmbedderFileChooser/FlutterEmbedderFileChooser.h>
+#import <FlutterEmbedderMenubar/FlutterEmbedderMenubar.h>
+
+@implementation PluginRegistrant
+
++ (void)registerWithRegistry:(NSObject<FLEPluginRegistry>*)registry {
+  [FLEColorPanelPlugin registerWithRegistrar:[registry registrarForPlugin:@"FLEColorPanelPlugin"]];
+  [FLEFileChooserPlugin registerWithRegistrar:[registry registrarForPlugin:@"FLEFileChooserPlugin"]];
+  [FLEMenubarPlugin registerWithRegistrar:[registry registrarForPlugin:@"FLEMenubarPlugin"]];
+}
+
+@end

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		3329005320D2EC9E002E5F16 /* FlutterEmbedderFileChooser.framework in Bundle Framework */ = {isa = PBXBuildFile; fileRef = 3329004F20D2EC7C002E5F16 /* FlutterEmbedderFileChooser.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3329009620D84F99002E5F16 /* FlutterEmbedderMenubar.framework in Bundle Framework */ = {isa = PBXBuildFile; fileRef = 3329009320D84F6E002E5F16 /* FlutterEmbedderMenubar.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3329FFFF20C9F5D9002E5F16 /* FlutterEmbedderColorPanel.framework in Bundle Framework */ = {isa = PBXBuildFile; fileRef = 3329FFFB20C9F5AC002E5F16 /* FlutterEmbedderColorPanel.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		33A2DE652267798600914F77 /* PluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 33A2DE642267798600914F77 /* PluginRegistrant.m */; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
@@ -136,6 +137,8 @@
 		3329008D20D84F6E002E5F16 /* FlutterEmbedderMenubar.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FlutterEmbedderMenubar.xcodeproj; path = ../../plugins/menubar/macos/FlutterEmbedderMenubar.xcodeproj; sourceTree = "<group>"; };
 		3329FFF520C9F5AC002E5F16 /* FlutterEmbedderColorPanel.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FlutterEmbedderColorPanel.xcodeproj; path = ../../plugins/color_panel/macos/FlutterEmbedderColorPanel.xcodeproj; sourceTree = "<group>"; };
 		33CC10ED2044A3C60003C045 /* Flutter Desktop Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Flutter Desktop Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33A2DE632267798600914F77 /* PluginRegistrant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PluginRegistrant.h; sourceTree = "<group>"; };
+		33A2DE642267798600914F77 /* PluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PluginRegistrant.m; sourceTree = "<group>"; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -190,6 +193,8 @@
 			children = (
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
 				33CC11122044BFA00003C045 /* ExampleWindow.swift */,
+				33A2DE632267798600914F77 /* PluginRegistrant.h */,
+				33A2DE642267798600914F77 /* PluginRegistrant.m */,
 				33CC11162044C3600003C045 /* Runner-Bridging-Header.h */,
 				33CC11242044D66E0003C045 /* Resources */,
 				33D1A10222148A83006C7A3E /* Frameworks */,
@@ -389,6 +394,7 @@
 			files = (
 				33CC11132044BFA00003C045 /* ExampleWindow.swift in Sources */,
 				33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */,
+				33A2DE652267798600914F77 /* PluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tools/dart_tools/lib/flutter_utils.dart
+++ b/tools/dart_tools/lib/flutter_utils.dart
@@ -25,7 +25,7 @@ import 'package:path/path.dart' as path;
 /// This should be updated whenever a new dependency is introduced (e.g., a
 /// required embedder API addition or implementation fix).
 const String lastKnownRequiredFlutterCommit =
-    '223d68ac8bac1da11b4fdd62fa8981345191376b';
+    '829130ddfcf84aa683291744fb6d170f61f0287b';
 
 /// Returns the path to the root of this repository.
 ///


### PR DESCRIPTION
Matches the structure of the iOS GeneratedPluginRegistrant. Uses ObjC,
rather than Swift, so that changes to add a new plugin are localized to
one file, instead of also affecting the bridging header.

This will make it easier to eventually transition to generated plugin
registration, and in the meantime makes it slightly easier to add
plugins manually.