### PR TITLE
[windows] Add SDK to FlutterBuild

### DIFF
--- a/example/windows/FlutterBuild.vcxproj
+++ b/example/windows/FlutterBuild.vcxproj
@@ -14,6 +14,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{6419BF13-6ECD-4CD2-9E85-E566A1F03F8F}</ProjectGuid>
     <ProjectName>Flutter Build</ProjectName>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/testbed/windows/FlutterBuild.vcxproj
+++ b/testbed/windows/FlutterBuild.vcxproj
@@ -14,6 +14,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{6419BF13-6ECD-4CD2-9E85-E566A1F03F8F}</ProjectGuid>
     <ProjectName>Flutter Build</ProjectName>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">


### PR DESCRIPTION
Even though the SDK isn't used by this project, VS still appears to do
SDK validation when the build starts (as with the tool version).

Longer term, the ideal solution would be to find a project template that
doesn't require setting tool and SDK versions that we don't need, if
possible, since all it needs to do is run a script.

Fixes #592