### PR TITLE
dummy android module for file_chooser plugin

### DIFF
--- a/plugins/file_chooser/android/build.gradle
+++ b/plugins/file_chooser/android/build.gradle
@@ -1,0 +1,6 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 28
+}
+

--- a/plugins/file_chooser/android/src/main/AndroidManifest.xml
+++ b/plugins/file_chooser/android/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="fde.file_chooser">
+</manifest>
+


### PR DESCRIPTION
in #440 you mention to be open for adding dummy modules for android&ios to enable mobile compilation.. this adds an empty android module for file_chooser, just to make gradle happy.

If you like I can add it also to the other plugins (it would only require customizing the package name in `AndroidManifest.xml` for each plugin i guess). Although i'm not sure if dummy plugins will be made obsolete by https://github.com/flutter/flutter/pull/38632 ?