### PR TITLE
Add an example plugin for Linux

### DIFF
--- a/plugins/example_plugin/analysis_options.yaml
+++ b/plugins/example_plugin/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options.yaml

--- a/plugins/example_plugin/lib/example_plugin.dart
+++ b/plugins/example_plugin/lib/example_plugin.dart
@@ -1,0 +1,13 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+class ExamplePlugin {
+  static const MethodChannel _channel =
+      const MethodChannel('example_plugin');
+
+  static Future<String> get platformVersion async {
+    final String version = await _channel.invokeMethod('getPlatformVersion');
+    return version;
+  }
+}

--- a/plugins/example_plugin/linux/Makefile
+++ b/plugins/example_plugin/linux/Makefile
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Example-specific variables.
-# To modify this Makefile for a different application, these are the values
-# that are mostly likely to need to be changed.
+# ====================
+# Core variables. To modify this Makefile for a different plugin, these are
+# the values that are mostly likely to need to be changed.
 
 # The name of the plugin.
+# The primary source file is assumed to be $(PLUGIN_NAME).cc, with
+# $(PLUGIN_NAME).h as the public header meant for inclusion by the application.
 PLUGIN_NAME=example_plugin
 # Any files other than the plugin class files that need to be compiled.
 EXTRA_SOURCES=
@@ -24,6 +26,7 @@ EXTRA_SOURCES=
 EXTRA_CXXFLAGS=
 EXTRA_CPPFLAGS=
 EXTRA_LDFLAGS=
+# ====================
 
 # Default build type. For a release build, set BUILD=release.
 # Currently this only sets NDEBUG, which is used to control the flags passed
@@ -32,21 +35,19 @@ EXTRA_LDFLAGS=
 BUILD=debug
 
 # Dependency locations
-PLUGIN_DIR=$(CURDIR)/..
-PLUGIN_BUILD_DIR=$(PLUGIN_DIR)/build
-OUT_DIR=$(FLUTTER_APP_BUILD_DIR)/linux
+# Default to building in the plugin directory.
+OUT_DIR=$(CURDIR)/../build/linux
 # Sharing an OUT_DIR will be common, so use a subdirectory for intermediates.
 PLUGIN_OUT_DIR=$(OUT_DIR)/$(PLUGIN_NAME)
 OBJ_DIR=$(PLUGIN_OUT_DIR)/obj
 FLUTTER_CACHE_DIR=$(PLUGIN_OUT_DIR)/flutter
 
-# Libraries
+# Flutter library
 FLUTTER_LIB_NAME=flutter_linux
 FLUTTER_LIB=$(FLUTTER_CACHE_DIR)/lib$(FLUTTER_LIB_NAME).so
 
-# Tools
 # If FLUTTER_ROOT is set, use that version of Flutter. Otherwise, assume that
-# the flutter tool is in the path.s
+# the flutter tool is in the path.
 ifeq ($(strip $(FLUTTER_ROOT)),)
 FLUTTER_BIN=flutter
 else
@@ -67,8 +68,9 @@ endif
 
 # Add relevant code from the wrapper library, which is intended to be statically
 # built into the plugin.
-# Use abspath for the root since the intermediate files will be based on the
-# source path, which will cause issues if they start with one or more '../'s.
+# Use abspath for the wrapper root, which can contain relative paths; the
+# intermediate build files will be based on the source path, which will cause
+# issues if they start with one or more '../'s.
 WRAPPER_ROOT=$(abspath $(FLUTTER_CACHE_DIR)/cpp_client_wrapper)
 # TODO: Once JSON codec files are merged, make a PLUGIN_CODEC variable in the
 # top section. For now, using JSON codec would require changes here.
@@ -76,9 +78,10 @@ WRAPPER_SOURCES= \
 	$(WRAPPER_ROOT)/engine_method_result.cc \
 	$(WRAPPER_ROOT)/plugin_registrar.cc \
 	$(WRAPPER_ROOT)/standard_codec.cc
-SOURCES+=$(WRAPPER_SOURCES)
 
