### PR TITLE
Convert macOS example_plugin to Swift

### DIFF
--- a/plugins/example_plugin/macos/Classes/ExamplePlugin.m
+++ b/plugins/example_plugin/macos/Classes/ExamplePlugin.m
@@ -14,22 +14,12 @@
 
 #import "ExamplePlugin.h"
 
+#import <example_plugin/example_plugin-Swift.h>
+
 @implementation FDEExamplePlugin
 
 + (void)registerWithRegistrar:(id<FlutterPluginRegistrar>)registrar {
-  FlutterMethodChannel *channel = [FlutterMethodChannel methodChannelWithName:@"example_plugin"
-                                                              binaryMessenger:registrar.messenger];
-  FDEExamplePlugin *instance = [[FDEExamplePlugin alloc] init];
-  [registrar addMethodCallDelegate:instance channel:channel];
-}
-
-- (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
-  if ([@"getPlatformVersion" isEqualToString:call.method]) {
-    result([@"macOS "
-        stringByAppendingString:[[NSProcessInfo processInfo] operatingSystemVersionString]]);
-  } else {
-    result(FlutterMethodNotImplemented);
-  }
+  [SwiftExamplePlugin registerWithRegistrar:registrar];
 }
 
 @end

--- a/plugins/example_plugin/macos/Classes/SwiftExamplePlugin.swift
+++ b/plugins/example_plugin/macos/Classes/SwiftExamplePlugin.swift
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import FlutterMacOS
 import Cocoa
 

--- a/plugins/example_plugin/macos/Classes/SwiftExamplePlugin.swift
+++ b/plugins/example_plugin/macos/Classes/SwiftExamplePlugin.swift
@@ -1,0 +1,18 @@
+import FlutterMacOS
+import Cocoa
+
+public class SwiftExamplePlugin: NSObject, FlutterPlugin {
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(name: "example_plugin", binaryMessenger: registrar.messenger)
+    let instance = SwiftExamplePlugin()
+    registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    if (call.method == "getPlatformVersion") {
+      result("macOS " + ProcessInfo.processInfo.operatingSystemVersionString)
+    } else {
+      result(FlutterMethodNotImplemented);
+    }
+  }
+}

--- a/plugins/example_plugin/macos/example_plugin.podspec
+++ b/plugins/example_plugin/macos/example_plugin.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'example_plugin'
-  s.version          = '0.0.1'
+  s.version          = '0.0.2'
   s.summary          = 'A new flutter plugin project.'
   s.description      = <<-DESC
 A new flutter plugin project.

--- a/testbed/macos/Podfile
+++ b/testbed/macos/Podfile
@@ -46,6 +46,8 @@ def pubspec_supports_macos(file)
 end
 
 target 'Runner' do
+  use_frameworks!
+
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.
   ephemeral_dir = File.join('Flutter', 'ephemeral')
@@ -77,3 +79,6 @@ target 'Runner' do
     end
   }
 end
+
+# Prevent Cocoapods from embedding a second Flutter framework and causing an error with the new Xcode build system.
+install! 'cocoapods', :disable_input_output_paths => true

--- a/testbed/macos/Podfile.lock
+++ b/testbed/macos/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - color_panel (0.0.1):
     - FlutterMacOS
-  - example_plugin (0.0.1):
+  - example_plugin (0.0.2):
     - FlutterMacOS
   - file_chooser (0.0.1):
     - FlutterMacOS
@@ -35,12 +35,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   color_panel: edeaa72f31e864550574a41ac2b01a27afe93363
-  example_plugin: 9b9c6bce3d44d6f5e1cad6770629ce1334c63973
+  example_plugin: 96eee6c9d68d71b3e6259a01074c3e07a4e50c40
   file_chooser: f03aec623d1f36716916546f61e047b27941f288
   FlutterMacOS: a0cd115f6cc6d3a91b8e3fb792e5babf85bcfee1
   menubar: 2c3beb319e775b4e301604ba2c3d7201eaed94a5
   window_size: 3b836660213487307b304e8484636a0d433216c2
 
-PODFILE CHECKSUM: b3530b82cea4ab30cd8bae86402dcbe75ea5e0a2
+PODFILE CHECKSUM: 8e22ef6b498b5efcd617873b5b5fe67bc84c66ed
 
 COCOAPODS: 1.7.0

--- a/testbed/macos/Runner.xcodeproj/project.pbxproj
+++ b/testbed/macos/Runner.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		33CEB41F229F4E8D004F2AC0 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 33CEB3B9229F4E8D004F2AC0 /* GeneratedPluginRegistrant.m */; };
 		33D1A10422148B71006C7A3E /* FlutterMacOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33D1A10322148B71006C7A3E /* FlutterMacOS.framework */; };
 		33D1A10522148B93006C7A3E /* FlutterMacOS.framework in Bundle Framework */ = {isa = PBXBuildFile; fileRef = 33D1A10322148B71006C7A3E /* FlutterMacOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		DD483B73F307097FF135FD10 /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 006D31AACFD6922B0211F576 /* libPods-Runner.a */; };
+		3914FFBFD17F4DD0557A6828 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43329B73CCFE1A6B439F81D9 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,7 +57,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		006D31AACFD6922B0211F576 /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10ED2044A3C60003C045 /* Testbed.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Testbed.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -73,6 +72,7 @@
 		33CEB47722A0578A004F2AC0 /* Flutter-Generated.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Flutter-Generated.xcconfig"; path = "ephemeral/Flutter-Generated.xcconfig"; sourceTree = "<group>"; };
 		33D1A10322148B71006C7A3E /* FlutterMacOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FlutterMacOS.framework; path = Flutter/ephemeral/FlutterMacOS.framework; sourceTree = SOURCE_ROOT; };
 		3A212F0C701BE2A93596D313 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		43329B73CCFE1A6B439F81D9 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		57F1506676D982B7D34CC3A5 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Configs/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Configs/Debug.xcconfig; sourceTree = "<group>"; };
@@ -84,7 +84,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				33D1A10422148B71006C7A3E /* FlutterMacOS.framework in Frameworks */,
-				DD483B73F307097FF135FD10 /* libPods-Runner.a in Frameworks */,
+				3914FFBFD17F4DD0557A6828 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -159,7 +159,7 @@
 		9AD75AA05535B54DFB4DB30B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				006D31AACFD6922B0211F576 /* libPods-Runner.a */,
+				43329B73CCFE1A6B439F81D9 /* Pods_Runner.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -279,12 +279,9 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../Flutter/ephemeral/.symlinks/flutter/darwin-x64/FlutterMacOS.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FlutterMacOS.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
Uses the same structure as an iOS Flutter plugin using the Swift
template, with an ObjC interface wrapper.

This required adding use_frameworks to the Podfile, which will be added
to the template upstream as well.

Also adds the disable_input_output_paths that was added upstream to
address strict build issues with duplicate outputs.

Fixes #421