### PR TITLE
Fix new assertion in Testbed

### DIFF
--- a/testbed/lib/main.dart
+++ b/testbed/lib/main.dart
@@ -38,6 +38,7 @@ void main() {
 
   // Try to resize and reposition the window to be half the width and height
   // of its screen, centered horizontally and shifted up from center.
+  WidgetsFlutterBinding.ensureInitialized();
   if (Platform.isMacOS || Platform.isLinux) {
     window_size.getWindowInfo().then((window) {
       if (window.screen != null) {


### PR DESCRIPTION
Accessing the window_size plugin before running the app triggers a new
assertion; this ensures that the relevant component is initialized (per
the instructions in the assertion message).