-SOURCES=$(PLUGIN_NAME).cc $(WRAPPER_SOURCES) $(EXTRA_SOURCES)
+# Use abspath for extra sources, which may also contain relative paths (see
+# note above about WRAPPER_ROOT).
+SOURCES=$(PLUGIN_NAME).cc $(WRAPPER_SOURCES) $(abspath $(EXTRA_SOURCES))
 PUBLIC_HEADER=$(PLUGIN_NAME).h
 
 WRAPPER_INCLUDE_DIR=$(WRAPPER_ROOT)/include
@@ -94,7 +97,7 @@ LDFLAGS=-L$(FLUTTER_CACHE_DIR) -l$(FLUTTER_LIB_NAME) $(EXTRA_LDFLAGS)
 
 # Final output files that will be used by applications.
 LIBRARY_OUT=$(OUT_DIR)/lib$(PLUGIN_NAME).so
-HEADER_OUT=$(OUT_DIR)/$(PUBLIC_HEADER)
+HEADER_OUT=$(OUT_DIR)/include/$(PUBLIC_HEADER)
 
 # Intermediate files.
 OBJ_FILES=$(SOURCES:%.cc=$(OBJ_DIR)/%.o)

--- a/plugins/example_plugin/linux/Makefile
+++ b/plugins/example_plugin/linux/Makefile
@@ -1,0 +1,136 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Example-specific variables.
+# To modify this Makefile for a different application, these are the values
+# that are mostly likely to need to be changed.
+
+# The name of the plugin.
+PLUGIN_NAME=example_plugin
+# Any files other than the plugin class files that need to be compiled.
+EXTRA_SOURCES=
+# Extra flags (e.g., for library dependencies).
+EXTRA_CXXFLAGS=
+EXTRA_CPPFLAGS=
+EXTRA_LDFLAGS=
+
+# Default build type. For a release build, set BUILD=release.
+# Currently this only sets NDEBUG, which is used to control the flags passed
+# to the Flutter engine in the example shell, and not the complation settings
+# (e.g., optimization level) of the C++ code.
+BUILD=debug
+
+# Dependency locations
+PLUGIN_DIR=$(CURDIR)/..
+PLUGIN_BUILD_DIR=$(PLUGIN_DIR)/build
+OUT_DIR=$(FLUTTER_APP_BUILD_DIR)/linux
+# Sharing an OUT_DIR will be common, so use a subdirectory for intermediates.
+PLUGIN_OUT_DIR=$(OUT_DIR)/$(PLUGIN_NAME)
+OBJ_DIR=$(PLUGIN_OUT_DIR)/obj
+FLUTTER_CACHE_DIR=$(PLUGIN_OUT_DIR)/flutter
+
+# Libraries
+FLUTTER_LIB_NAME=flutter_linux
+FLUTTER_LIB=$(FLUTTER_CACHE_DIR)/lib$(FLUTTER_LIB_NAME).so
+
+# Tools
+# If FLUTTER_ROOT is set, use that version of Flutter. Otherwise, assume that
+# the flutter tool is in the path.s
+ifeq ($(strip $(FLUTTER_ROOT)),)
+FLUTTER_BIN=flutter
+else
+FLUTTER_BIN=$(FLUTTER_ROOT)/bin/flutter
+endif
+
+# Unpack configuration.
+# TODO: Revisit how this is managed, either by having plugins builds always use
+# an existing cache provided to the build, or moving logic into the tool.
+FLUTTER_UNPACK_ARGS=--target-platform=linux-x64 \
+	--cache-dir="$(FLUTTER_CACHE_DIR)"
+ifneq ($(strip $(LOCAL_ENGINE)),)
+FLUTTER_UNPACK_ARGS+= --local-engine="$(LOCAL_ENGINE)"
+endif
+ifneq ($(strip $(FLUTTER_ENGINE)),)
+FLUTTER_UNPACK_ARGS+= --local-engine-src-path="$(FLUTTER_ENGINE)"
+endif
+
+# Add relevant code from the wrapper library, which is intended to be statically
+# built into the plugin.
+# Use abspath for the root since the intermediate files will be based on the
+# source path, which will cause issues if they start with one or more '../'s.
+WRAPPER_ROOT=$(abspath $(FLUTTER_CACHE_DIR)/cpp_client_wrapper)
+# TODO: Once JSON codec files are merged, make a PLUGIN_CODEC variable in the
+# top section. For now, using JSON codec would require changes here.
+WRAPPER_SOURCES= \
+	$(WRAPPER_ROOT)/engine_method_result.cc \
+	$(WRAPPER_ROOT)/plugin_registrar.cc \
+	$(WRAPPER_ROOT)/standard_codec.cc
+SOURCES+=$(WRAPPER_SOURCES)
+
+SOURCES=$(PLUGIN_NAME).cc $(WRAPPER_SOURCES) $(EXTRA_SOURCES)
+PUBLIC_HEADER=$(PLUGIN_NAME).h
+
+WRAPPER_INCLUDE_DIR=$(WRAPPER_ROOT)/include
+INCLUDE_DIRS=$(FLUTTER_CACHE_DIR) $(WRAPPER_INCLUDE_DIR)
+
+# Build settings
+CXX=g++ -std=c++14
+CXXFLAGS.release=-DNDEBUG
+CXXFLAGS=-Wall -Werror -shared -fPIC -fvisibility=hidden \
+	-DFLUTTER_PLUGIN_IMPL $(CXXFLAGS.$(BUILD)) $(EXTRA_CXXFLAGS)
+CPPFLAGS=$(patsubst %,-I%,$(INCLUDE_DIRS)) $(EXTRA_CPPFLAGS)
+LDFLAGS=-L$(FLUTTER_CACHE_DIR) -l$(FLUTTER_LIB_NAME) $(EXTRA_LDFLAGS)
+
+# Final output files that will be used by applications.
+LIBRARY_OUT=$(OUT_DIR)/lib$(PLUGIN_NAME).so
+HEADER_OUT=$(OUT_DIR)/$(PUBLIC_HEADER)
+
+# Intermediate files.
+OBJ_FILES=$(SOURCES:%.cc=$(OBJ_DIR)/%.o)
+DEPENDENCY_FILES=$(OBJ_FILES:%.o=%.d)
+
+# Targets
+
+.PHONY: all
+all: $(PLUGIN_NAME)
+
+.PHONY: $(PLUGIN_NAME)
+$(PLUGIN_NAME) : $(LIBRARY_OUT) $(HEADER_OUT)
+
+$(LIBRARY_OUT): $(OBJ_FILES)
+	mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ $(LDFLAGS) -o $@
+
+$(HEADER_OUT): $(PUBLIC_HEADER)
+	mkdir -p $(@D)
+	cp $< $@
+
+$(WRAPPER_SOURCES) $(FLUTTER_LIB): | sync
+
+# This is a phony target because the flutter tool cannot describe
+# its inputs and outputs yet.
+.PHONY: sync
+sync:
+	$(FLUTTER_BIN) unpack $(FLUTTER_UNPACK_ARGS)
+
+-include $(DEPENDENCY_FILES)
+
+$(OBJ_DIR)/%.o : %.cc | sync
+	mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -MMD -c $< -o $@
+
+.PHONY: clean
+clean:
+	rm -f $(LIBRARY_OUT) $(HEADER_OUT)
+	rm -rf $(PLUGINOUT_DIR)

