### PR TITLE
Use 'flutter build' for CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,6 +28,8 @@ build_script:
   - set "PATH=%APPVEYOR_BUILD_FOLDER%\bin;%APPVEYOR_BUILD_FOLDER%\..\flutter\bin;C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\;%PATH%"
   - set "ENABLE_FLUTTER_DESKTOP=true"
   - ps: cd %APPVEYOR_BUILD_FOLDER%\example
+  - flutter packages get
   - flutter build -v windows --debug
   - ps: cd %APPVEYOR_BUILD_FOLDER%\testbed
+  - flutter packages get
   - flutter build -v windows --debug

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,9 +27,9 @@ install:
 build_script:
   - set "PATH=%APPVEYOR_BUILD_FOLDER%\bin;%APPVEYOR_BUILD_FOLDER%\..\flutter\bin;C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\;%PATH%"
   - set "ENABLE_FLUTTER_DESKTOP=true"
-  - ps: cd %APPVEYOR_BUILD_FOLDER%\example
+  - ps: cd "$env:APPVEYOR_BUILD_FOLDER\example"
   - flutter packages get
   - flutter build -v windows --debug
-  - ps: cd %APPVEYOR_BUILD_FOLDER%\testbed
+  - ps: cd "$env:APPVEYOR_BUILD_FOLDER\testbed"
   - flutter packages get
   - flutter build -v windows --debug

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,5 +26,8 @@ install:
 
 build_script:
   - set "PATH=%APPVEYOR_BUILD_FOLDER%\bin;C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\;%PATH%"
-  - msbuild "example\windows\Runner.sln"
-  - msbuild "testbed\windows\Runner.sln"
+  - set "ENABLE_FLUTTER_DESKTOP=true"
+  - ps: cd %APPVEYOR_BUILD_FOLDER%\example
+  - %APPVEYOR_BUILD_FOLDER%\..\flutter\bin\flutter build -v windows --debug
+  - ps: cd %APPVEYOR_BUILD_FOLDER%\testbed
+  - %APPVEYOR_BUILD_FOLDER%\..\flutter\bin\flutter build -v windows --debug

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,9 +25,9 @@ install:
   - tools\run_dart_tool.bat fetch_jsoncpp %APPVEYOR_BUILD_FOLDER%\third_party\jsoncpp\src
 
 build_script:
-  - set "PATH=%APPVEYOR_BUILD_FOLDER%\bin;C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\;%PATH%"
+  - set "PATH=%APPVEYOR_BUILD_FOLDER%\bin;%APPVEYOR_BUILD_FOLDER%\..\flutter\bin;C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\;%PATH%"
   - set "ENABLE_FLUTTER_DESKTOP=true"
   - ps: cd %APPVEYOR_BUILD_FOLDER%\example
-  - %APPVEYOR_BUILD_FOLDER%\..\flutter\bin\flutter build -v windows --debug
+  - flutter build -v windows --debug
   - ps: cd %APPVEYOR_BUILD_FOLDER%\testbed
-  - %APPVEYOR_BUILD_FOLDER%\..\flutter\bin\flutter build -v windows --debug
+  - flutter build -v windows --debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,15 @@ matrix:
         - git clone -b master https://github.com/flutter/flutter.git $TRAVIS_BUILD_DIR/../flutter
         - build/ci/linux/install_gn bin
       before_script:
-        - export PATH=$PATH:$TRAVIS_BUILD_DIR/bin
+        - export PATH=$PATH:$TRAVIS_BUILD_DIR/bin:$TRAVIS_BUILD_DIR/../flutter/bin
         - export ENABLE_FLUTTER_DESKTOP=true
       script:
-        - cd $TRAVIS_BUILD_DIR/example && $TRAVIS_BUILD_DIR/../flutter/bin/flutter build -v linux --debug
-        - cd $TRAVIS_BUILD_DIR/testbed && $TRAVIS_BUILD_DIR/../flutter/bin/flutter build -v linux --debug
+        - cd $TRAVIS_BUILD_DIR/example
+        - flutter packages get
+        - flutter build -v linux --debug
+        - cd $TRAVIS_BUILD_DIR/testbed
+        - flutter packages get
+        - flutter build -v linux --debug
 
     - os: osx
       language: objective-c
@@ -43,8 +47,13 @@ matrix:
         #- build/ci/install_flutter $TRAVIS_BUILD_DIR/..
         - git clone -b master https://github.com/flutter/flutter.git $TRAVIS_BUILD_DIR/../flutter
       before_script:
+        - export PATH=$PATH:$TRAVIS_BUILD_DIR/../flutter/bin
         - export ENABLE_FLUTTER_DESKTOP=true
       script:
-        - cd $TRAVIS_BUILD_DIR/example && $TRAVIS_BUILD_DIR/../flutter/bin/flutter build -v macos --debug
-        - cd $TRAVIS_BUILD_DIR/testbed && $TRAVIS_BUILD_DIR/../flutter/bin/flutter build -v macos --debug
+        - cd $TRAVIS_BUILD_DIR/example
+        - flutter packages get
+        - flutter build -v macos --debug
+        - cd $TRAVIS_BUILD_DIR/testbed
+        - flutter packages get
+        - flutter build -v macos --debug
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,10 @@ matrix:
         - build/ci/linux/install_gn bin
       before_script:
         - export PATH=$PATH:$TRAVIS_BUILD_DIR/bin
+        - export ENABLE_FLUTTER_DESKTOP=true
       script:
-        - make -C example/linux
-        - make -C testbed/linux
+        - cd $TRAVIS_BUILD_DIR/example && $TRAVIS_BUILD_DIR/../flutter/bin/flutter build -v linux --debug
+        - cd $TRAVIS_BUILD_DIR/testbed && $TRAVIS_BUILD_DIR/../flutter/bin/flutter build -v linux --debug
 
     - os: osx
       language: objective-c
@@ -41,11 +42,9 @@ matrix:
         # of FDE, so for now clone master instead.
         #- build/ci/install_flutter $TRAVIS_BUILD_DIR/..
         - git clone -b master https://github.com/flutter/flutter.git $TRAVIS_BUILD_DIR/../flutter
-      # Override the build command to remove 'test'. The example embedder
-      # doesn't have any unit tests, and while a UI test to ensure that it
-      # launches would be useful, that's currently broken by:
-      # https://travis-ci.community/t/issue-cant-run-macos-ui-tests-with-xcode10-1-image/1445
+      before_script:
+        - export ENABLE_FLUTTER_DESKTOP=true
       script:
-        - set -o pipefail && xcodebuild -project $TRAVIS_XCODE_PROJECT -scheme $TRAVIS_XCODE_SCHEME build | xcpretty
-        - set -o pipefail && xcodebuild -project testbed/macos/Runner.xcodeproj -scheme $TRAVIS_XCODE_SCHEME build | xcpretty
+        - cd $TRAVIS_BUILD_DIR/example && $TRAVIS_BUILD_DIR/../flutter/bin/flutter build -v macos --debug
+        - cd $TRAVIS_BUILD_DIR/testbed && $TRAVIS_BUILD_DIR/../flutter/bin/flutter build -v macos --debug
 


### PR DESCRIPTION
The builds are now dependent on files generated by the Flutter build
process, so the first build must be done with 'flutter build' rather than
direct build commands. This updates the CI scripts accordingly.