### PR TITLE
Add example_plugin implementation for macOS

### DIFF
--- a/plugins/example_plugin/macos/.gitignore
+++ b/plugins/example_plugin/macos/.gitignore
@@ -1,0 +1,2 @@
+# See 'Cache Flutter Framework' target's script phase.
+Flutter/

--- a/plugins/example_plugin/macos/Classes/FDEExamplePlugin.h
+++ b/plugins/example_plugin/macos/Classes/FDEExamplePlugin.h
@@ -1,0 +1,24 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import <FlutterMacOS/FlutterMacOS.h>
+
+/**
+ * An example Flutter plugin for macOS.
+ */
+@interface FDEExamplePlugin : NSObject <FLEPlugin>
+
+@end

--- a/plugins/example_plugin/macos/Classes/FDEExamplePlugin.m
+++ b/plugins/example_plugin/macos/Classes/FDEExamplePlugin.m
@@ -1,0 +1,35 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FDEExamplePlugin.h"
+
+@implementation FDEExamplePlugin
+
++ (void)registerWithRegistrar:(id<FLEPluginRegistrar>)registrar {
+  FlutterMethodChannel *channel = [FlutterMethodChannel methodChannelWithName:@"example_plugin"
+                                                              binaryMessenger:registrar.messenger];
+  FDEExamplePlugin *instance = [[FDEExamplePlugin alloc] init];
+  [registrar addMethodCallDelegate:instance channel:channel];
+}
+
+- (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
+  if ([@"getPlatformVersion" isEqualToString:call.method]) {
+    result([@"macOS "
+        stringByAppendingString:[[NSProcessInfo processInfo] operatingSystemVersionString]]);
+  } else {
+    result(FlutterMethodNotImplemented);
+  }
+}
+
+@end

--- a/plugins/example_plugin/macos/ExamplePlugin.h
+++ b/plugins/example_plugin/macos/ExamplePlugin.h
@@ -1,0 +1,15 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FDEExamplePlugin.h"