--- a/plugins/example_plugin/linux/example_plugin.cc
+++ b/plugins/example_plugin/linux/example_plugin.cc
@@ -1,0 +1,94 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "example_plugin.h"
+
+#include <flutter/method_channel.h>
+#include <flutter/plugin_registrar.h>
+#include <flutter/standard_method_codec.h>
+#include <sys/utsname.h>
+#include <memory>
+#include <sstream>
+
+namespace {
+
+class ExamplePlugin : public flutter::Plugin {
+ public:
+  static void RegisterWithRegistrar(flutter::PluginRegistrar *registrar);
+
+  // Creates a plugin that communicates on the given channel.
+  ExamplePlugin(
+      std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel);
+
+  virtual ~ExamplePlugin();
+
+ private:
+  // Called when a method is called on |channel_|;
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue> &method_call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+
+  // The MethodChannel used for communication with the Flutter engine.
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_;
+};
+
+// static
+void ExamplePlugin::RegisterWithRegistrar(flutter::PluginRegistrar *registrar) {
+  auto channel =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          registrar->messenger(), "example_plugin",
+          &flutter::StandardMethodCodec::GetInstance());
+  auto *channel_pointer = channel.get();
+
+  auto plugin = std::make_unique<ExamplePlugin>(std::move(channel));
+
+  channel_pointer->SetMethodCallHandler(
+      [plugin_pointer = plugin.get()](const auto &call, auto result) {
+        plugin_pointer->HandleMethodCall(call, std::move(result));
+      });
+
+  registrar->AddPlugin(std::move(plugin));
+}
+
+ExamplePlugin::ExamplePlugin(
+    std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel)
+    : channel_(std::move(channel)) {}
+
+ExamplePlugin::~ExamplePlugin(){};
+
+void ExamplePlugin::HandleMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue> &method_call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  if (method_call.method_name().compare("getPlatformVersion") == 0) {
+    struct utsname uname_data = {};
+    uname(&uname_data);
+    std::ostringstream version_stream;
+    version_stream << "Linux " << uname_data.sysname << " "
+                   << uname_data.release << " " << uname_data.version;
+    flutter::EncodableValue response(version_stream.str());
+    result->Success(&response);
+  } else {
+    result->NotImplemented();
+  }
+}
+
+}  // namespace
+
+void ExamplePluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  // The plugin registrar owns the plugin, registered callbacks, etc., so must
+  // remain valid for the life of the application.
+  static auto *plugin_registrar = new flutter::PluginRegistrar(registrar);
+
+  ExamplePlugin::RegisterWithRegistrar(plugin_registrar);
+}

