### PR TITLE
Quote call to tool_backend in Windows build

### DIFF
--- a/example/windows/scripts/prepare_dependencies.bat
+++ b/example/windows/scripts/prepare_dependencies.bat
@@ -14,4 +14,4 @@
 @echo off
 
 set BUILD_MODE=%~1
-%FLUTTER_ROOT%\packages\flutter_tools\bin\tool_backend windows-x64 %BUILD_MODE%
+"%FLUTTER_ROOT%\packages\flutter_tools\bin\tool_backend" windows-x64 %BUILD_MODE%

--- a/testbed/windows/scripts/prepare_dependencies.bat
+++ b/testbed/windows/scripts/prepare_dependencies.bat
@@ -15,4 +15,4 @@
 
 :: Run flutter tool backend.
 set BUILD_MODE=%~1
-%FLUTTER_ROOT%\packages\flutter_tools\bin\tool_backend windows-x64 %BUILD_MODE%
+"%FLUTTER_ROOT%\packages\flutter_tools\bin\tool_backend" windows-x64 %BUILD_MODE%


### PR DESCRIPTION
The call was missing quoting, which will be an issue if FLUTTER_ROOT
contains spaces.

Fixes #415