### PR TITLE
Remove dummy Android implementations of plugins

### DIFF
--- a/plugins/file_chooser/android/build.gradle
+++ b/plugins/file_chooser/android/build.gradle
@@ -1,6 +1,0 @@
-apply plugin: 'com.android.library'
-
-android {
-    compileSdkVersion 28
-}
-

--- a/plugins/file_chooser/android/src/main/AndroidManifest.xml
+++ b/plugins/file_chooser/android/src/main/AndroidManifest.xml
@@ -1,4 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="fde.file_chooser">
-</manifest>
-

--- a/plugins/flutter_plugins/connectivity_fde/pubspec.yaml
+++ b/plugins/flutter_plugins/connectivity_fde/pubspec.yaml
@@ -1,7 +1,7 @@
 name: connectivity_fde
 description: Temporary desktop implmentation of connectivity from flutter/plugins
 version: 0.0.1
-author: Flutter Desktop Embedding Developers' => 'flutter-desktop-embedding-dev@googlegroups.com
+author: Flutter Desktop Embedding Developers <flutter-desktop-embedding-dev@googlegroups.com>
 homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugins/flutter_plugins/connectivity_fde
 
 flutter:

--- a/plugins/flutter_plugins/path_provider_fde/android/build.gradle
+++ b/plugins/flutter_plugins/path_provider_fde/android/build.gradle
@@ -1,6 +1,0 @@
-apply plugin: 'com.android.library'
-
-android {
-    compileSdkVersion 28
-}
-

--- a/plugins/flutter_plugins/path_provider_fde/android/src/main/AndroidManifest.xml
+++ b/plugins/flutter_plugins/path_provider_fde/android/src/main/AndroidManifest.xml
@@ -1,4 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="fde.path_provider_fde">
-</manifest>
-

--- a/plugins/flutter_plugins/url_launcher_fde/android/build.gradle
+++ b/plugins/flutter_plugins/url_launcher_fde/android/build.gradle
@@ -1,6 +1,0 @@
-apply plugin: 'com.android.library'
-
-android {
-    compileSdkVersion 28
-}
-

--- a/plugins/flutter_plugins/url_launcher_fde/android/src/main/AndroidManifest.xml
+++ b/plugins/flutter_plugins/url_launcher_fde/android/src/main/AndroidManifest.xml
@@ -1,4 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="fde.url_launcher_fde">
-</manifest>
-


### PR DESCRIPTION
As of https://github.com/flutter/flutter/pull/40640 these should no
longer be necessary.

Also fixes a typo in a plugin pubspec.yaml.