### PR TITLE
Implement example_plugin for Windows

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -11,7 +11,11 @@ from this repository, and you must manually manage the linking and registration
 of plugins in your application (unlike on mobile, where the `flutter` tool
 handles that automatically).
 
-### Flutter
+An overview of the approach for each platform is below. See the `testbed`
+example of including optional plugins, including the changes to each platform's
+runner in the corresponding platform directory.
+
+### Dart
 
 Add local package references for the plugins you want to use to your
 pubspec.yaml. For example:
@@ -19,13 +23,13 @@ pubspec.yaml. For example:
 ```
 dependencies:
   ...
-  color_panel:
-    path: relative/path/to/plugins/color_panel
+  example_plugin:
+    path: relative/path/to/plugins/example_plugin
 ```
 
 Then import it in your dart code as you would any other package:
 ```dart
-import 'package:color_panel/color_panel.dart';
+import 'package:example_plugin/example_plugin.dart';
 ```
 
 ### macOS
@@ -64,13 +68,12 @@ the application build.
 Link the plugin frameworks in your application, and add them to the Copy
 Frameworks step.
 
-When you set up your FLEViewController, before calling `launchEngine...`,
-call `-registerWithRegistrar:` on each plugin you want to use. For
-instance:
+In PluginRegistrant.m, call `-registerWithRegistrar:` on each plugin you
+want to use. For instance:
 
 ```objc
-  [FLEFileChooserPlugin registerWithRegistrar:
-      [myFlutterViewController registrarForPlugin:"FLEFileChooserPlugin"]];
+  [FDEExamplePlugin registerWithRegistrar:
+      [registry registrarForPlugin:"FDEExamplePlugin"]];
 ```
 
 ### Linux
@@ -90,6 +93,8 @@ $ sudo apt-get install libgtk-3-dev pkg-config
 
 #### Building
 
+Run `make -C linux` in the directory of the plugin you want to build.
+
 #### Adding to an Application
 
 Link the library files for the plugins you want to include into your binary.
@@ -101,21 +106,31 @@ After creating your Flutter window controller, call your plugin's registrar
 function. For instance:
 
 ```cpp
-  ColorPanelRegisterWithRegistrar(
-      flutter_controller.GetRegistrarForPlugin("ColorPanel"));
+  ExamplePluginRegisterWithRegistrar(
+      flutter_controller.GetRegistrarForPlugin("ExamplePlugin"));
 ```
 
 ### Windows
 
-**TODO**. None of the plugins have been ported to Windows yet, so the structure
-for using them is not yet established.
+#### Building
 
-### Example Use
+The plugin projects are designed to be built from within the solution of
+the application using them. Add the .vcxproj files for the plugins you want
+to build to your application's Runner.sln.
 
-See the runner under each platform's directory in the `testbed`
-directory to see an example of including optional plugins on that platform.
-(The Windows example does not yet include any plugins, but the registration
-process would be the same as for Linux.)
+#### Adding to an Application
+
+Link the library files for the plugins you want to include into your exe.
+The plugin builds in this project put the library at the top level of the
+Plugins directory in the build output, along with their public headers.
+
+After creating your Flutter window controller, call your plugin's registrar
+function. For instance:
+
+```cpp
+  ExamplePluginRegisterWithRegistrar(
+      flutter_controller.GetRegistrarForPlugin("ExamplePlugin"));
+```
 
 ## Writing your own plugins
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -12,8 +12,8 @@ of plugins in your application (unlike on mobile, where the `flutter` tool
 handles that automatically).
 
 An overview of the approach for each platform is below. See the `testbed`
-example of including optional plugins, including the changes to each platform's
-runner in the corresponding platform directory.
+application for an example of including optional plugins, including the changes
+to each platform's runner in the corresponding platform directory.
 
 ### Dart
 

--- a/plugins/example_plugin/windows/.gitignore
+++ b/plugins/example_plugin/windows/.gitignore
@@ -1,0 +1,1 @@
+flutter/

--- a/plugins/example_plugin/windows/.gitignore
+++ b/plugins/example_plugin/windows/.gitignore
@@ -1,1 +1,4 @@
 flutter/
+
+# Visual Studio files
+*.user

