### PR TITLE
Support --track-widget-creation on Linux

### DIFF
--- a/example/linux/Makefile
+++ b/example/linux/Makefile
@@ -35,7 +35,7 @@ FLUTTER_APP_DIR=$(CURDIR)/..
 FLUTTER_APP_BUILD_DIR=$(FLUTTER_APP_DIR)/build
 FLUTTER_EMBEDDER_LIB_DIR=$(FDE_ROOT)/library/linux
 TOOLS_DIR=$(FDE_ROOT)/tools
-FLUTTER_DIR=$(shell $(TOOLS_DIR)/flutter_location)
+FLUTTER_ROOT:=$(shell $(TOOLS_DIR)/flutter_location)
 
 OUT_DIR=$(FLUTTER_APP_BUILD_DIR)/linux
 CACHE_DIR=$(OUT_DIR)/cache
@@ -47,11 +47,11 @@ FLUTTER_LIB=$(FLUTTER_LIBRARY_DIR)/lib$(FLUTTER_LIB_NAME).so
 # Tools
 BUILD_ASSETS_BIN=$(TOOLS_DIR)/build_flutter_assets
 SYNC_FLUTTER_LIBRARY_BIN=$(TOOLS_DIR)/sync_flutter_library
-FLUTTER_BIN=$(FLUTTER_DIR)/bin/flutter
+FLUTTER_BIN=$(FLUTTER_ROOT)/bin/flutter
 
 # Resources
 ICU_DATA_NAME=icudtl.dat
-ICU_DATA_SOURCE=$(FLUTTER_DIR)/bin/cache/artifacts/engine/linux-x64/$(ICU_DATA_NAME)
+ICU_DATA_SOURCE=$(FLUTTER_ROOT)/bin/cache/artifacts/engine/linux-x64/$(ICU_DATA_NAME)
 FLUTTER_ASSETS_NAME=flutter_assets
 FLUTTER_ASSETS_SOURCE=$(FLUTTER_APP_BUILD_DIR)/$(FLUTTER_ASSETS_NAME)
 
@@ -135,7 +135,7 @@ bundleflutterassets: $(FLUTTER_ASSETS_SOURCE)
 # to know if 'build bundle' needs to be re-run.
 .PHONY: $(FLUTTER_ASSETS_SOURCE)
 $(FLUTTER_ASSETS_SOURCE):
-	$(BUILD_ASSETS_BIN) $(FLUTTER_APP_DIR)
+	$(BUILD_ASSETS_BIN) $(FLUTTER_APP_DIR) $(FLUTTER_BUNDLE_FLAGS)
 
 .PHONY: clean
 clean:

--- a/example/linux/build.sh
+++ b/example/linux/build.sh
@@ -22,8 +22,16 @@
 # Arguments
 readonly flutter_root="$1"
 readonly flutter_config="$2"
+readonly widget_tracking="$3"
+
+if [[ $widget_tracking == "track-widget-creation" ]]; then
+  readonly bundle_flags="--track-widget-creation";
+fi
 
 # Directories
 readonly base_dir="$(dirname "$0")"
 
-make -C "$base_dir" BUILD="${flutter_config}"
+make -C "$base_dir" \
+  BUILD="${flutter_config}" \
+  FLUTTER_ROOT="${flutter_root}" \
+  FLUTTER_BUNDLE_FLAGS="${bundle_flags}"

--- a/testbed/linux/Makefile
+++ b/testbed/linux/Makefile
@@ -38,7 +38,7 @@ FLUTTER_APP_BUILD_DIR=$(FLUTTER_APP_DIR)/build
 FLUTTER_EMBEDDER_LIB_DIR=$(FDE_ROOT)/library/linux
 PLUGINS_DIR=$(FDE_ROOT)/plugins
 TOOLS_DIR=$(FDE_ROOT)/tools
-FLUTTER_DIR=$(shell $(TOOLS_DIR)/flutter_location)
+FLUTTER_ROOT:=$(shell $(TOOLS_DIR)/flutter_location)
 GN_OUT_DIR=$(FDE_ROOT)/out
 
 OUT_DIR=$(FLUTTER_APP_BUILD_DIR)/linux
