### PR TITLE
Added Multiple Solution Targets for VS proj file

### DIFF
--- a/plugins/example_plugin/windows/ExamplePlugin.vcxproj
+++ b/plugins/example_plugin/windows/ExamplePlugin.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{95E21B2C-C18A-4CED-8509-585CB2570FDE}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ExamplePlugin</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/plugins/example_plugin/windows/ExamplePlugin.vcxproj
+++ b/plugins/example_plugin/windows/ExamplePlugin.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{95E21B2C-C18A-4CED-8509-585CB2570FDE}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ExamplePlugin</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/plugins/example_plugin/windows/ExamplePlugin.vcxproj
+++ b/plugins/example_plugin/windows/ExamplePlugin.vcxproj
@@ -21,13 +21,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
+++ b/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{18F565CD-7BD5-459C-9FEB-2E2379E88105}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>UrlLauncherPlugin</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
+++ b/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
@@ -21,13 +21,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
+++ b/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{18F565CD-7BD5-459C-9FEB-2E2379E88105}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>UrlLauncherPlugin</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">


### PR DESCRIPTION
Currently for only existed implementations of windows side plugins

PS:
i don't change the characterset on properties file i see that example solution file uses multibyte https://github.com/google/flutter-desktop-embedding/blob/master/example/windows/Runner.vcxproj#L25
but example_plugin uses unicode characterset is this change forgotten ?