--- a/plugins/example_plugin/windows/ExamplePlugin.vcxproj
+++ b/plugins/example_plugin/windows/ExamplePlugin.vcxproj
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{95E21B2C-C18A-4CED-8509-585CB2570FDE}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ExamplePlugin</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ProjectDir)flutter\cpp_client_wrapper\include;$(SolutionDir)flutter</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(SolutionDir)flutter</LibraryPath>
+    <OutDir>$(SolutionDir)..\build\windows\$(Platform)\$(Configuration)\Plugins\</OutDir>
+    <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ProjectDir)flutter\cpp_client_wrapper\include;$(SolutionDir)flutter</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(SolutionDir)flutter</LibraryPath>
+    <OutDir>$(SolutionDir)..\build\windows\$(Platform)\$(Configuration)\Plugins\</OutDir>
+    <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;EXAMPLEPLUGIN_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>flutter_windows.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PreBuildEvent>
+      <Command>xcopy /q /i /s /y "$(SolutionDir)flutter" "$(ProjectDir)flutter"</Command>
+      <Message>Copy Flutter SDK cache from enclosing solution.</Message>
+    </PreBuildEvent>
+    <CustomBuildStep>
+      <Command>
+      </Command>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Message>
+      </Message>
+    </CustomBuildStep>
+    <PostBuildEvent>
+      <Command>xcopy /q /i /s /y "$(ProjectDir)example_plugin.h" "$(OutDir)"</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Publishing header to output directory</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;EXAMPLEPLUGIN_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>flutter_windows.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PreBuildEvent>
+      <Command>xcopy /q /i /s /y "$(SolutionDir)flutter" "$(ProjectDir)flutter"</Command>
+      <Message>Copy Flutter SDK cache from enclosing solution.</Message>
+    </PreBuildEvent>
+    <CustomBuildStep>
+      <Command>
+      </Command>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Message>
+      </Message>
+    </CustomBuildStep>
+    <PostBuildEvent>
+      <Command>xcopy /q /i /s /y "$(ProjectDir)example_plugin.h" "$(OutDir)"</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Publishing header to output directory</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="example_plugin.h" />
+    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="example_plugin.cpp" />
+    <ClCompile Include="flutter\cpp_client_wrapper\engine_method_result.cc" />
+    <ClCompile Include="flutter\cpp_client_wrapper\plugin_registrar.cc" />
+    <ClCompile Include="flutter\cpp_client_wrapper\standard_codec.cc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/plugins/example_plugin/windows/ExamplePlugin.vcxproj
+++ b/plugins/example_plugin/windows/ExamplePlugin.vcxproj
@@ -38,24 +38,30 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(SolutionDir)flutter\Generated.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(SolutionDir)flutter\Generated.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ProjectDir)flutter\cpp_client_wrapper\include;$(SolutionDir)flutter</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(SolutionDir)flutter</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ProjectDir)flutter\cpp_client_wrapper\include;$(ProjectDir)flutter</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(ProjectDir)flutter</LibraryPath>
     <OutDir>$(SolutionDir)..\build\windows\$(Platform)\$(Configuration)\Plugins\</OutDir>
     <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+    <CustomBuildBeforeTargets>
+    </CustomBuildBeforeTargets>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ProjectDir)flutter\cpp_client_wrapper\include;$(SolutionDir)flutter</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(SolutionDir)flutter</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ProjectDir)flutter\cpp_client_wrapper\include;$(ProjectDir)flutter</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(ProjectDir)flutter</LibraryPath>
     <OutDir>$(SolutionDir)..\build\windows\$(Platform)\$(Configuration)\Plugins\</OutDir>
     <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+    <CustomBuildBeforeTargets>
+    </CustomBuildBeforeTargets>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -72,8 +78,8 @@
       <AdditionalDependencies>flutter_windows.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>xcopy /q /i /s /y "$(SolutionDir)flutter" "$(ProjectDir)flutter"</Command>
-      <Message>Copy Flutter SDK cache from enclosing solution.</Message>
+      <Command>"$(ProjectDir)scripts\cache_flutter" "$(ProjectDir)flutter" debug</Command>
+      <Message>Cache Flutter artifacts</Message>
     </PreBuildEvent>
     <CustomBuildStep>
       <Command>
