### PR TITLE
Add initial shortcut support to menubar for macOS

### DIFF
--- a/plugins/menubar/lib/src/menu_item.dart
+++ b/plugins/menubar/lib/src/menu_item.dart
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
 /// A callback provided to [MenuItem] to handle menu selection.
@@ -33,6 +34,7 @@ class MenuItem extends AbstractMenuItem {
   /// or the menu item will be selectable but not do anything.
   const MenuItem({
     @required String label,
+    this.shortcut,
     this.enabled = true,
     this.onClicked,
   }) : super(label);
@@ -42,6 +44,16 @@ class MenuItem extends AbstractMenuItem {
 
   /// Whether or not the menu item is enabled.
   final bool enabled;
+
+  /// The shortcut/accelerator for the menu item, if any.
+  ///
+  /// Note: Currently modifiers have only Left or Right variants, so must be
+  /// specified with one of those. The actual left/right distinction will be
+  /// ignored. This part of the API is likely to change in the future.
+  ///
+  /// Example: a Save menu item would likely use:
+  ///   LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyS)
+  final LogicalKeySet shortcut;
 }
 
 /// A menu item continaing a submenu.

--- a/testbed/lib/main.dart
+++ b/testbed/lib/main.dart
@@ -17,6 +17,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:color_panel/color_panel.dart';
 import 'package:example_flutter/keyboard_test_page.dart';
@@ -102,6 +103,8 @@ class _AppState extends State<MyApp> {
         MenuItem(
             label: 'Reset',
             enabled: _primaryColor != Colors.blue,
+            shortcut: LogicalKeySet(
+                LogicalKeyboardKey.meta, LogicalKeyboardKey.backspace),
             onClicked: () {
               setPrimaryColor(Colors.blue);
             }),
@@ -110,18 +113,24 @@ class _AppState extends State<MyApp> {
           MenuItem(
               label: 'Red',
               enabled: _primaryColor != Colors.red,
+              shortcut: LogicalKeySet(LogicalKeyboardKey.meta,
+                  LogicalKeyboardKey.shift, LogicalKeyboardKey.keyR),
               onClicked: () {
                 setPrimaryColor(Colors.red);
               }),
           MenuItem(
               label: 'Green',
               enabled: _primaryColor != Colors.green,
+              shortcut: LogicalKeySet(LogicalKeyboardKey.meta,
+                  LogicalKeyboardKey.alt, LogicalKeyboardKey.keyG),
               onClicked: () {
                 setPrimaryColor(Colors.green);
               }),
           MenuItem(
               label: 'Purple',
               enabled: _primaryColor != Colors.deepPurple,
+              shortcut: LogicalKeySet(LogicalKeyboardKey.meta,
+                  LogicalKeyboardKey.control, LogicalKeyboardKey.keyP),
               onClicked: () {
                 setPrimaryColor(Colors.deepPurple);
               }),
@@ -131,14 +140,20 @@ class _AppState extends State<MyApp> {
         MenuItem(
             label: 'Reset',
             enabled: _counter != 0,
+            shortcut: LogicalKeySet(
+                LogicalKeyboardKey.meta, LogicalKeyboardKey.digit0),
             onClicked: () {
               _setCounter(0);
             }),
         MenuDivider(),
-        MenuItem(label: 'Increment', onClicked: incrementCounter),
+        MenuItem(
+            label: 'Increment',
+            shortcut: LogicalKeySet(LogicalKeyboardKey.f2),
+            onClicked: incrementCounter),
         MenuItem(
             label: 'Decrement',
             enabled: _counter > 0,
+            shortcut: LogicalKeySet(LogicalKeyboardKey.f1),
             onClicked: _decrementCounter),
       ]),
     ]);


### PR DESCRIPTION
Adds the ability to set shortcuts for menu items, using the same format
on the Dart side that will be used for Action shorcuts. Currently only
the macOS platform implementation uses them.

There are some limitations around non-ascii keys, which will be resolved
via a full generated keymap once this is folded into Flutter, but common
cases are special-cased, and more special-casing can be added as needed
by clients.

Adds various shortcuts to the testbed app, exercising various modifiers
and special cases.

Partially addresses #95