### PR TITLE
Fix double-result on error in Linux url_launcher

### DIFF
--- a/plugins/flutter_plugins/url_launcher_fde/linux/url_launcher_fde_plugin.cc
+++ b/plugins/flutter_plugins/url_launcher_fde/linux/url_launcher_fde_plugin.cc
@@ -38,7 +38,7 @@ class UrlLauncherPlugin : public flutter::Plugin {
  private:
   UrlLauncherPlugin();
 
-  // Called when a method is called on |channel_|;
+  // Called when a method is called on the plugin's channel;
   void HandleMethodCall(
       const flutter::MethodCall<EncodableValue> &method_call,
       std::unique_ptr<flutter::MethodResult<EncodableValue>> result);
@@ -94,6 +94,7 @@ void UrlLauncherPlugin::HandleMethodCall(
       std::ostringstream error_message;
       error_message << "Failed to open " << url << ": error " << status;
       result->Error("open_error", error_message.str());
+      return;
     }
     result->Success();
   } else {


### PR DESCRIPTION
Adds a missing return in error handling, leading to a path that calls
|result| twice.

Also fixes a comment that was left over from an earlier plugin that kept
a channel reference.