### PR TITLE
Switch Linux testbed to tool_backend.sh

### DIFF
--- a/LocalEngine.md
+++ b/LocalEngine.md
@@ -5,14 +5,14 @@ Flutter engine](https://github.com/flutter/flutter/wiki/Compiling-the-engine).
 
 ## Building
 
-### macOS
+### macOS and Linux
 
-The `flutter run` workflow for macOS supports `--local-engine`, so just follow
+The `flutter run` workflow for macOS and Linux supports `--local-engine`, so just follow
 the normal Flutter workflow for using a local engine build.
 
-### Windows and Linux
+### Windows
 
-Work is in progress to add `--local-engine` support for Windows and Linux.
+Work is in progress to add `--local-engine` support for Windows.
 In the meantime, you can get the same effect by adding a file called
 `engine_override` at the root of your `flutter_desktop_embedding` checkout
 containing the name of your build output directory. For instance on Linux:

--- a/example/linux/Makefile
+++ b/example/linux/Makefile
@@ -31,13 +31,13 @@ BUILD=debug
 include flutter/generated_config
 
 # Dependency locations
+FLUTTER_APP_CACHE_DIR=flutter/
 FLUTTER_APP_DIR=$(CURDIR)/..
 FLUTTER_APP_BUILD_DIR=$(FLUTTER_APP_DIR)/build
 
 OUT_DIR=$(FLUTTER_APP_BUILD_DIR)/linux
-CACHE_DIR=$(OUT_DIR)/cache
 
-FLUTTER_APP_CACHE_DIR=flutter/
+# Libraries
 FLUTTER_LIB_NAME=flutter_linux
 FLUTTER_LIB=$(FLUTTER_APP_CACHE_DIR)/lib$(FLUTTER_LIB_NAME).so
 
@@ -84,11 +84,12 @@ LDFLAGS=-L$(BUNDLE_LIB_DIR) \
 
 # Targets
 
-# These include phony targets because the flutter tool cannot describe
-# its outputs yet.
 .PHONY: all
 all: $(BIN_OUT) bundle
 
+# This is a phony target because the flutter tool cannot describe
+# its inputs and outputs yet.
+.PHONY: sync
 sync: flutter/generated_config
 	$(FLUTTER_ROOT)/packages/flutter_tools/bin/tool_backend.sh linux-x64 $(BUILD)
 
@@ -99,7 +100,8 @@ $(BIN_OUT): $(SOURCES) $(FLUTTER_LIB_OUT)
 	mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(SOURCES) $(LDFLAGS) -o $@
 
-$(WRAPPER_SOURCES) $(FLUTTER_LIB) $(ICU_DATA_SOURCE): | sync
+$(WRAPPER_SOURCES) $(FLUTTER_LIB) $(ICU_DATA_SOURCE) $(FLUTTER_ASSETS_SOURCE): \
+	| sync
 
 $(FLUTTER_LIB_OUT): $(FLUTTER_LIB)
 	mkdir -p $(BUNDLE_LIB_DIR)
@@ -114,7 +116,7 @@ $(ICU_DATA_OUT): $(ICU_DATA_SOURCE)
 # in the Flutter example (e.g., adding a new font to pubspec.yaml would require
 # changes here).
 .PHONY: bundleflutterassets
-bundleflutterassets: | sync
+bundleflutterassets: $(FLUTTER_ASSETS_SOURCE)
 	mkdir -p $(BUNDLE_DATA_DIR)
 	rsync -rpu --delete $(FLUTTER_ASSETS_SOURCE) $(BUNDLE_DATA_DIR)
 

--- a/testbed/linux/Makefile
+++ b/testbed/linux/Makefile
@@ -30,24 +30,23 @@ PLUGIN_NAMES=color_panel file_chooser menubar window_size
 # Currently this only sets NDEBUG, which is used to control the flags passed
 # to the Flutter engine in the example shell, and not the complation settings
 # (e.g., optimization level) of the C++ code.
-BUILD:=debug
+BUILD=debug
+
+# Configuration provided via flutter tool.
+include flutter/generated_config
 
 # Dependency locations
+FLUTTER_APP_CACHE_DIR=flutter/
 FLUTTER_APP_DIR=$(CURDIR)/..
 FLUTTER_APP_BUILD_DIR=$(FLUTTER_APP_DIR)/build
-FLUTTER_EMBEDDER_LIB_DIR=$(FDE_ROOT)/library/linux
 PLUGINS_DIR=$(FDE_ROOT)/plugins
-TOOLS_DIR=$(FDE_ROOT)/tools
-FLUTTER_ROOT:=$(shell $(TOOLS_DIR)/flutter_location)
 GN_OUT_DIR=$(FDE_ROOT)/out
 
 OUT_DIR=$(FLUTTER_APP_BUILD_DIR)/linux
-CACHE_DIR=$(OUT_DIR)/cache
-FLUTTER_LIBRARY_DIR=$(CACHE_DIR)/flutter_library
 
 # Libraries
 FLUTTER_LIB_NAME=flutter_linux
-FLUTTER_LIB=$(FLUTTER_LIBRARY_DIR)/lib$(FLUTTER_LIB_NAME).so
+FLUTTER_LIB=$(FLUTTER_APP_CACHE_DIR)/lib$(FLUTTER_LIB_NAME).so
 
 PLUGIN_LIB_NAME_PREFIX=flutter_embedder_
 PLUGIN_LIBS=$(foreach plugin,$(PLUGIN_NAMES)\
@@ -56,15 +55,13 @@ PLUGIN_LIBS=$(foreach plugin,$(PLUGIN_NAMES)\
 ALL_LIBS=$(FLUTTER_LIB) $(PLUGIN_LIBS)
 
 # Tools
-BUILD_ASSETS_BIN=$(TOOLS_DIR)/build_flutter_assets
-SYNC_FLUTTER_LIBRARY_BIN=$(TOOLS_DIR)/sync_flutter_library
 FLUTTER_BIN=$(FLUTTER_ROOT)/bin/flutter
-GN_WRAPPER=$(TOOLS_DIR)/gn_dart
+GN_WRAPPER=$(FDE_ROOT)/tools/gn_dart
 NINJA_BIN=ninja
 
 # Resources
 ICU_DATA_NAME=icudtl.dat
-ICU_DATA_SOURCE=$(FLUTTER_ROOT)/bin/cache/artifacts/engine/linux-x64/$(ICU_DATA_NAME)
+ICU_DATA_SOURCE=$(FLUTTER_APP_CACHE_DIR)/$(ICU_DATA_NAME)
 FLUTTER_ASSETS_NAME=flutter_assets
 FLUTTER_ASSETS_SOURCE=$(FLUTTER_APP_BUILD_DIR)/$(FLUTTER_ASSETS_NAME)
 
@@ -79,7 +76,7 @@ ALL_LIBS_OUT=$(foreach lib,$(ALL_LIBS),$(BUNDLE_LIB_DIR)/$(notdir $(lib)))
 
 # Add relevant code from the wrapper library, which is intended to be statically
 # built into the client.
-WRAPPER_ROOT=$(FLUTTER_LIBRARY_DIR)/cpp_client_wrapper
+WRAPPER_ROOT=$(FLUTTER_APP_CACHE_DIR)/cpp_client_wrapper
 WRAPPER_SOURCES= \
 	$(WRAPPER_ROOT)/flutter_window_controller.cc \
 	$(WRAPPER_ROOT)/plugin_registrar.cc \
@@ -90,11 +87,8 @@ SOURCES+=$(WRAPPER_SOURCES)
 WRAPPER_INCLUDE_DIR=$(WRAPPER_ROOT)/include
 # The GN build places all published headers in a top-level include/.
 PLUGIN_INCLUDE_DIRS+=$(GN_OUT_DIR)/include
-INCLUDE_DIRS=$(FLUTTER_LIBRARY_DIR) $(PLUGIN_INCLUDE_DIRS) \
+INCLUDE_DIRS=$(FLUTTER_APP_CACHE_DIR) $(PLUGIN_INCLUDE_DIRS) \
 	$(WRAPPER_INCLUDE_DIR)
-
-# The stamp file created by sync_flutter_library.
-FLUTTER_LIBRARY_STAMP_FILE=$(FLUTTER_LIBRARY_DIR)/.last_flutter_version
 
 # Build settings
 CXX=g++ -std=c++14
@@ -111,6 +105,12 @@ LDFLAGS=-L$(BUNDLE_LIB_DIR) \
 .PHONY: all
 all: $(BIN_OUT) bundle
 
+# This is a phony target because the flutter tool cannot describe
+# its inputs and outputs yet.
+.PHONY: sync
+sync: flutter/generated_config
+	$(FLUTTER_ROOT)/packages/flutter_tools/bin/tool_backend.sh linux-x64 $(BUILD)
+
 .PHONY: bundle
 bundle: $(ICU_DATA_OUT) $(ALL_LIBS_OUT) bundleflutterassets
 
@@ -118,18 +118,8 @@ $(BIN_OUT): $(SOURCES) $(ALL_LIBS_OUT)
 	mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(SOURCES) $(LDFLAGS) -o $@
 
-$(WRAPPER_SOURCES) $(FLUTTER_LIB): $(FLUTTER_LIBRARY_STAMP_FILE)
-
-# Use an order-only dependency to avoid unnecessary relinking when
-# sync_flutter_library is a no-op.
-$(FLUTTER_LIBRARY_STAMP_FILE): | sync_flutter_library
-
-# This is phony since it should always run; otherwise local engine build changes
-# won't be picked up. For the normal case, the script knows how to avoid doing
-# unnecessary work, so running it is fast.
-.PHONY: sync_flutter_library
-sync_flutter_library:
-	$(TOOLS_DIR)/sync_flutter_library $(FLUTTER_LIBRARY_DIR)
+$(WRAPPER_SOURCES) $(FLUTTER_LIB) $(ICU_DATA_SOURCE) $(FLUTTER_ASSETS_SOURCE): \
+	| sync
 
 # Run the GN build for anything depending on the plugins, but use order-only
 # so that it doesn't trigger rebuilds of all dependencies every time.
@@ -160,12 +150,6 @@ $(ICU_DATA_OUT): $(ICU_DATA_SOURCE)
 bundleflutterassets: $(FLUTTER_ASSETS_SOURCE)
 	mkdir -p $(BUNDLE_DATA_DIR)
 	rsync -rpu --delete $(FLUTTER_ASSETS_SOURCE) $(BUNDLE_DATA_DIR)
-
-# PHONY since the Makefile doesn't have all the dependency information necessary
-# to know if 'build bundle' needs to be re-run.
-.PHONY: $(FLUTTER_ASSETS_SOURCE)
-$(FLUTTER_ASSETS_SOURCE):
-	$(BUILD_ASSETS_BIN) $(FLUTTER_APP_DIR) $(FLUTTER_BUNDLE_FLAGS)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Brings testbed in line with the recent changes to example, supporting
--local-engine for testbed on Linux.

Includes a few tweaks to the example Makefile for some dependencies and
structure adjustments that I didn't notice in review of the earlier PR.