### PR TITLE
[glfw] Use RawKeyEventDataLinux on testbed keyboard page

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,6 +15,7 @@
 import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 void main() {
   // See https://github.com/flutter/flutter/wiki/Desktop-shells#target-platform-override

--- a/testbed/lib/keyboard_test_page.dart
+++ b/testbed/lib/keyboard_test_page.dart
@@ -88,9 +88,8 @@ class _KeyboardTestPageState extends State<KeyboardTestPage> {
         logicalKey = data.logicalKey.debugName;
         physicalKey = data.physicalKey.debugName;
         break;
-      // The Windows and Linux shells are still sending Android-encoded events.
-      // Once Windows and Linux keyboard support is in place and the shells send
-      // the correct type, this will need to be updated.
+      // TODO(https://github.com/flutter/flutter/issues/37830): The Windows and Linux shells share a 
+      // GLFW implementation. Update once RawKeyEventDataWindows is implemented.
       case RawKeyEventDataLinux:
         final RawKeyEventDataLinux data = event.data;
         keyCode = data.keyCode;
@@ -101,7 +100,8 @@ class _KeyboardTestPageState extends State<KeyboardTestPage> {
         throw new Exception('Unsupported platform ${event.data.runtimeType}');
     }
 
-    _addMessage('''${isKeyDown ? 'KeyDown' : 'KeyUp'}: $keyCode \nLogical key: ${logicalKey}\nPhysical key: ${physicalKey}''');
+    _addMessage('${isKeyDown ? 'KeyDown' : 'KeyUp'}: $keyCode \nLogical key: ${logicalKey}\n'
+      'Physical key: ${physicalKey}');
   }
 
   void _addMessage(String message) {

--- a/testbed/lib/keyboard_test_page.dart
+++ b/testbed/lib/keyboard_test_page.dart
@@ -50,11 +50,16 @@ class _KeyboardTestPageState extends State<KeyboardTestPage> {
         onKey: onKeyEvent,
         child: Container(
           padding: EdgeInsets.symmetric(horizontal: 16.0),
-          child: SingleChildScrollView(
-              controller: _scrollController,
-              child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: _messages.map((m) => new Text(m)).toList())),
+          child: ListView.builder(
+            controller: _scrollController,
+            itemCount: _messages.length,
+            itemBuilder: (_, index) {
+              return Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(_messages[index]),
+              );
+            },
+          ),
         ),
       ),
     );
@@ -74,23 +79,29 @@ class _KeyboardTestPageState extends State<KeyboardTestPage> {
     }
 
     int keyCode;
+    String logicalKey;
+    String physicalKey;
     switch (event.data.runtimeType) {
       case RawKeyEventDataMacOs:
         final RawKeyEventDataMacOs data = event.data;
         keyCode = data.keyCode;
+        logicalKey = data.logicalKey.debugName;
+        physicalKey = data.physicalKey.debugName;
         break;
       // The Windows and Linux shells are still sending Android-encoded events.
       // Once Windows and Linux keyboard support is in place and the shells send
       // the correct type, this will need to be updated.
-      case RawKeyEventDataAndroid:
-        final RawKeyEventDataAndroid data = event.data;
+      case RawKeyEventDataLinux:
+        final RawKeyEventDataLinux data = event.data;
         keyCode = data.keyCode;
+        logicalKey = data.logicalKey.debugName;
+        physicalKey = data.physicalKey.debugName;
         break;
       default:
         throw new Exception('Unsupported platform ${event.data.runtimeType}');
     }
 
-    _addMessage('${isKeyDown ? 'KeyDown' : 'KeyUp'}: $keyCode');
+    _addMessage('''${isKeyDown ? 'KeyDown' : 'KeyUp'}: $keyCode \nLogical key: ${logicalKey}\nPhysical key: ${physicalKey}''');
   }
 
   void _addMessage(String message) {

--- a/testbed/lib/keyboard_test_page.dart
+++ b/testbed/lib/keyboard_test_page.dart
@@ -88,7 +88,7 @@ class _KeyboardTestPageState extends State<KeyboardTestPage> {
         logicalKey = data.logicalKey.debugName;
         physicalKey = data.physicalKey.debugName;
         break;
-      // TODO(https://github.com/flutter/flutter/issues/37830): The Windows and Linux shells share a 
+      // TODO(https://github.com/flutter/flutter/issues/37830): The Windows and Linux shells share a
       // GLFW implementation. Update once RawKeyEventDataWindows is implemented.
       case RawKeyEventDataLinux:
         final RawKeyEventDataLinux data = event.data;


### PR DESCRIPTION
Depends on https://github.com/flutter/engine/pull/9386