### PR TITLE
Move Windows window setup and exe name to configs

### DIFF
--- a/example/windows/AppConfiguration.props
+++ b/example/windows/AppConfiguration.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetName>Flutter Desktop Example</TargetName>
+  </PropertyGroup>
+</Project>

--- a/example/windows/Runner.vcxproj
+++ b/example/windows/Runner.vcxproj
@@ -40,10 +40,12 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="flutter\Generated.props" />
+    <Import Project="AppConfiguration.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="flutter\Generated.props" />
+    <Import Project="AppConfiguration.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -51,14 +53,12 @@
     <IntDir>$(ProjectDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <IncludePath>$(ProjectDir)flutter\;$(ProjectDir)flutter\cpp_client_wrapper\include\;$(IncludePath)</IncludePath>
     <LibraryPath>$(ProjectDir)flutter;$(LibraryPath)</LibraryPath>
-    <TargetName>Flutter Desktop Example</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(ProjectDir)..\build\windows\$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
     <IntDir>$(ProjectDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <IncludePath>$(ProjectDir)flutter\;$(ProjectDir)flutter\cpp_client_wrapper\include\;$(IncludePath)</IncludePath>
     <LibraryPath>$(ProjectDir)flutter;$(LibraryPath)</LibraryPath>
-    <TargetName>Flutter Desktop Example</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/example/windows/Runner.vcxproj
+++ b/example/windows/Runner.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="$(ProjectDir)flutter\cpp_client_wrapper\engine_method_result.cc" />
     <ClCompile Include="$(ProjectDir)flutter\cpp_client_wrapper\plugin_registrar.cc" />
     <ClCompile Include="plugin_registrant.cpp" />
+    <ClCompile Include="window_configuration.cpp" />
     <ClCompile Include="win32_window.cc" />
     <ClCompile Include="$(ProjectDir)flutter\cpp_client_wrapper\flutter_view_controller.cc" />
     <ClCompile Include="main.cpp" />
@@ -157,6 +158,7 @@
   <ItemGroup>
     <ClInclude Include="plugin_registrant.h" />
     <ClInclude Include="win32_window.h" />
+    <ClInclude Include="window_configuration.h" />
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="runner.exe.manifest" />

--- a/example/windows/Runner.vcxproj.filters
+++ b/example/windows/Runner.vcxproj.filters
@@ -36,12 +36,18 @@
     <ClCompile Include="plugin_registrant.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="window_configuration.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="win32_window.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="plugin_registrant.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="window_configuration.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/example/windows/main.cpp
+++ b/example/windows/main.cpp
@@ -22,6 +22,7 @@
 
 #include "plugin_registrant.h"
 #include "win32_window.h"
+#include "window_configuration.h"
 
 namespace {
 
@@ -67,8 +68,8 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE prev, wchar_t *command_line,
   std::vector<std::string> arguments;
 
   // Top-level window frame.
-  Win32Window::Point origin(10, 10);
-  Win32Window::Size size(800, 600);
+  Win32Window::Point origin(kFlutterWindowOriginX, kFlutterWindowOriginY);
+  Win32Window::Size size(kFlutterWindowWidth, kFlutterWindowHeight);
 
   flutter::FlutterViewController flutter_controller(
       icu_data_path, size.width, size.height, assets_path, arguments);
@@ -76,7 +77,7 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE prev, wchar_t *command_line,
 
   // Create a top-level win32 window to host the Flutter view.
   Win32Window window;
-  if (!window.CreateAndShow(L"Flutter Desktop Example", origin, size)) {
+  if (!window.CreateAndShow(kFlutterWindowTitle, origin, size)) {
     return EXIT_FAILURE;
   }
 

--- a/example/windows/window_configuration.cpp
+++ b/example/windows/window_configuration.cpp
@@ -1,0 +1,21 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "window_configuration.h"
+
+const wchar_t *kFlutterWindowTitle = L"Flutter Desktop Example";
+const unsigned int kFlutterWindowOriginX = 10;
+const unsigned int kFlutterWindowOriginY = 10;
+const unsigned int kFlutterWindowWidth = 800;
+const unsigned int kFlutterWindowHeight = 600;

--- a/example/windows/window_configuration.h
+++ b/example/windows/window_configuration.h
@@ -1,0 +1,33 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef WINDOW_CONFIGURATION_
+#define WINDOW_CONFIGURATION_
+
+// This is a temporary approach to isolate changes that people are likely to
+// make to the example project from main.cpp, where the APIs are still in flux.
+// This will avoid people needing to resolve conflicts or re-create changes
+// slightly different every time the Windows Flutter API surface changes just
+// because of, e.g., a local change to the window title.
+//
+// Longer term there should be simpler configuration options for common
+// customizations like this, without requiring native code changes.
+
+extern const wchar_t *kFlutterWindowTitle;
+extern const unsigned int kFlutterWindowOriginX;
+extern const unsigned int kFlutterWindowOriginY;
+extern const unsigned int kFlutterWindowWidth;
+extern const unsigned int kFlutterWindowHeight;
+
+#endif  // WINDOW_CONFIGURATION_

--- a/testbed/windows/AppConfiguration.props
+++ b/testbed/windows/AppConfiguration.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetName>Testbed</TargetName>
+  </PropertyGroup>
+</Project>

--- a/testbed/windows/Runner.vcxproj
+++ b/testbed/windows/Runner.vcxproj
@@ -153,10 +153,12 @@
     <ClCompile Include="$(ProjectDir)flutter\cpp_client_wrapper\plugin_registrar.cc" />
     <ClCompile Include="$(ProjectDir)flutter\cpp_client_wrapper\flutter_view_controller.cc" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="window_configuration.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="plugin_registrant.h" />
     <ClInclude Include="win32_window.h" />
+    <ClInclude Include="window_configuration.h" />
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="runner.exe.manifest" />

--- a/testbed/windows/Runner.vcxproj
+++ b/testbed/windows/Runner.vcxproj
@@ -40,10 +40,12 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="flutter\Generated.props" />
+    <Import Project="AppConfiguration.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="flutter\Generated.props" />
+    <Import Project="AppConfiguration.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -51,14 +53,12 @@
     <IntDir>$(ProjectDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <IncludePath>$(ProjectDir)..\..\;$(ProjectDir)flutter\;$(ProjectDir)flutter\cpp_client_wrapper\include\;$(OutDir)..\Plugins;$(IncludePath)</IncludePath>
     <LibraryPath>$(ProjectDir)flutter;$(OutDir)..\Plugins;$(LibraryPath)</LibraryPath>
-    <TargetName>Testbed</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(ProjectDir)..\build\windows\$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
     <IntDir>$(ProjectDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <IncludePath>$(ProjectDir)..\..\;$(ProjectDir)flutter\;$(ProjectDir)flutter\cpp_client_wrapper\include\;$(OutDir)..\Plugins;$(IncludePath)</IncludePath>
     <LibraryPath>$(ProjectDir)flutter;$(OutDir)..\Plugins;$(LibraryPath)</LibraryPath>
-    <TargetName>Testbed</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/testbed/windows/Runner.vcxproj.filters
+++ b/testbed/windows/Runner.vcxproj.filters
@@ -36,12 +36,18 @@
     <ClCompile Include="plugin_registrant.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="window_configuration.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="win32_window.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="plugin_registrant.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="window_configuration.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/testbed/windows/main.cpp
+++ b/testbed/windows/main.cpp
@@ -22,6 +22,7 @@
 
 #include "plugin_registrant.h"
 #include "win32_window.h"
+#include "window_configuration.h"
 
 namespace {
 
@@ -70,8 +71,8 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE prev, wchar_t *command_line,
 #endif
 
   // Top-level window frame.
-  Win32Window::Point origin(10, 10);
-  Win32Window::Size size(800, 600);
+  Win32Window::Point origin(kFlutterWindowOriginX, kFlutterWindowOriginY);
+  Win32Window::Size size(kFlutterWindowWidth, kFlutterWindowHeight);
 
   flutter::FlutterViewController flutter_controller(
       icu_data_path, size.width, size.height, assets_path, arguments);
@@ -79,10 +80,11 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE prev, wchar_t *command_line,
 
   // Create a top-level win32 window to host the Flutter view.
   Win32Window window;
-  if (!window.CreateAndShow(L"Testbed", origin, size)) {
+  if (!window.CreateAndShow(kFlutterWindowTitle, origin, size)) {
     return EXIT_FAILURE;
   }
 
+  // Parent and resize Flutter view into top-level window.
   window.SetChildContent(flutter_controller.GetNativeWindow());
 
   // Run messageloop with a hook for flutter_view to do work.

--- a/testbed/windows/window_configuration.cpp
+++ b/testbed/windows/window_configuration.cpp
@@ -1,0 +1,21 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "window_configuration.h"
+
+const wchar_t *kFlutterWindowTitle = L"Testbed";
+const unsigned int kFlutterWindowOriginX = 10;
+const unsigned int kFlutterWindowOriginY = 10;
+const unsigned int kFlutterWindowWidth = 800;
+const unsigned int kFlutterWindowHeight = 600;

--- a/testbed/windows/window_configuration.h
+++ b/testbed/windows/window_configuration.h
@@ -1,0 +1,33 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef WINDOW_CONFIGURATION_
+#define WINDOW_CONFIGURATION_
+
+// This is a temporary approach to isolate changes that people are likely to
+// make to the example project from main.cpp, where the APIs are still in flux.
+// This will avoid people needing to resolve conflicts or re-create changes
+// slightly different every time the Windows Flutter API surface changes just
+// because of, e.g., a local change to the window title.
+//
+// Longer term there should be simpler configuration options for common
+// customizations like this, without requiring native code changes.
+
+extern const wchar_t *kFlutterWindowTitle;
+extern const unsigned int kFlutterWindowOriginX;
+extern const unsigned int kFlutterWindowOriginY;
+extern const unsigned int kFlutterWindowWidth;
+extern const unsigned int kFlutterWindowHeight;
+
+#endif  // WINDOW_CONFIGURATION_


### PR DESCRIPTION
Rather than having the Window title and size be inlined in main.cpp,
where local modifications will cause conflicts on every API update,
move them to a separate constants file. This will help isolate early
users of the Windows embedding from API churn as we iterate on the
Windows Flutter API surface.

Per the comment in the file this is not a long-term solution to
configuration, but it should help in the short term.

Also moves the executable name out of the project and into
a .props file, to similarly simplify maintain a local edit of that
likely change.