### PR TITLE
Roll minimum Flutter version forward

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   # The example interacts with build scripts on the Flutter side that are not
   # yet stable, so it requires a very recent version of Flutter.
   # This version will increase regularly as the build scripts change.
-  flutter: '>=1.9.8-pre.31'
+  flutter: '>=1.10.2-pre.54'
 
 dependencies:
   flutter:

--- a/testbed/pubspec.yaml
+++ b/testbed/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   # The testbed interacts with build scripts on the Flutter side that are not
   # yet stable, so it requires a very recent version of Flutter.
   # This version will increase regularly as the build scripts change.
-  flutter: '>=1.9.8-pre.31'
+  flutter: '>=1.10.2-pre.54'
 
 dependencies:
   flutter:


### PR DESCRIPTION
This should have been done as part of #553; it would have avoided #556.

Since there have been several other recent desktop-related fixes, this
requires a new enough version to pick them up as well to reduce the
chance of people hitting them.