--- a/plugins/example_plugin/macos/ExamplePlugin.xcodeproj/project.pbxproj
+++ b/plugins/example_plugin/macos/ExamplePlugin.xcodeproj/project.pbxproj
@@ -1,0 +1,436 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		33B2319A2293B11E00DAD38E /* Cache Flutter Framework */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 33B2319D2293B11E00DAD38E /* Build configuration list for PBXAggregateTarget "Cache Flutter Framework" */;
+			buildPhases = (
+				33B2319E2293B12500DAD38E /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = "Cache Flutter Framework";
+			productName = "Cache Flutter Framework";
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		3329FFD020C9D284002E5F16 /* ExamplePlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 3329FFCF20C9D25C002E5F16 /* ExamplePlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3378246F20D3758700909728 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3378246E20D3758700909728 /* AppKit.framework */; };
+		33B231B32294305900DAD38E /* FDEExamplePlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 33B231B12294305900DAD38E /* FDEExamplePlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		33B231B42294305900DAD38E /* FDEExamplePlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = 33B231B22294305900DAD38E /* FDEExamplePlugin.m */; };
+		33D1A0FD221487DE006C7A3E /* FlutterMacOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33D1A0FC221487DE006C7A3E /* FlutterMacOS.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		33B2319F2293B13800DAD38E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 332A46B820C9CFE600C30EB9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 33B2319A2293B11E00DAD38E;
+			remoteInfo = "Cache Flutter Framework";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		3329FFCF20C9D25C002E5F16 /* ExamplePlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExamplePlugin.h; sourceTree = "<group>"; };
+		332A46C120C9CFE600C30EB9 /* ExamplePlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ExamplePlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		332A46C520C9CFE600C30EB9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3378246E20D3758700909728 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		33B231B12294305900DAD38E /* FDEExamplePlugin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FDEExamplePlugin.h; sourceTree = "<group>"; };
+		33B231B22294305900DAD38E /* FDEExamplePlugin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FDEExamplePlugin.m; sourceTree = "<group>"; };
+		33D1A0FC221487DE006C7A3E /* FlutterMacOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FlutterMacOS.framework; path = Flutter/FlutterMacOS.framework; sourceTree = SOURCE_ROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		332A46BD20C9CFE600C30EB9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3378246F20D3758700909728 /* AppKit.framework in Frameworks */,
+				33D1A0FD221487DE006C7A3E /* FlutterMacOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		332A46B720C9CFE600C30EB9 = {
+			isa = PBXGroup;
+			children = (
+				33B231B02294305900DAD38E /* Classes */,
+				3329FFCF20C9D25C002E5F16 /* ExamplePlugin.h */,
+				332A46C520C9CFE600C30EB9 /* Info.plist */,
+				332A46C220C9CFE600C30EB9 /* Products */,
+				3378246B20D3758100909728 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		332A46C220C9CFE600C30EB9 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				332A46C120C9CFE600C30EB9 /* ExamplePlugin.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3378246B20D3758100909728 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				33D1A0FC221487DE006C7A3E /* FlutterMacOS.framework */,
+				3378246E20D3758700909728 /* AppKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		33B231B02294305900DAD38E /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				33B231B12294305900DAD38E /* FDEExamplePlugin.h */,
+				33B231B22294305900DAD38E /* FDEExamplePlugin.m */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		332A46BE20C9CFE600C30EB9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				33B231B32294305900DAD38E /* FDEExamplePlugin.h in Headers */,
+				3329FFD020C9D284002E5F16 /* ExamplePlugin.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		332A46C020C9CFE600C30EB9 /* ExamplePlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 332A46C920C9CFE600C30EB9 /* Build configuration list for PBXNativeTarget "ExamplePlugin" */;
+			buildPhases = (
+				332A46BC20C9CFE600C30EB9 /* Sources */,
+				332A46BD20C9CFE600C30EB9 /* Frameworks */,
+				332A46BE20C9CFE600C30EB9 /* Headers */,
+				332A46BF20C9CFE600C30EB9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				33B231A02293B13800DAD38E /* PBXTargetDependency */,
+			);
+			name = ExamplePlugin;
+			productName = ExamplePlugin;
+			productReference = 332A46C120C9CFE600C30EB9 /* ExamplePlugin.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		332A46B820C9CFE600C30EB9 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0930;
+				ORGANIZATIONNAME = "Google LLC";
+				TargetAttributes = {
+					332A46C020C9CFE600C30EB9 = {
+						CreatedOnToolsVersion = 9.3.1;
+					};
+					33B2319A2293B11E00DAD38E = {
+						CreatedOnToolsVersion = 10.2.1;
+					};
+				};
+			};
+			buildConfigurationList = 332A46BB20C9CFE600C30EB9 /* Build configuration list for PBXProject "ExamplePlugin" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 332A46B720C9CFE600C30EB9;
+			productRefGroup = 332A46C220C9CFE600C30EB9 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				332A46C020C9CFE600C30EB9 /* ExamplePlugin */,
+				33B2319A2293B11E00DAD38E /* Cache Flutter Framework */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		332A46BF20C9CFE600C30EB9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		33B2319E2293B12500DAD38E /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# This is a temporary workaround for the fact that plugins are\n# currently compiled in their own project, without the flutter\n# command-line tool. This means the plugin needs its own copy\n# of the framework to reference, and that the FDE wrapper script\n# is needed to find Flutter and to handle local engine builds.\nreadonly FDE_ROOT=\"$PROJECT_DIR\"/../../..\n\"$FDE_ROOT\"/tools/sync_flutter_library \"$PROJECT_DIR\"/Flutter\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		332A46BC20C9CFE600C30EB9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				33B231B42294305900DAD38E /* FDEExamplePlugin.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		33B231A02293B13800DAD38E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 33B2319A2293B11E00DAD38E /* Cache Flutter Framework */;
+			targetProxy = 33B2319F2293B13800DAD38E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		332A46C720C9CFE600C30EB9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		332A46C820C9CFE600C30EB9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		332A46CA20C9CFE600C30EB9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = $PROJECT_DIR/Flutter;
+				FRAMEWORK_VERSION = A;
+				HEADER_SEARCH_PATHS = ../../..;
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.FDEExamplePlugin;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		332A46CB20C9CFE600C30EB9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = $PROJECT_DIR/Flutter;
+				FRAMEWORK_VERSION = A;
+				HEADER_SEARCH_PATHS = ../../..;
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.FDEExamplePlugin;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		33B2319B2293B11E00DAD38E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		33B2319C2293B11E00DAD38E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		332A46BB20C9CFE600C30EB9 /* Build configuration list for PBXProject "ExamplePlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				332A46C720C9CFE600C30EB9 /* Debug */,
+				332A46C820C9CFE600C30EB9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		332A46C920C9CFE600C30EB9 /* Build configuration list for PBXNativeTarget "ExamplePlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				332A46CA20C9CFE600C30EB9 /* Debug */,
+				332A46CB20C9CFE600C30EB9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		33B2319D2293B11E00DAD38E /* Build configuration list for PBXAggregateTarget "Cache Flutter Framework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				33B2319B2293B11E00DAD38E /* Debug */,
+				33B2319C2293B11E00DAD38E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 332A46B820C9CFE600C30EB9 /* Project object */;
+}

