### PR TITLE
Add release builds to CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,6 +28,7 @@ build_script:
   - ps: cd "$env:APPVEYOR_BUILD_FOLDER\example"
   - flutter packages get
   - flutter build -v windows --debug
+  - flutter build -v windows --release
   - ps: cd "$env:APPVEYOR_BUILD_FOLDER\testbed"
   - flutter packages get
   - flutter build -v windows --debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
         - cd $TRAVIS_BUILD_DIR/example
         - flutter packages get
         - flutter build -v linux --debug
+        - flutter build -v linux --release
         - cd $TRAVIS_BUILD_DIR/testbed
         - flutter packages get
         - flutter build -v linux --debug
@@ -54,6 +55,7 @@ matrix:
         - cd $TRAVIS_BUILD_DIR/example
         - flutter packages get
         - flutter build -v macos --debug
+        - flutter build -v macos --release
         - cd $TRAVIS_BUILD_DIR/testbed
         - flutter packages get
         - flutter build -v macos --debug


### PR DESCRIPTION
Although building the applications in release mode still uses debug Flutter
libraries on all frameworks, adding a release build ensures that we have
coverage on the runner-specific aspects of building in release mode.

It will also be useful as release libraries become available, to ensure that
we have coverage for changes for that on the Flutter side.