### PR TITLE
Remove xcfilelist input and outputs

### DIFF
--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -254,10 +254,8 @@
 			files = (
 			);
 			inputFileListPaths = (
-				Flutter/ephemeral/FlutterInputs.xcfilelist,
 			);
 			outputFileListPaths = (
-				Flutter/ephemeral/FlutterOutputs.xcfilelist,
 			);
 			inputPaths = (
 			);

--- a/testbed/macos/Runner.xcodeproj/project.pbxproj
+++ b/testbed/macos/Runner.xcodeproj/project.pbxproj
@@ -270,10 +270,8 @@
 			files = (
 			);
 			inputFileListPaths = (
-				Flutter/ephemeral/FlutterInputs.xcfilelist,
 			);
 			outputFileListPaths = (
-				Flutter/ephemeral/FlutterOutputs.xcfilelist,
 			);
 			inputPaths = (
 			);


### PR DESCRIPTION
as discussed in https://github.com/flutter/flutter/issues/38863, these won't work with multiple configurations - though the flutter_tool driven caching will still apply so the loss isn't huge.