### PR TITLE
Fix name_output.bat typo

### DIFF
--- a/example/windows/name_output.bat
+++ b/example/windows/name_output.bat
@@ -27,7 +27,7 @@ set EXE_NAME=Flutter Desktop Example
 
 set BASE_DIR=%~dp0
 set FLUTTER_APP_DIR=%BASE_DIR%..\
-set PRODUCTS_DIR=%FLUTTER_APP_DIR%build\windows\x86\
+set PRODUCTS_DIR=%FLUTTER_APP_DIR%build\windows\x64\
 
 if "%FLUTTER_CONFIG%"=="release" (
   set BUILD_CONFIG=Release


### PR DESCRIPTION
The build directory is x64, not x86.