@@ -82,6 +88,8 @@
     <CustomBuildStep>
       <Message>
       </Message>
+      <Outputs>
+      </Outputs>
     </CustomBuildStep>
     <PostBuildEvent>
       <Command>xcopy /q /i /s /y "$(ProjectDir)example_plugin.h" "$(OutDir)"</Command>
@@ -109,8 +117,8 @@
       <AdditionalDependencies>flutter_windows.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>xcopy /q /i /s /y "$(SolutionDir)flutter" "$(ProjectDir)flutter"</Command>
-      <Message>Copy Flutter SDK cache from enclosing solution.</Message>
+      <Command>"$(ProjectDir)scripts\cache_flutter" "$(ProjectDir)flutter" release</Command>
+      <Message>Cache Flutter artifacts</Message>
     </PreBuildEvent>
     <CustomBuildStep>
       <Command>
@@ -119,6 +127,8 @@
     <CustomBuildStep>
       <Message>
       </Message>
+      <Outputs>
+      </Outputs>
     </CustomBuildStep>
     <PostBuildEvent>
       <Command>xcopy /q /i /s /y "$(ProjectDir)example_plugin.h" "$(OutDir)"</Command>

--- a/plugins/example_plugin/windows/ExamplePlugin.vcxproj
+++ b/plugins/example_plugin/windows/ExamplePlugin.vcxproj
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
@@ -26,19 +18,6 @@
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -57,12 +36,6 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -70,18 +43,12 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ProjectDir)flutter\cpp_client_wrapper\include;$(SolutionDir)flutter</IncludePath>
     <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(SolutionDir)flutter</LibraryPath>
     <OutDir>$(SolutionDir)..\build\windows\$(Platform)\$(Configuration)\Plugins\</OutDir>
     <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
@@ -90,20 +57,6 @@
     <OutDir>$(SolutionDir)..\build\windows\$(Platform)\$(Configuration)\Plugins\</OutDir>
     <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;EXAMPLEPLUGIN_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -136,24 +89,6 @@
     <PostBuildEvent>
       <Message>Publishing header to output directory</Message>
     </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;EXAMPLEPLUGIN_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>

--- a/plugins/example_plugin/windows/ExamplePlugin.vcxproj.filters
+++ b/plugins/example_plugin/windows/ExamplePlugin.vcxproj.filters
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\cpp_client_wrapper">
+      <UniqueIdentifier>{dbe2dac9-4a21-4849-bef5-2069d695609d}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="stdafx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="targetver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="example_plugin.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="flutter\cpp_client_wrapper\plugin_registrar.cc">
+      <Filter>Source Files\cpp_client_wrapper</Filter>
+    </ClCompile>
+    <ClCompile Include="flutter\cpp_client_wrapper\standard_codec.cc">
+      <Filter>Source Files\cpp_client_wrapper</Filter>
+    </ClCompile>
+    <ClCompile Include="flutter\cpp_client_wrapper\engine_method_result.cc">
+      <Filter>Source Files\cpp_client_wrapper</Filter>
+    </ClCompile>
+    <ClCompile Include="example_plugin.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/plugins/example_plugin/windows/ExamplePlugin.vcxproj.user
+++ b/plugins/example_plugin/windows/ExamplePlugin.vcxproj.user
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
-</Project>

