### PR TITLE
Update gitignore for build output changes

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,4 +1,5 @@
 .atom/
+.dart_tool/
 .idea
 .vscode/
 .packages

--- a/testbed/.gitignore
+++ b/testbed/.gitignore
@@ -1,4 +1,5 @@
 .atom/
+.dart_tool/
 .idea
 .vscode/
 .packages


### PR DESCRIPTION
Build output for macOS is now under .dart_tool, not build, so update the
ignored directories to include that.