--- a/plugins/example_plugin/macos/ExamplePlugin.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/plugins/example_plugin/macos/ExamplePlugin.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:ExamplePlugin.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/plugins/example_plugin/macos/ExamplePlugin.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/plugins/example_plugin/macos/ExamplePlugin.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/plugins/example_plugin/macos/Info.plist
+++ b/plugins/example_plugin/macos/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/testbed/lib/main.dart
+++ b/testbed/lib/main.dart
@@ -47,8 +47,8 @@ void main() {
     });
   }
 
-  // TODO: Add implementations for the other platforms.
-  if (Platform.isLinux) {
+  // TODO: Add implementation for Windows.
+  if (Platform.isMacOS || Platform.isLinux) {
     example_plugin.ExamplePlugin.platformVersion.then((versionInfo) {
       print('Example plugin returned $versionInfo');
     });

--- a/testbed/macos/PluginRegistrant.m
+++ b/testbed/macos/PluginRegistrant.m
@@ -18,6 +18,7 @@
 
 #import "PluginRegistrant.h"
 
+#import <ExamplePlugin/ExamplePlugin.h>
 #import <FlutterEmbedderColorPanel/FlutterEmbedderColorPanel.h>
 #import <FlutterEmbedderFileChooser/FlutterEmbedderFileChooser.h>
 #import <FlutterEmbedderMenubar/FlutterEmbedderMenubar.h>
@@ -26,6 +27,7 @@
 @implementation PluginRegistrant
 
 + (void)registerWithRegistry:(NSObject<FLEPluginRegistry>*)registry {
+  [FDEExamplePlugin registerWithRegistrar:[registry registrarForPlugin:@"FDEExamplePlugin"]];
   [FLEColorPanelPlugin registerWithRegistrar:[registry registrarForPlugin:@"FLEColorPanelPlugin"]];
   [FLEFileChooserPlugin registerWithRegistrar:[registry registrarForPlugin:@"FLEFileChooserPlugin"]];
   [FLEMenubarPlugin registerWithRegistrar:[registry registrarForPlugin:@"FLEMenubarPlugin"]];

--- a/testbed/macos/Runner.xcodeproj/project.pbxproj
+++ b/testbed/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		3399D4652277B94E009A79C7 /* FlutterEmbedderWindowSize.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3399D4642277B915009A79C7 /* FlutterEmbedderWindowSize.framework */; };
 		3399D4662277B95B009A79C7 /* FlutterEmbedderWindowSize.framework in Bundle Framework */ = {isa = PBXBuildFile; fileRef = 3399D4642277B915009A79C7 /* FlutterEmbedderWindowSize.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		33A2DE652267798600914F77 /* PluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 33A2DE642267798600914F77 /* PluginRegistrant.m */; };
+		33B231C6229439E600DAD38E /* ExamplePlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33B231C32294399200DAD38E /* ExamplePlugin.framework */; };
+		33B231C7229439F300DAD38E /* ExamplePlugin.framework in Bundle Framework */ = {isa = PBXBuildFile; fileRef = 33B231C32294399200DAD38E /* ExamplePlugin.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
@@ -96,6 +98,20 @@
 			remoteGlobalIDString = 332A46C020C9CFE600C30EB9;
 			remoteInfo = FlutterEmbedderWindowSize;
 		};
+		33B231C22294399200DAD38E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 33B231BD2294399200DAD38E /* ExamplePlugin.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 332A46C120C9CFE600C30EB9;
+			remoteInfo = ExamplePlugin;
+		};
+		33B231C4229439DE00DAD38E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 33B231BD2294399200DAD38E /* ExamplePlugin.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 332A46C020C9CFE600C30EB9;
+			remoteInfo = ExamplePlugin;
+		};
 		33CC111F2044C79F0003C045 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 33CC10E52044A3C60003C045 /* Project object */;
@@ -112,6 +128,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				33B231C7229439F300DAD38E /* ExamplePlugin.framework in Bundle Framework */,
 				3399D4662277B95B009A79C7 /* FlutterEmbedderWindowSize.framework in Bundle Framework */,
 				33D1A10522148B93006C7A3E /* FlutterMacOS.framework in Bundle Framework */,
 				3329009620D84F99002E5F16 /* FlutterEmbedderMenubar.framework in Bundle Framework */,
@@ -131,6 +148,7 @@
 		3399D45E2277B915009A79C7 /* FlutterEmbedderWindowSize.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FlutterEmbedderWindowSize.xcodeproj; path = ../../plugins/window_size/macos/FlutterEmbedderWindowSize.xcodeproj; sourceTree = "<group>"; };
 		33A2DE632267798600914F77 /* PluginRegistrant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PluginRegistrant.h; sourceTree = "<group>"; };
 		33A2DE642267798600914F77 /* PluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PluginRegistrant.m; sourceTree = "<group>"; };
+		33B231BD2294399200DAD38E /* ExamplePlugin.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ExamplePlugin.xcodeproj; path = ../../plugins/example_plugin/macos/ExamplePlugin.xcodeproj; sourceTree = "<group>"; };
 		33CC10ED2044A3C60003C045 /* Testbed.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Testbed.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -149,6 +167,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				33B231C6229439E600DAD38E /* ExamplePlugin.framework in Frameworks */,
 				33E98C0821824E4C00EB88EF /* FlutterEmbedderColorPanel.framework in Frameworks */,
 				33E98C0721824E4800EB88EF /* FlutterEmbedderFileChooser.framework in Frameworks */,
 				33E98C0521824E4000EB88EF /* FlutterEmbedderMenubar.framework in Frameworks */,
@@ -202,6 +221,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		33B231BE2294399200DAD38E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				33B231C32294399200DAD38E /* ExamplePlugin.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		33CC10E42044A3C60003C045 = {
 			isa = PBXGroup;
 			children = (
@@ -218,6 +245,7 @@
 				3329004920D2EC7C002E5F16 /* FlutterEmbedderFileChooser.xcodeproj */,
 				3329008D20D84F6E002E5F16 /* FlutterEmbedderMenubar.xcodeproj */,
 				3399D45E2277B915009A79C7 /* FlutterEmbedderWindowSize.xcodeproj */,
+				33B231BD2294399200DAD38E /* ExamplePlugin.xcodeproj */,
 			);
 			sourceTree = "<group>";
 		};
