### PR TITLE
Switch plugin declaration for path_provider_fde

### DIFF
--- a/plugins/flutter_plugins/path_provider_fde/pubspec.yaml
+++ b/plugins/flutter_plugins/path_provider_fde/pubspec.yaml
@@ -6,8 +6,9 @@ homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugin
 
 flutter:
   plugin:
-    macosPrefix: FLE
-    pluginClass: PathProviderPlugin
+    platforms:
+      macos:
+        pluginClass: PathProviderPlugin
 
 environment:
   sdk: ">=2.1.0 <3.0.0"


### PR DESCRIPTION
The PR adding this plugin was posted before the change to pubspec.yaml
but landed after, so it doesn't work with the current version of
Flutter.