### PR TITLE
Update Linux apps for incremental GLFW runloop

### DIFF
--- a/example/linux/Makefile
+++ b/example/linux/Makefile
@@ -20,6 +20,11 @@
 BINARY_NAME=flutter_desktop_example
 # The C++ code for the embedder application.
 SOURCES=flutter_embedder_example.cc
+# Extra flags (e.g., for library dependencies).
+SYSTEM_LIBRARIES=
+EXTRA_CXXFLAGS=
+EXTRA_CPPFLAGS=$(patsubst -I%,-isystem%,$(shell pkg-config --cflags $(SYSTEM_LIBRARIES)))
+EXTRA_LDFLAGS=$(shell pkg-config --libs $(SYSTEM_LIBRARIES))
 
 # Default build type. For a release build, set BUILD=release.
 # Currently this only sets NDEBUG, which is used to control the flags passed
@@ -74,12 +79,13 @@ WRAPPER_INCLUDE_DIR=$(WRAPPER_ROOT)/include
 INCLUDE_DIRS=$(FLUTTER_APP_CACHE_DIR) $(WRAPPER_INCLUDE_DIR)
 
 # Build settings
-CXX=clang++
+CXX=clang++ $(EXTRA_CXXFLAGS)
 CXXFLAGS.release=-DNDEBUG
 CXXFLAGS=-std=c++14 -Wall -Werror $(CXXFLAGS.$(BUILD))
-CPPFLAGS=$(patsubst %,-I%,$(INCLUDE_DIRS))
+CPPFLAGS=$(patsubst %,-I%,$(INCLUDE_DIRS)) $(EXTRA_CPPFLAGS)
 LDFLAGS=-L$(BUNDLE_LIB_DIR) \
 	-l$(FLUTTER_LIB_NAME) \
+	$(EXTRA_LDFLAGS) \
 	-Wl,-rpath=\$$ORIGIN/lib
 
 # Targets

--- a/example/linux/flutter_embedder_example.cc
+++ b/example/linux/flutter_embedder_example.cc
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <flutter/flutter_window_controller.h>
 #include <linux/limits.h>
 #include <unistd.h>
 
@@ -18,8 +19,6 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-
-#include <flutter/flutter_window_controller.h>
 
 namespace {
 
@@ -66,6 +65,8 @@ int main(int argc, char **argv) {
   }
 
   // Run until the window is closed.
-  flutter_controller.RunEventLoop();
+  while (!flutter_controller.RunEventLoopWithTimeout(
+      std::chrono::milliseconds::max())) {
+  }
   return EXIT_SUCCESS;
 }

--- a/testbed/README.md
+++ b/testbed/README.md
@@ -24,6 +24,13 @@ This application uses all of the plugins in this repository, so make sure you
 have all the dependencies for
 [building the plugins on your platform](../plugins/README.md).
 
+### Linux
+
+You will also need the X11 headers. For debian-based systems:
+```
+$ sudo apt-get install libx11-dev
+```
+
 ## Building and Running
 
 Just `flutter run`, as with `example`.

--- a/testbed/lib/main.dart
+++ b/testbed/lib/main.dart
@@ -38,6 +38,7 @@ void main() {
 
   // Try to resize and reposition the window to be half the width and height
   // of its screen, centered horizontally and shifted up from center.
+  WidgetsFlutterBinding.ensureInitialized();
   if (Platform.isMacOS || Platform.isLinux) {
     window_size.getWindowInfo().then((window) {
       if (window.screen != null) {

--- a/testbed/linux/Makefile
+++ b/testbed/linux/Makefile
@@ -18,6 +18,11 @@ BINARY_NAME=testbed
 FDE_ROOT=$(CURDIR)/../..
 # The C++ code for the embedder application.
 SOURCES=testbed.cc
+# Extra flags (e.g., for library dependencies).
+SYSTEM_LIBRARIES=gtk+-3.0 x11
+EXTRA_CXXFLAGS=
+EXTRA_CPPFLAGS=$(patsubst -I%,-isystem%,$(shell pkg-config --cflags $(SYSTEM_LIBRARIES)))
+EXTRA_LDFLAGS=$(shell pkg-config --libs $(SYSTEM_LIBRARIES))
 
 # Plugins to include from the flutter-desktop-embedding plugins/ directory.
 PLUGIN_NAMES=color_panel file_chooser menubar window_size
@@ -89,13 +94,14 @@ INCLUDE_DIRS=$(FLUTTER_APP_CACHE_DIR) $(PLUGIN_INCLUDE_DIRS) \
 	$(WRAPPER_INCLUDE_DIR)
 
 # Build settings
-CXX=clang++
+CXX=clang++ $(EXTRA_CXXFLAGS)
 CXXFLAGS.release=-DNDEBUG
 CXXFLAGS=-std=c++14 -Wall -Werror $(CXXFLAGS.$(BUILD))
-CPPFLAGS=$(patsubst %,-I%,$(INCLUDE_DIRS))
+CPPFLAGS=$(patsubst %,-I%,$(INCLUDE_DIRS)) $(EXTRA_CPPFLAGS)
 LDFLAGS=-L$(BUNDLE_LIB_DIR) \
 	-l$(FLUTTER_LIB_NAME) \
 	$(patsubst %,-l%,$(PLUGIN_LIB_NAMES)) \
+	$(EXTRA_LDFLAGS) \
 	-Wl,-rpath=\$$ORIGIN/lib
 
 # Targets

--- a/testbed/linux/testbed.cc
+++ b/testbed/linux/testbed.cc
@@ -13,15 +13,19 @@
 // limitations under the License.
 #include <linux/limits.h>
 #include <unistd.h>
+
 #include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <vector>
 
+// For plugin-compatible event handling (e.g., modal windows).
+#include <X11/Xlib.h>
 #include <color_panel_plugin.h>
 #include <example_plugin.h>
 #include <file_chooser_plugin.h>
 #include <flutter/flutter_window_controller.h>
+#include <gtk/gtk.h>
 #include <menubar_plugin.h>
 #include <url_launcher_fde_plugin.h>
 #include <window_size_plugin.h>
@@ -87,7 +91,17 @@ int main(int argc, char **argv) {
   WindowSizeRegisterWithRegistrar(
       flutter_controller.GetRegistrarForPlugin("WindowSize"));
 
-  // Run until the window is closed.
-  flutter_controller.RunEventLoop();
+  // Set up for GTK event handling, needed by the GTK-based plugins.
+  gtk_init(0, nullptr);
+  XInitThreads();
+
+  // Run until the window is closed, processing GTK events in parallel for
+  // plugin handling.
+  while (flutter_controller.RunEventLoopWithTimeout(
+      std::chrono::milliseconds(10))) {
+    if (gtk_events_pending()) {
+      gtk_main_iteration();
+    }
+  }
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Switches to the new API from https://github.com/flutter/engine/pull/11368 and moves the GTK event handling into the application level of 'testbed'. 'example' doesn't do that handling since it doesn't use plugins. (Longer term a specific toolkit like GTK will be a core requirement of the library, so this divergence won't exist; for now this makes the simple example easier to build and run.)

Note: Since the run-forever version in the C++ wrapper is still present (to avoid this change being a hard compilation break), and Windows didn't need special handling beyond what that does, Windows is not updated; it will be changing to a new API soon anyway, and leaving it avoids collisions with that work.