### PR TITLE
Support --track-widget-creation on Windows

### DIFF
--- a/example/windows/.gitignore
+++ b/example/windows/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Local additions, not from the link above
+Generated.props
+
 # User-specific files
 *.suo
 *.user

--- a/example/windows/Runner.vcxproj
+++ b/example/windows/Runner.vcxproj
@@ -37,9 +37,11 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="Generated.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="Generated.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/example/windows/generate_props.dart
+++ b/example/windows/generate_props.dart
@@ -1,0 +1,58 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This script creates a generated .props file containing various user
+// macros needed by the Visual Studio build, adding all of them to the
+// build environment for use in build scripts.
+import 'dart:io';
+
+void main(List<String> arguments) {
+  final outputPath = arguments[0];
+  final settings = {
+    'FLUTTER_ROOT': arguments[1],
+    'EXTRA_BUNDLE_FLAGS': arguments[2],
+  };
+
+  File(outputPath).writeAsStringSync('''<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros">
+${getUserMacrosContent(settings)}
+  </PropertyGroup>
+  <PropertyGroup />
+  <ItemDefinitionGroup />
+  <ItemGroup>
+${getItemGroupContent(settings)}
+  </ItemGroup>
+</Project>''');
+}
+
+String getUserMacrosContent(Map<String, String> settings) {
+  final macroList = StringBuffer();
+  for (final setting in settings.entries) {
+    macroList.writeln('    <${setting.key}>${setting.value}</${setting.key}>');
+  }
+  return macroList.toString();
+}
+
+String getItemGroupContent(Map<String, String> settings) {
+  final macroList = StringBuffer();
+  for (final name in settings.keys) {
+    macroList.writeln('''    <BuildMacro Include="$name">
+      <Value>\$($name)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>''');
+  }
+  return macroList.toString();
+}

--- a/example/windows/scripts/build_example_app.bat
+++ b/example/windows/scripts/build_example_app.bat
@@ -29,7 +29,7 @@ if not exist "%DATA_DIR%" call mkdir "%DATA_DIR%"
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: Build the Flutter assets.
-call %TOOLS_DIR%\build_flutter_assets %FLUTTER_APP_DIR%
+call %TOOLS_DIR%\build_flutter_assets %FLUTTER_APP_DIR% %EXTRA_BUNDLE_FLAGS%
 if %errorlevel% neq 0 exit /b %errorlevel%
 :: Copy them to the data directory.
 if exist "%TARGET_ASSET_DIR%" call rmdir /s /q "%TARGET_ASSET_DIR%"

--- a/testbed/windows/.gitignore
+++ b/testbed/windows/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Local additions, not from the link above
+Generated.props
+
 # User-specific files
 *.suo
 *.user

--- a/testbed/windows/Runner.vcxproj
+++ b/testbed/windows/Runner.vcxproj
@@ -37,9 +37,11 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="Generated.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="Generated.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/testbed/windows/generate_props.dart
+++ b/testbed/windows/generate_props.dart
@@ -1,0 +1,58 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This script creates a generated .props file containing various user
+// macros needed by the Visual Studio build, adding all of them to the
+// build environment for use in build scripts.
+import 'dart:io';
+
+void main(List<String> arguments) {
+  final outputPath = arguments[0];
+  final settings = {
+    'FLUTTER_ROOT': arguments[1],
+    'EXTRA_BUNDLE_FLAGS': arguments[2],
+  };
+
+  File(outputPath).writeAsStringSync('''<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros">
+${getUserMacrosContent(settings)}
+  </PropertyGroup>
+  <PropertyGroup />
+  <ItemDefinitionGroup />
+  <ItemGroup>
+${getItemGroupContent(settings)}
+  </ItemGroup>
+</Project>''');
+}
+
+String getUserMacrosContent(Map<String, String> settings) {
+  final macroList = StringBuffer();
+  for (final setting in settings.entries) {
+    macroList.writeln('    <${setting.key}>${setting.value}</${setting.key}>');
+  }
+  return macroList.toString();
+}
+
+String getItemGroupContent(Map<String, String> settings) {
+  final macroList = StringBuffer();
+  for (final name in settings.keys) {
+    macroList.writeln('''    <BuildMacro Include="$name">
+      <Value>\$($name)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>''');
+  }
+  return macroList.toString();
+}

--- a/testbed/windows/scripts/build_example_app.bat
+++ b/testbed/windows/scripts/build_example_app.bat
@@ -29,7 +29,7 @@ if not exist "%DATA_DIR%" call mkdir "%DATA_DIR%"
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: Build the Flutter assets.
-call %TOOLS_DIR%\build_flutter_assets %FLUTTER_APP_DIR%
+call %TOOLS_DIR%\build_flutter_assets %FLUTTER_APP_DIR% %EXTRA_BUNDLE_FLAGS%
 if %errorlevel% neq 0 exit /b %errorlevel%
 :: Copy them to the data directory.
 if exist "%TARGET_ASSET_DIR%" call rmdir /s /q "%TARGET_ASSET_DIR%"


### PR DESCRIPTION
Plumbs the flag for enabling widget creation tracking from the build
script through to 'flutter build bundle'. Fixes the crash-on-hot-reload
in VS Code for Windows.

Since this added the logic to generate a property file for VS with
settings, also plumbs through FLUTTER_ROOT, although doesn't yet rely on
it being there in the example.