--- a/plugins/example_plugin/linux/example_plugin.cc
+++ b/plugins/example_plugin/linux/example_plugin.cc
@@ -73,8 +73,7 @@ void ExamplePlugin::HandleMethodCall(
     struct utsname uname_data = {};
     uname(&uname_data);
     std::ostringstream version_stream;
-    version_stream << "Linux " << uname_data.sysname << " "
-                   << uname_data.release << " " << uname_data.version;
+    version_stream << "Linux " << uname_data.version;
     flutter::EncodableValue response(version_stream.str());
     result->Success(&response);
   } else {

--- a/plugins/example_plugin/linux/example_plugin.h
+++ b/plugins/example_plugin/linux/example_plugin.h
@@ -1,0 +1,36 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef PLUGINS_EXAMPLE_LINUX_EXAMPLE_PLUGIN_H_
+#define PLUGINS_EXAMPLE_LINUX_EXAMPLE_PLUGIN_H_
+
+#include <flutter_plugin_registrar.h>
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __attribute__((visibility("default")))
+#else
+#define FLUTTER_PLUGIN_EXPORT
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+FLUTTER_PLUGIN_EXPORT void ExamplePluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar);
+
+#if defined(__cplusplus)
+}  // extern "C"
+#endif
+
+#endif  // PLUGINS_EXAMPLE_LINUX_EXAMPLE_PLUGIN_H_

--- a/plugins/example_plugin/pubspec.yaml
+++ b/plugins/example_plugin/pubspec.yaml
@@ -1,0 +1,12 @@
+name: example_plugin
+description: A minimal example plugin for desktop, in the style of the 'flutter create' plugin template.
+version: 0.0.1
+author:
+homepage:
+
+environment:
+  sdk: ">=2.1.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter

