### PR TITLE
Apply the toolchain branching to FlutterBuild

### DIFF
--- a/example/windows/FlutterBuild.vcxproj
+++ b/example/windows/FlutterBuild.vcxproj
@@ -17,7 +17,8 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/testbed/windows/FlutterBuild.vcxproj
+++ b/testbed/windows/FlutterBuild.vcxproj
@@ -17,7 +17,8 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
Even though FlutterBuild.vcxproj doesn't actually use the C++ toolchain,
VS checks it as part of the build process, so listing only 141 prevents
building in a VS 2019 install that only has v142 (the default).

Fixes https://github.com/flutter/flutter/issues/40532