@@ -58,13 +58,13 @@ ALL_LIBS=$(FLUTTER_LIB) $(PLUGIN_LIBS)
 # Tools
 BUILD_ASSETS_BIN=$(TOOLS_DIR)/build_flutter_assets
 SYNC_FLUTTER_LIBRARY_BIN=$(TOOLS_DIR)/sync_flutter_library
-FLUTTER_BIN=$(FLUTTER_DIR)/bin/flutter
+FLUTTER_BIN=$(FLUTTER_ROOT)/bin/flutter
 GN_WRAPPER=$(TOOLS_DIR)/gn_dart
 NINJA_BIN=ninja
 
 # Resources
 ICU_DATA_NAME=icudtl.dat
-ICU_DATA_SOURCE=$(FLUTTER_DIR)/bin/cache/artifacts/engine/linux-x64/$(ICU_DATA_NAME)
+ICU_DATA_SOURCE=$(FLUTTER_ROOT)/bin/cache/artifacts/engine/linux-x64/$(ICU_DATA_NAME)
 FLUTTER_ASSETS_NAME=flutter_assets
 FLUTTER_ASSETS_SOURCE=$(FLUTTER_APP_BUILD_DIR)/$(FLUTTER_ASSETS_NAME)
 
@@ -165,7 +165,7 @@ bundleflutterassets: $(FLUTTER_ASSETS_SOURCE)
 # to know if 'build bundle' needs to be re-run.
 .PHONY: $(FLUTTER_ASSETS_SOURCE)
 $(FLUTTER_ASSETS_SOURCE):
-	$(BUILD_ASSETS_BIN) $(FLUTTER_APP_DIR)
+	$(BUILD_ASSETS_BIN) $(FLUTTER_APP_DIR) $(FLUTTER_BUNDLE_FLAGS)
 
 .PHONY: clean
 clean:

--- a/testbed/linux/build.sh
+++ b/testbed/linux/build.sh
@@ -22,8 +22,16 @@
 # Arguments
 readonly flutter_root="$1"
 readonly flutter_config="$2"
+readonly widget_tracking="$3"
+
+if [[ $widget_tracking == "track-widget-creation" ]]; then
+  readonly bundle_flags="--track-widget-creation";
+fi
 
 # Directories
 readonly base_dir="$(dirname "$0")"
 
-make -C "$base_dir" BUILD="${flutter_config}"
+make -C "$base_dir" \
+  BUILD="${flutter_config}" \
+  FLUTTER_ROOT="${flutter_root}" \
+  FLUTTER_BUNDLE_FLAGS="${bundle_flags}"

--- a/tools/dart_tools/bin/build_flutter_assets.dart
+++ b/tools/dart_tools/bin/build_flutter_assets.dart
@@ -31,6 +31,8 @@ Future<void> main(List<String> arguments) async {
         help: 'The root of the Flutter tree to run \'flutter\' from.\n'
             'Defaults to a "flutter" directory next to this repository.',
         defaultsTo: getDefaultFlutterRoot())
+    ..addFlag('track-widget-creation',
+        help: 'Passed to flutter build.', negatable: false)
     ..addFlag('help', help: 'Prints this usage message.', negatable: false);
   ArgResults parsedArguments;
 
@@ -55,6 +57,10 @@ Future<void> main(List<String> arguments) async {
   }
 
   final buildArguments = ['build', 'bundle'];
+
+  if (parsedArguments['track-widget-creation']) {
+    buildArguments.add('--track-widget-creation');
+  }
 
   // Add --local-engine if an override is specified. --local-engine-src-path
   // isn't provided since per


### PR DESCRIPTION
Plumbs the flag for enabling widget creation tracking from the build
script through to 'flutter build bundle'. Fixes the crash-on-hot-reload
in VS Code for Linux.

Since this was touching the build.sh/Makefile interaction, also plumbs
through FLUTTER_ROOT, although doesn't yet rely on it being there in the
example.