--- a/testbed/lib/main.dart
+++ b/testbed/lib/main.dart
@@ -23,6 +23,7 @@ import 'package:example_flutter/keyboard_test_page.dart';
 import 'package:file_chooser/file_chooser.dart' as file_chooser;
 import 'package:menubar/menubar.dart';
 import 'package:window_size/window_size.dart' as window_size;
+import 'package:example_plugin/example_plugin.dart' as example_plugin;
 
 void main() {
   // Desktop platforms are not recognized as valid targets by
@@ -43,6 +44,13 @@ void main() {
         final frame = Rect.fromLTWH(left, top, width, height);
         window_size.setWindowFrame(frame);
       }
+    });
+  }
+
+  // TODO: Add implementations for the other platforms.
+  if (Platform.isLinux) {
+    example_plugin.ExamplePlugin.platformVersion.then((versionInfo) {
+      print('Example plugin returned $versionInfo');
     });
   }
 

--- a/testbed/linux/Makefile
+++ b/testbed/linux/Makefile
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Example-specific variables.
-# To modify this Makefile for a different application, these are the values
-# that are mostly likely to need to be changed.
-
 # Executable name.
 BINARY_NAME=testbed
 # The location of the flutter-desktop-embedding repository.
 FDE_ROOT=$(CURDIR)/../..
 # The C++ code for the embedder application.
 SOURCES=testbed.cc
+
 # Plugins to include (from the flutter-desktop-embedding plugins/ directory).
-PLUGIN_NAMES=color_panel file_chooser menubar window_size
+PLUGIN_NAMES=example_plugin
+# FDE Plugins still built using GN.
+# TODO: Migrate these to Makefiles.
+GN_PLUGIN_NAMES=color_panel file_chooser menubar window_size
 
 
 # Default build type. For a release build, set BUILD=release.
@@ -48,11 +48,12 @@ OUT_DIR=$(FLUTTER_APP_BUILD_DIR)/linux
 FLUTTER_LIB_NAME=flutter_linux
 FLUTTER_LIB=$(FLUTTER_APP_CACHE_DIR)/lib$(FLUTTER_LIB_NAME).so
 
-PLUGIN_LIB_NAME_PREFIX=flutter_embedder_
-PLUGIN_LIBS=$(foreach plugin,$(PLUGIN_NAMES)\
-	,$(GN_OUT_DIR)/lib$(PLUGIN_LIB_NAME_PREFIX)$(plugin).so)
+GN_PLUGIN_LIB_NAME_PREFIX=flutter_embedder_
+GN_PLUGIN_LIBS=$(foreach plugin,$(GN_PLUGIN_NAMES)\
+	,$(GN_OUT_DIR)/lib$(GN_PLUGIN_LIB_NAME_PREFIX)$(plugin).so)
+PLUGIN_LIBS=$(foreach plugin,$(PLUGIN_NAMES),$(OUT_DIR)/lib$(plugin).so)
 
-ALL_LIBS=$(FLUTTER_LIB) $(PLUGIN_LIBS)
+ALL_LIBS=$(FLUTTER_LIB) $(PLUGIN_LIBS) $(GN_PLUGIN_LIBS)
 
 # Tools
 FLUTTER_BIN=$(FLUTTER_ROOT)/bin/flutter
@@ -85,7 +86,9 @@ SOURCES+=$(WRAPPER_SOURCES)
 
 # Headers
 WRAPPER_INCLUDE_DIR=$(WRAPPER_ROOT)/include
-# The GN build places all published headers in a top-level include/.
+# The plugin builds place all published headers in a top-level include/.
+PLUGIN_INCLUDE_DIRS=$(OUT_DIR)/include
+# As does the GN build, but relative to its output directory.
 PLUGIN_INCLUDE_DIRS+=$(GN_OUT_DIR)/include
 INCLUDE_DIRS=$(FLUTTER_APP_CACHE_DIR) $(PLUGIN_INCLUDE_DIRS) \
 	$(WRAPPER_INCLUDE_DIR)