--- a/plugins/example_plugin/windows/ExamplePlugin.vcxproj.user
+++ b/plugins/example_plugin/windows/ExamplePlugin.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/plugins/example_plugin/windows/example_plugin.cpp
+++ b/plugins/example_plugin/windows/example_plugin.cpp
@@ -1,0 +1,101 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "example_plugin.h"
+
+#include <windows.h>
+
+#include <VersionHelpers.h>
+#include <flutter/method_channel.h>
+#include <flutter/plugin_registrar.h>
+#include <flutter/standard_method_codec.h>
+#include <memory>
+#include <sstream>
+
+namespace {
+
+class ExamplePlugin : public flutter::Plugin {
+ public:
+  static void RegisterWithRegistrar(flutter::PluginRegistrar *registrar);
+
+  // Creates a plugin that communicates on the given channel.
+  ExamplePlugin(
+      std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel);
+
+  virtual ~ExamplePlugin();
+
+ private:
+  // Called when a method is called on |channel_|;
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue> &method_call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+
+  // The MethodChannel used for communication with the Flutter engine.
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_;
+};
+
+// static
+void ExamplePlugin::RegisterWithRegistrar(flutter::PluginRegistrar *registrar) {
+  auto channel =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          registrar->messenger(), "example_plugin",
+          &flutter::StandardMethodCodec::GetInstance());
+  auto *channel_pointer = channel.get();
+
+  auto plugin = std::make_unique<ExamplePlugin>(std::move(channel));
+
+  channel_pointer->SetMethodCallHandler(
+      [plugin_pointer = plugin.get()](const auto &call, auto result) {
+        plugin_pointer->HandleMethodCall(call, std::move(result));
+      });
+
+  registrar->AddPlugin(std::move(plugin));
+}
+
+ExamplePlugin::ExamplePlugin(
+    std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel)
+    : channel_(std::move(channel)) {}
+
+ExamplePlugin::~ExamplePlugin(){};
+
+void ExamplePlugin::HandleMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue> &method_call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  if (method_call.method_name().compare("getPlatformVersion") == 0) {
+    std::ostringstream version_stream;
+    version_stream << "Windows ";
+	// The result returned here will depend on the app manifest of the runner.
+    if (IsWindows10OrGreater()) {
+      version_stream << "10+";
+    } else if (IsWindows8OrGreater()) {
+      version_stream << "8";
+    } else if (IsWindows7OrGreater()) {
+      version_stream << "7";
+    }
+    flutter::EncodableValue response(version_stream.str());
+    result->Success(&response);
+  } else {
+    result->NotImplemented();
+  }
+}
+
+}  // namespace
+
+void ExamplePluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  // The plugin registrar owns the plugin, registered callbacks, etc., so must
+  // remain valid for the life of the application.
+  static auto *plugin_registrar = new flutter::PluginRegistrar(registrar);
+
+  ExamplePlugin::RegisterWithRegistrar(plugin_registrar);
+}

--- a/plugins/example_plugin/windows/example_plugin.h
+++ b/plugins/example_plugin/windows/example_plugin.h
@@ -1,0 +1,36 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef PLUGINS_EXAMPLE_EXAMPLE_PLUGIN_WINDOWS_H_
+#define PLUGINS_EXAMPLE_EXAMPLE_PLUGIN_WINDOWS_H_
+
+#include <flutter_plugin_registrar.h>
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define FLUTTER_PLUGIN_EXPORT __declspec(dllimport)
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+FLUTTER_PLUGIN_EXPORT void ExamplePluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar);
+
+#if defined(__cplusplus)
+}  // extern "C"
+#endif
+
+#endif  // PLUGINS_EXAMPLE_EXAMPLE_PLUGIN_WINDOWS_H_

--- a/plugins/example_plugin/windows/scripts/cache_flutter.bat
+++ b/plugins/example_plugin/windows/scripts/cache_flutter.bat
@@ -1,0 +1,27 @@
+:: Copyright 2019 Google LLC
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::      http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+@echo off
+
+:: Caches the Flutter artifacts. This unfortunately reproduces logic from
+:: Flutter's tool_backend.dart, since currently that step combines building
+:: the bundle and running unpack. Future tool changes should simplify this.
+
+set CACHE_DIR=%~1
+:: Currently unused, but present now to avoid project changes when unpack needs it later.
+set BUILD_MODE=%~2
+
+if defined LOCAL_ENGINE set ENGINE_PARAM=--local-engine=%LOCAL_ENGINE%
+if defined FLUTTER_ENGINE set ENGINE_SOURCE_PARAM=--local-engine-src-path=%FLUTTER_ENGINE%
+
+"%FLUTTER_ROOT%\bin\flutter" unpack --target-platform=windows-x64 --cache-dir="%CACHE_DIR%" %ENGINE_PARAM% %ENGINE_SOURCE_PARAM%

--- a/testbed/lib/main.dart
+++ b/testbed/lib/main.dart
@@ -47,12 +47,9 @@ void main() {
     });
   }
 
