### PR TITLE
Switch CI to use 'flutter config'

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,14 +17,14 @@ image: Visual Studio 2017
 platform: x64
 
 install:
-  # None of the packaged channels are new enough for the current state
-  # of FDE, so for now clone master instead.
+  # Desktop support currently requires master, so clone the latest master
+  # rather than doing a standard install.
   #- ps: build\ci\install_flutter.ps1 $env:APPVEYOR_BUILD_FOLDER\..
   - git clone -b master https://github.com/flutter/flutter.git %APPVEYOR_BUILD_FOLDER%\..\flutter
 
 build_script:
   - set "PATH=%APPVEYOR_BUILD_FOLDER%\..\flutter\bin;C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\;%PATH%"
-  - set "ENABLE_FLUTTER_DESKTOP=true"
+  - flutter config --enable-windows-desktop
   - ps: cd "$env:APPVEYOR_BUILD_FOLDER\example"
   - flutter packages get
   - flutter build -v windows --debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ matrix:
         - sudo apt-get update
       install:
         - build/ci/linux/install_dependencies
-        # None of the packaged channels are new enough for the current state
-        # of FDE, so for now clone master instead.
+        # Desktop support currently requires master, so clone the latest master
+        # rather than doing a standard install.
         #- build/ci/install_flutter $TRAVIS_BUILD_DIR/..
         - git clone -b master https://github.com/flutter/flutter.git $TRAVIS_BUILD_DIR/../flutter
       before_script:
         - export PATH=$PATH:$TRAVIS_BUILD_DIR/../flutter/bin
-        - export ENABLE_FLUTTER_DESKTOP=true
+        - flutter config --enable-linux-desktop
       script:
         - cd $TRAVIS_BUILD_DIR/example
         - flutter packages get
@@ -44,13 +44,13 @@ matrix:
       before_install:
         - gem install cocoapods -v '1.6.0'
       install:
-        # None of the packaged channels are new enough for the current state
-        # of FDE, so for now clone master instead.
+        # Desktop support currently requires master, so clone the latest master
+        # rather than doing a standard install.
         #- build/ci/install_flutter $TRAVIS_BUILD_DIR/..
         - git clone -b master https://github.com/flutter/flutter.git $TRAVIS_BUILD_DIR/../flutter
       before_script:
         - export PATH=$PATH:$TRAVIS_BUILD_DIR/../flutter/bin
-        - export ENABLE_FLUTTER_DESKTOP=true
+        - flutter config --enable-macos-desktop
       script:
         - cd $TRAVIS_BUILD_DIR/example
         - flutter packages get


### PR DESCRIPTION
The CI scripts were never updated to use the new 'flutter config'
workflow, and are instead relying on the environment variable fallback.
This switches to the new workflow for both Travis and AppVeyor.