### PR TITLE
Remove launch call on FLEViewController

### DIFF
--- a/example/macos/ExampleWindow.swift
+++ b/example/macos/ExampleWindow.swift
@@ -24,8 +24,6 @@ class ExampleWindow: NSWindow {
 
     RegisterGeneratedPlugins(registry: flutterViewController)
 
-    flutterViewController.launchEngine(with: nil)
-
     super.awakeFromNib()
   }
 }

--- a/testbed/macos/FlutterWindow.swift
+++ b/testbed/macos/FlutterWindow.swift
@@ -17,20 +17,19 @@ import FlutterMacOS
 
 class FlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FLEViewController.init()
-    let windowFrame = self.frame
-    self.contentViewController = flutterViewController
-    self.setFrame(windowFrame, display: true)
-
-    RegisterGeneratedPlugins(registry: flutterViewController)
-
     let project = FLEDartProject.init()
     var arguments: [String] = [];
 #if !DEBUG
     arguments.append("--disable-dart-asserts");
 #endif
     project.engineSwitches = arguments
-    flutterViewController.launchEngine(with: project)
+
+    let flutterViewController = FLEViewController.init(project: project)
+    let windowFrame = self.frame
+    self.contentViewController = flutterViewController
+    self.setFrame(windowFrame, display: true)
+
+    RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()
   }


### PR DESCRIPTION
Updates macOS Runners for
flutter/engine#9750

Projects are now configured via init, and there is no explicit launch
command on a view controller.