### PR TITLE
Add a _plugin suffix to plugin DLLs

### DIFF
--- a/plugins/file_chooser/windows/file_chooser.vcxproj
+++ b/plugins/file_chooser/windows/file_chooser.vcxproj
@@ -57,6 +57,7 @@
     <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <CustomBuildBeforeTargets>
     </CustomBuildBeforeTargets>
+    <TargetName>$(ProjectName)_plugin</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
@@ -66,6 +67,7 @@
     <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <CustomBuildBeforeTargets>
     </CustomBuildBeforeTargets>
+    <TargetName>$(ProjectName)_plugin</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/plugins/flutter_plugins/path_provider_fde/windows/path_provider_fde.vcxproj
+++ b/plugins/flutter_plugins/path_provider_fde/windows/path_provider_fde.vcxproj
@@ -57,6 +57,7 @@
     <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <CustomBuildBeforeTargets>
     </CustomBuildBeforeTargets>
+    <TargetName>$(ProjectName)_plugin</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
@@ -66,6 +67,7 @@
     <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <CustomBuildBeforeTargets>
     </CustomBuildBeforeTargets>
+    <TargetName>$(ProjectName)_plugin</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
+++ b/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
@@ -57,6 +57,7 @@
     <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <CustomBuildBeforeTargets>
     </CustomBuildBeforeTargets>
+    <TargetName>$(ProjectName)_plugin</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
@@ -66,6 +67,7 @@
     <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <CustomBuildBeforeTargets>
     </CustomBuildBeforeTargets>
+    <TargetName>$(ProjectName)_plugin</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/plugins/sample/windows/sample.vcxproj
+++ b/plugins/sample/windows/sample.vcxproj
@@ -57,6 +57,7 @@
     <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <CustomBuildBeforeTargets>
     </CustomBuildBeforeTargets>
+    <TargetName>$(ProjectName)_plugin</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
@@ -66,6 +67,7 @@
     <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <CustomBuildBeforeTargets>
     </CustomBuildBeforeTargets>
+    <TargetName>$(ProjectName)_plugin</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/plugins/window_size/windows/window_size.vcxproj
+++ b/plugins/window_size/windows/window_size.vcxproj
@@ -57,6 +57,7 @@
     <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <CustomBuildBeforeTargets>
     </CustomBuildBeforeTargets>
+    <TargetName>$(ProjectName)_plugin</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
@@ -66,6 +67,7 @@
     <IntDir>$(SolutionDir)..\build\windows\intermediates\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <CustomBuildBeforeTargets>
     </CustomBuildBeforeTargets>
+    <TargetName>$(ProjectName)_plugin</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/testbed/windows/FlutterPlugins.props
+++ b/testbed/windows/FlutterPlugins.props
@@ -4,7 +4,7 @@
   <PropertyGroup />
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalDependencies>sample.lib;file_chooser.lib;path_provider_fde.lib;url_launcher_fde.lib;window_size.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>sample_plugin.lib;file_chooser_plugin.lib;path_provider_fde_plugin.lib;url_launcher_fde_plugin.lib;window_size_plugin.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
Giving them a suffix makes it easier to identify what the DLL is. This is also consistent with the current naming for Linux plugins.

(Longer term the name may be controlled via a pubspec key or similar instead of being expected to follow a set form, but for now this is potentially useful.)