-  // TODO: Add implementation for Windows.
-  if (Platform.isMacOS || Platform.isLinux) {
-    example_plugin.ExamplePlugin.platformVersion.then((versionInfo) {
-      print('Example plugin returned $versionInfo');
-    });
-  }
+  example_plugin.ExamplePlugin.platformVersion.then((versionInfo) {
+    print('Example plugin returned $versionInfo');
+  });
 
   runApp(new MyApp());
 }

--- a/testbed/windows/Runner.sln
+++ b/testbed/windows/Runner.sln
@@ -4,6 +4,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 15.0.27703.2026
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Runner", "Runner.vcxproj", "{5A827760-CF8B-408A-99A3-B6C0AD2271E7}"
+	ProjectSection(ProjectDependencies) = postProject
+		{95E21B2C-C18A-4CED-8509-585CB2570FDE} = {95E21B2C-C18A-4CED-8509-585CB2570FDE}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ExamplePlugin", "..\..\plugins\example_plugin\windows\ExamplePlugin.vcxproj", "{95E21B2C-C18A-4CED-8509-585CB2570FDE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +20,10 @@ Global
 		{5A827760-CF8B-408A-99A3-B6C0AD2271E7}.Debug|x64.Build.0 = Debug|x64
 		{5A827760-CF8B-408A-99A3-B6C0AD2271E7}.Release|x64.ActiveCfg = Release|x64
 		{5A827760-CF8B-408A-99A3-B6C0AD2271E7}.Release|x64.Build.0 = Release|x64
+		{95E21B2C-C18A-4CED-8509-585CB2570FDE}.Debug|x64.ActiveCfg = Debug|x64
+		{95E21B2C-C18A-4CED-8509-585CB2570FDE}.Debug|x64.Build.0 = Debug|x64
+		{95E21B2C-C18A-4CED-8509-585CB2570FDE}.Release|x64.ActiveCfg = Release|x64
+		{95E21B2C-C18A-4CED-8509-585CB2570FDE}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/testbed/windows/Runner.vcxproj
+++ b/testbed/windows/Runner.vcxproj
@@ -49,15 +49,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(ProjectDir)..\build\windows\$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
     <IntDir>$(ProjectDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
-    <IncludePath>$(ProjectDir)..\..\;$(ProjectDir)flutter\;$(ProjectDir)flutter\cpp_client_wrapper\include\;$(ProjectDir)..\..\out\include\;$(IncludePath)</IncludePath>
-    <LibraryPath>$(ProjectDir)flutter;$(ProjectDir)..\..\out;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(ProjectDir)..\..\;$(ProjectDir)flutter\;$(ProjectDir)flutter\cpp_client_wrapper\include\;$(OutDir)..\Plugins;$(IncludePath)</IncludePath>
+    <LibraryPath>$(ProjectDir)flutter;$(OutDir)..\Plugins;$(LibraryPath)</LibraryPath>
     <TargetName>Testbed</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(ProjectDir)..\build\windows\$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
     <IntDir>$(ProjectDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
-    <IncludePath>$(ProjectDir)..\..\;$(ProjectDir)flutter\;$(ProjectDir)flutter\cpp_client_wrapper\include\;$(ProjectDir)..\..\out\include\;$(IncludePath)</IncludePath>
-    <LibraryPath>$(ProjectDir)flutter;$(ProjectDir)..\..\out;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(ProjectDir)..\..\;$(ProjectDir)flutter\;$(ProjectDir)flutter\cpp_client_wrapper\include\;$(OutDir)..\Plugins;$(IncludePath)</IncludePath>
+    <LibraryPath>$(ProjectDir)flutter;$(OutDir)..\Plugins;$(LibraryPath)</LibraryPath>
     <TargetName>Testbed</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -71,7 +71,7 @@
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>flutter_windows.dll.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>flutter_windows.dll.lib;ExamplePlugin.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>"$(ProjectDir)scripts\prepare_dependencies" debug</Command>
@@ -92,7 +92,7 @@
       </Message>
     </PostBuildEvent>
     <CustomBuildStep>
-      <Command>"$(ProjectDir)scripts\bundle_assets_and_deps" "$(ProjectDir)flutter\" "$(OutputPath)" "$(TargetFileName)"</Command>
+      <Command>"$(ProjectDir)scripts\bundle_assets_and_deps" "$(ProjectDir)flutter\" "$(OutputPath)" "$(OutputPath)..\Plugins\" "$(TargetFileName)"</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Bundling dependencies</Message>
@@ -116,7 +116,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>flutter_windows.dll.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>flutter_windows.dll.lib;ExamplePlugin.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>"$(ProjectDir)scripts\prepare_dependencies" release</Command>
@@ -137,7 +137,7 @@
       </Message>
     </PostBuildEvent>
     <CustomBuildStep>
-      <Command>"$(ProjectDir)scripts\bundle_assets_and_deps" "$(ProjectDir)flutter\" "$(OutputPath)" "$(TargetFileName)"</Command>
+      <Command>"$(ProjectDir)scripts\bundle_assets_and_deps" "$(ProjectDir)flutter\" "$(OutputPath)" "$(OutputPath)..\Plugins\" "$(TargetFileName)"</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Bundling dependencies</Message>
@@ -147,7 +147,7 @@
     </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="$(ProjectDir)flutter\cpp_client_wrapper\engine_method_result.cc" />
+    <ClCompile Include="flutter\cpp_client_wrapper\engine_method_result.cc" />
     <ClCompile Include="$(ProjectDir)flutter\cpp_client_wrapper\flutter_window_controller.cc" />
     <ClCompile Include="$(ProjectDir)flutter\cpp_client_wrapper\plugin_registrar.cc" />
     <ClCompile Include="testbed.cpp" />

--- a/testbed/windows/scripts/bundle_assets_and_deps.bat
+++ b/testbed/windows/scripts/bundle_assets_and_deps.bat
@@ -15,7 +15,8 @@
 
 set FLUTTER_CACHE_DIR=%~1
 set BUNDLE_DIR=%~2
-set EXE_NAME=%~3
+set PLUGIN_DIR=%~3
+set EXE_NAME=%~4
 
 set DATA_DIR=%BUNDLE_DIR%data
 
@@ -40,4 +41,8 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: Copy the Flutter DLL to the target location.
 call xcopy /y /d /q "%FLUTTER_CACHE_DIR%flutter_windows.dll" "%BUNDLE_DIR%"
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+:: Copy the Plugin DLLs to the target location.
+call xcopy /y /d /q "%PLUGIN_DIR%"*.dll "%BUNDLE_DIR%"
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/testbed/windows/testbed.cpp
+++ b/testbed/windows/testbed.cpp
@@ -16,6 +16,8 @@
 #include <string>
 #include <vector>
 
+#include <example_plugin.h>
+
 #include "flutter/flutter_window_controller.h"
 
 // Include windows.h last, to minimize potential conflicts. The CreateWindow
@@ -64,10 +66,14 @@ int main(int argc, char **argv) {
   flutter::FlutterWindowController flutter_controller(icu_data_path);
 
   // Start the engine.
-  if (!flutter_controller.CreateWindow(800, 600, "Testbed",
-                                       assets_path, arguments)) {
+  if (!flutter_controller.CreateWindow(800, 600, "Testbed", assets_path,
+                                       arguments)) {
     return EXIT_FAILURE;
   }
+
+  // Register any native plugins.
+  ExamplePluginRegisterWithRegistrar(
+      flutter_controller.GetRegistrarForPlugin("ExamplePlugin"));
 
   // Run until the window is closed.
   flutter_controller.RunEventLoop();


### PR DESCRIPTION
Adds an example_plugin implementation for Windows.

As with other platforms, the current build approach is a placeholder
which will be replaced with real dependency management in the future.
For now, the structure is that the plugin project is designed to only be
buildable from a Runner.sln; it uses Generated.props from the
Runner's source directory, and it builds into the Runner's build
directory.

As with the other platforms, this does not have dependencies on the rest
of FDE, should should be copyable as a starting point for making other
experimental plugins on Windows.

Also updates the plugin README to reflect that Windows now has an
example, and does some minor cleanup (e.g., standardizing example
code on using the example plugin).

Fixes #357