### PR TITLE
Remove disabling of asserts from example runners

### DIFF
--- a/example/linux/flutter_embedder_example.cc
+++ b/example/linux/flutter_embedder_example.cc
@@ -56,9 +56,6 @@ int main(int argc, char **argv) {
 
   // Arguments for the Flutter Engine.
   std::vector<std::string> arguments;
-#ifdef NDEBUG
-  arguments.push_back("--disable-dart-asserts");
-#endif
 
   flutter::FlutterWindowController flutter_controller(icu_data_path);
 

--- a/example/macos/ExampleWindow.swift
+++ b/example/macos/ExampleWindow.swift
@@ -22,9 +22,6 @@ class ExampleWindow: NSWindow {
 
     let assets = NSURL.fileURL(withPath: "flutter_assets", relativeTo: Bundle.main.resourceURL)
     var arguments: [String] = [];
-#if !DEBUG
-    arguments.append("--disable-dart-asserts");
-#endif
     flutterViewController.launchEngine(
       withAssetsPath: assets,
       commandLineArguments: arguments)

--- a/example/windows/flutter_embedder_example.cpp
+++ b/example/windows/flutter_embedder_example.cpp
@@ -58,9 +58,7 @@ int main(int argc, char **argv) {
 
   // Arguments for the Flutter Engine.
   std::vector<std::string> arguments;
-#ifndef _DEBUG
-  arguments.push_back("--disable-dart-asserts");
-#endif
+
   flutter::FlutterWindowController flutter_controller(icu_data_path);
 
   // Start the engine.


### PR DESCRIPTION
Make it more clear to people using the example little or no context that
there's currently no actual support for a release mode.