### PR TITLE
{linux}/generated_plugin_registrant.cc: [fix] #include wrong filename

### DIFF
--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -2,7 +2,7 @@
 //  Generated file. Do not edit.
 //
 
-#include "plugin_registrant.h"
+#include "generated_plugin_registrant.h"
 
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {


### PR DESCRIPTION
`flutter build linux` was giving this error:

```
flutter/generated_plugin_registrant.cc:5:10: fatal error: 'plugin_registrant.h' file not found
#include "plugin_registrant.h"
```