@@ -97,7 +100,8 @@ CXXFLAGS=-Wall -Werror $(CXXFLAGS.$(BUILD))
 CPPFLAGS=$(patsubst %,-I%,$(INCLUDE_DIRS))
 LDFLAGS=-L$(BUNDLE_LIB_DIR) \
 	-l$(FLUTTER_LIB_NAME) \
-	$(patsubst %,-l$(PLUGIN_LIB_NAME_PREFIX)%,$(PLUGIN_NAMES)) \
+	$(patsubst %,-l$(GN_PLUGIN_LIB_NAME_PREFIX)%,$(GN_PLUGIN_NAMES)) \
+	$(patsubst %,-l%,$(PLUGIN_NAMES)) \
 	-Wl,-rpath=\$$ORIGIN/lib
 
 # Targets
@@ -121,16 +125,23 @@ $(BIN_OUT): $(SOURCES) $(ALL_LIBS_OUT)
 $(WRAPPER_SOURCES) $(FLUTTER_LIB) $(ICU_DATA_SOURCE) $(FLUTTER_ASSETS_SOURCE): \
 	| sync
 
-# Run the GN build for anything depending on the plugins, but use order-only
+# Run the GN build for anything depending on the GN plugins, but use order-only
 # so that it doesn't trigger rebuilds of all dependencies every time.
-$(PLUGIN_LIBS): | gnbuild
+$(GN_PLUGIN_LIBS): | gnbuild
 
 .PHONY: gnbuild
 gnbuild $(WRAPPER_SOURCES): $(GN_OUT_DIR)
-	$(NINJA_BIN) -C $(GN_OUT_DIR) $(PLUGIN_NAMES)
+	$(NINJA_BIN) -C $(GN_OUT_DIR) $(GN_PLUGIN_NAMES)
 
 $(GN_OUT_DIR):
 	$(GN_WRAPPER) gen $(GN_OUT_DIR)
+
+$(OUT_DIR)/libexample_plugin.so: | example_plugin
+
+.PHONY: $(PLUGIN_NAMES)
+$(PLUGIN_NAMES):
+	make -C $(PLUGINS_DIR)/$@/linux \
+		OUT_DIR=$(OUT_DIR) FLUTTER_ROOT=$(FLUTTER_ROOT)
 
 # This is slightly inefficient in that it copies all libraries if any of them
 # changes, but is far simpler than setting up individual rules for each library.

--- a/testbed/linux/testbed.cc
+++ b/testbed/linux/testbed.cc
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include <color_panel/color_panel_plugin.h>
+#include <example_plugin.h>
 #include <file_chooser/file_chooser_plugin.h>
 #include <flutter/flutter_window_controller.h>
 #include <menubar/menubar_plugin.h>
@@ -73,12 +74,14 @@ int main(int argc, char **argv) {
   }
 
   // Register any native plugins.
-  MenubarRegisterWithRegistrar(
-      flutter_controller.GetRegistrarForPlugin("Menubar"));
   ColorPanelRegisterWithRegistrar(
       flutter_controller.GetRegistrarForPlugin("ColorPanel"));
+  ExamplePluginRegisterWithRegistrar(
+      flutter_controller.GetRegistrarForPlugin("ExamplePlugin"));
   FileChooserRegisterWithRegistrar(
       flutter_controller.GetRegistrarForPlugin("FileChooser"));
+  MenubarRegisterWithRegistrar(
+      flutter_controller.GetRegistrarForPlugin("Menubar"));
   WindowSizeRegisterWithRegistrar(
       flutter_controller.GetRegistrarForPlugin("WindowSize"));
 

--- a/testbed/pubspec.yaml
+++ b/testbed/pubspec.yaml
@@ -20,6 +20,8 @@ dependencies:
   # checkout.
   color_panel:
     path: ../plugins/color_panel
+  example_plugin:
+    path: ../plugins/example_plugin
   file_chooser:
     path: ../plugins/file_chooser
   menubar:


### PR DESCRIPTION
Adds a trivial example plugin (currently Linux-only, but will support all platforms)
to serve as a starting point for new plugins, and a place to iterate on the
plugin build/management flow.

Linux part of #357