### PR TITLE
Add version support to macOS

### DIFF
--- a/example/macos/Info.plist
+++ b/example/macos/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,8 @@
 name: example_flutter
 description: An example project for flutter-desktop-embedding.
 
+version: 0.1.0
+
 environment:
   sdk: '>=2.0.0 <3.0.0'
   # The example interacts with build scripts on the Flutter side that are not


### PR DESCRIPTION
Plumb FLUTTER_BUILD_* into the Info.plist, and update the pubspec.yaml
to include a version in order to populate it. This wires up the example
to use the same version plumbing that is already used on iOS.