@@ -265,6 +293,7 @@
 			);
 			dependencies = (
 				33CC11202044C79F0003C045 /* PBXTargetDependency */,
+				33B231C5229439DE00DAD38E /* PBXTargetDependency */,
 				3329FFFE20C9F5CF002E5F16 /* PBXTargetDependency */,
 				3329005220D2EC90002E5F16 /* PBXTargetDependency */,
 				3329009520D84F84002E5F16 /* PBXTargetDependency */,
@@ -308,6 +337,10 @@
 			productRefGroup = 33CC10EE2044A3C60003C045 /* Products */;
 			projectDirPath = "";
 			projectReferences = (
+				{
+					ProductGroup = 33B231BE2294399200DAD38E /* Products */;
+					ProjectRef = 33B231BD2294399200DAD38E /* ExamplePlugin.xcodeproj */;
+				},
 				{
 					ProductGroup = 3329FFF620C9F5AC002E5F16 /* Products */;
 					ProjectRef = 3329FFF520C9F5AC002E5F16 /* FlutterEmbedderColorPanel.xcodeproj */;
@@ -360,6 +393,13 @@
 			fileType = wrapper.framework;
 			path = FlutterEmbedderWindowSize.framework;
 			remoteRef = 3399D4632277B915009A79C7 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		33B231C32294399200DAD38E /* ExamplePlugin.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ExamplePlugin.framework;
+			remoteRef = 33B231C22294399200DAD38E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -443,6 +483,11 @@
 			isa = PBXTargetDependency;
 			name = FlutterEmbedderWindowSize;
 			targetProxy = 3399D4672277BA0B009A79C7 /* PBXContainerItemProxy */;
+		};
+		33B231C5229439DE00DAD38E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ExamplePlugin;
+			targetProxy = 33B231C4229439DE00DAD38E /* PBXContainerItemProxy */;
 		};
 		33CC11202044C79F0003C045 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;


### PR DESCRIPTION
For now this uses essentially the same structure as the other plugins,
although it doesn't use the shared project/framework copy, in order to
make it less closely tied to the FDE repo.

It still use the tools/ directory, but that will be eliminated as part
of migrating to CocoaPods in the future.