### PR TITLE
Fix wide-to-utf8 conversions on Windows

### DIFF
--- a/example/windows/main.cpp
+++ b/example/windows/main.cpp
@@ -35,7 +35,7 @@ std::string GetExecutableDirectory() {
     std::cerr << "Couldn't locate executable" << std::endl;
     return "";
   }
-  std::wstring_convert<std::codecvt_utf8<wchar_t>> wide_to_utf8;
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> wide_to_utf8;
   std::string executable_path = wide_to_utf8.to_bytes(buffer);
   size_t last_separator_position = executable_path.find_last_of('\\');
   if (last_separator_position == std::string::npos) {

--- a/plugins/flutter_plugins/path_provider_fde/windows/path_provider_plugin.cpp
+++ b/plugins/flutter_plugins/path_provider_fde/windows/path_provider_plugin.cpp
@@ -30,7 +30,7 @@ using flutter::EncodableValue;
 
 // Converts an null-terminated array of wchar_t's to a std::string.
 std::string StdStringFromWideChars(wchar_t *wide_chars) {
-  std::wstring_convert<std::codecvt_utf8<wchar_t>> wide_to_utf8;
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> wide_to_utf8;
   return wide_to_utf8.to_bytes(wide_chars);
 }
 
@@ -119,8 +119,7 @@ void PathProviderPlugin::HandleMethodCall(
       result->Error("Unable to get temporary path");
       return;
     }
-    std::wstring_convert<std::codecvt_utf8<wchar_t>> wide_to_utf8;
-    std::string result_path = wide_to_utf8.to_bytes(path_buffer);
+    std::string result_path = StdStringFromWideChars(path_buffer);
     flutter::EncodableValue response(result_path);
     result->Success(&response);
   } else if (method_call.method_name().compare(


### PR DESCRIPTION
`codecvt_utf8` is for UCS2, not UTF-16, and all versions of Windows we would
conceivably support use UTF-16. This replaces the incorrect conversions with the
correct `codecvt_utf8_utf16`.