### PR TITLE
Add a min Flutter version to the example

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,13 @@
 name: example_flutter
 description: An example project for flutter-desktop-embedding.
 
+environment:
+  sdk: '>=2.0.0 <3.0.0'
+  # The example interacts with build scripts on the Flutter side that are not
+  # yet stable, so it requires a very recent version of Flutter.
+  # This version will increase regularly as the build scripts change.
+  flutter: '>=1.5.9-pre.56'
+
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
This will help catch some errors caused by version mismatches that would
otherwise cause error messages that aren't at all self-explanatory.
This won't catch all cases, but for those that it does the failure will
be very early, and much clearer.

The intent is to rev this number every time a change is made on the
Flutter side that requires a corresponding change in this repository.