### PR TITLE
Update macOS code for the plugin API rename

### DIFF
--- a/example/macos/PluginRegistrant.h
+++ b/example/macos/PluginRegistrant.h
@@ -15,5 +15,5 @@
 #import <FlutterMacOS/FlutterMacOS.h>
 
 @interface PluginRegistrant : NSObject
-+ (void)registerWithRegistry:(NSObject<FLEPluginRegistry>*)registry;
++ (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry;
 @end

--- a/example/macos/PluginRegistrant.m
+++ b/example/macos/PluginRegistrant.m
@@ -20,7 +20,7 @@
 
 @implementation PluginRegistrant
 
-+ (void)registerWithRegistry:(NSObject<FLEPluginRegistry>*)registry {
++ (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry {
   // Add your plugin regitration here.
 }
 

--- a/plugins/color_panel/macos/FLEColorPanelPlugin.h
+++ b/plugins/color_panel/macos/FLEColorPanelPlugin.h
@@ -20,6 +20,6 @@
  * A FlutterPlugin to manage macOS's shared NSColorPanel singleton.
  * Responsible for managing the panel's display state and sending selected color data to Flutter.
  */
-@interface FLEColorPanelPlugin : NSObject <FLEPlugin, NSWindowDelegate>
+@interface FLEColorPanelPlugin : NSObject <FlutterPlugin, NSWindowDelegate>
 
 @end

--- a/plugins/color_panel/macos/FLEColorPanelPlugin.mm
+++ b/plugins/color_panel/macos/FLEColorPanelPlugin.mm
@@ -23,7 +23,7 @@
   FlutterMethodChannel *_channel;
 }
 
-+ (void)registerWithRegistrar:(id<FLEPluginRegistrar>)registrar {
++ (void)registerWithRegistrar:(id<FlutterPluginRegistrar>)registrar {
   FlutterMethodChannel *channel =
       [FlutterMethodChannel methodChannelWithName:@(plugins_color_panel::kChannelName)
                                   binaryMessenger:registrar.messenger];

--- a/plugins/example_plugin/macos/Classes/FDEExamplePlugin.h
+++ b/plugins/example_plugin/macos/Classes/FDEExamplePlugin.h
@@ -19,6 +19,6 @@
 /**
  * An example Flutter plugin for macOS.
  */
-@interface FDEExamplePlugin : NSObject <FLEPlugin>
+@interface FDEExamplePlugin : NSObject <FlutterPlugin>
 
 @end

--- a/plugins/example_plugin/macos/Classes/FDEExamplePlugin.m
+++ b/plugins/example_plugin/macos/Classes/FDEExamplePlugin.m
@@ -16,7 +16,7 @@
 
 @implementation FDEExamplePlugin
 
-+ (void)registerWithRegistrar:(id<FLEPluginRegistrar>)registrar {
++ (void)registerWithRegistrar:(id<FlutterPluginRegistrar>)registrar {
   FlutterMethodChannel *channel = [FlutterMethodChannel methodChannelWithName:@"example_plugin"
                                                               binaryMessenger:registrar.messenger];
   FDEExamplePlugin *instance = [[FDEExamplePlugin alloc] init];

--- a/plugins/file_chooser/macos/FLEFileChooserPlugin.h
+++ b/plugins/file_chooser/macos/FLEFileChooserPlugin.h
@@ -21,6 +21,6 @@
  * Responsible for creating and showing instances of NSSavePanel or NSOpenPanel and sending
  * selected file paths to flutter clients, via system channels.
  */
-@interface FLEFileChooserPlugin : NSObject <FLEPlugin>
+@interface FLEFileChooserPlugin : NSObject <FlutterPlugin>
 
 @end

--- a/plugins/file_chooser/macos/FLEFileChooserPlugin.mm
+++ b/plugins/file_chooser/macos/FLEFileChooserPlugin.mm
@@ -76,9 +76,9 @@
   }
 }
 
-#pragma FLEPlugin implementation
+#pragma FlutterPlugin implementation
 
-+ (void)registerWithRegistrar:(id<FLEPluginRegistrar>)registrar {
++ (void)registerWithRegistrar:(id<FlutterPluginRegistrar>)registrar {
   FlutterMethodChannel *channel =
       [FlutterMethodChannel methodChannelWithName:@(plugins_file_chooser::kChannelName)
                                   binaryMessenger:registrar.messenger];

--- a/plugins/menubar/macos/FLEMenubarPlugin.h
+++ b/plugins/menubar/macos/FLEMenubarPlugin.h
@@ -19,7 +19,7 @@
 /**
  * A Flutter plugin to control the native menu bar.
  */
-@interface FLEMenubarPlugin : NSObject <FLEPlugin>
+@interface FLEMenubarPlugin : NSObject <FlutterPlugin>
 
 /**
  * The menu item that Flutter-provided menus should be inserted after. If unset, Flutter-provided

--- a/plugins/menubar/macos/FLEMenubarPlugin.mm
+++ b/plugins/menubar/macos/FLEMenubarPlugin.mm
@@ -114,9 +114,9 @@
   [_channel invokeMethod:@(plugins_menubar::kMenuItemSelectedCallbackMethod) arguments:@(item.tag)];
 }
 
-#pragma FLEPlugin implementation
+#pragma FlutterPlugin implementation
 
-+ (void)registerWithRegistrar:(id<FLEPluginRegistrar>)registrar {
++ (void)registerWithRegistrar:(id<FlutterPluginRegistrar>)registrar {
   FlutterMethodChannel *channel =
       [FlutterMethodChannel methodChannelWithName:@(plugins_menubar::kChannelName)
                                   binaryMessenger:registrar.messenger];

--- a/plugins/window_size/macos/FLEWindowSizePlugin.h
+++ b/plugins/window_size/macos/FLEWindowSizePlugin.h
@@ -20,6 +20,6 @@
  * A FlutterPlugin to manage macOS's shared NSColorPanel singleton.
  * Responsible for managing the panel's display state and sending selected color data to Flutter.
  */
-@interface FLEWindowSizePlugin : NSObject <FLEPlugin, NSWindowDelegate>
+@interface FLEWindowSizePlugin : NSObject <FlutterPlugin, NSWindowDelegate>
 
 @end

--- a/plugins/window_size/macos/FLEWindowSizePlugin.mm
+++ b/plugins/window_size/macos/FLEWindowSizePlugin.mm
@@ -66,7 +66,7 @@ NSRect GetFlippedRect(NSRect frame) {
   NSView *_flutterView;
 }
 
-+ (void)registerWithRegistrar:(id<FLEPluginRegistrar>)registrar {
++ (void)registerWithRegistrar:(id<FlutterPluginRegistrar>)registrar {
   FlutterMethodChannel *channel =
       [FlutterMethodChannel methodChannelWithName:@(plugins_window_size::kChannelName)
                                   binaryMessenger:registrar.messenger];

--- a/testbed/macos/PluginRegistrant.h
+++ b/testbed/macos/PluginRegistrant.h
@@ -15,5 +15,5 @@
 #import <FlutterMacOS/FlutterMacOS.h>
 
 @interface PluginRegistrant : NSObject
-+ (void)registerWithRegistry:(NSObject<FLEPluginRegistry>*)registry;
++ (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry;
 @end

--- a/testbed/macos/PluginRegistrant.m
+++ b/testbed/macos/PluginRegistrant.m
@@ -26,7 +26,7 @@
 
 @implementation PluginRegistrant
 
-+ (void)registerWithRegistry:(NSObject<FLEPluginRegistry>*)registry {
++ (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry {
   [FDEExamplePlugin registerWithRegistrar:[registry registrarForPlugin:@"FDEExamplePlugin"]];
   [FLEColorPanelPlugin registerWithRegistrar:[registry registrarForPlugin:@"FLEColorPanelPlugin"]];
   [FLEFileChooserPlugin registerWithRegistrar:[registry registrarForPlugin:@"FLEFileChooserPlugin"]];


### PR DESCRIPTION
FLEPlugin* was FlutterPlugin* in https://github.com/flutter/engine/pull/9074
This updates all the runner and plugin code for that change.