### PR TITLE
Install newer CocoaPods in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ matrix:
       language: objective-c
       xcode_project: example/macos/Runner.xcodeproj
       xcode_scheme: Runner
+      before_install:
+        - gem install cocoapods -v '1.6.0'
       install:
         # None of the packaged channels are new enough for the current state
         # of FDE, so for now clone master instead.


### PR DESCRIPTION
Recent Flutter changes require a newer version of CocoaPods than is
pre-installed.