### PR TITLE
Allow filter groups in file_chooser

### DIFF
--- a/plugins/file_chooser/lib/file_chooser.dart
+++ b/plugins/file_chooser/lib/file_chooser.dart
@@ -11,5 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+export 'src/filter_group.dart';
 export 'src/result.dart';
 export 'src/utilities.dart';

--- a/plugins/file_chooser/lib/src/channel_controller.dart
+++ b/plugins/file_chooser/lib/src/channel_controller.dart
@@ -110,7 +110,8 @@ class FileChooserConfigurationOptions {
     }
     if (allowedFileTypes != null && allowedFileTypes.isNotEmpty) {
       args[_kAllowedFileTypesKey] = allowedFileTypes
-          .map((filter) => [filter.label ?? '', filter.fileExtensions ?? []]);
+          .map((filter) => [filter.label ?? '', filter.fileExtensions ?? []])
+          .toList();
     }
     if (confirmButtonText != null && confirmButtonText.isNotEmpty) {
       args[_kConfirmButtonTextKey] = confirmButtonText;

--- a/plugins/file_chooser/lib/src/channel_controller.dart
+++ b/plugins/file_chooser/lib/src/channel_controller.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 import 'package:flutter/services.dart';
 
+import 'filter_group.dart';
 import 'result.dart';
 
 /// The name of the plugin's platform channel.
@@ -34,7 +35,19 @@ const String _kInitialDirectoryKey = 'initialDirectory';
 /// an empty string if not provided.
 const String _kInitialFileNameKey = 'initialFileName';
 
-/// An array of UTI or file extension strings a panel is allowed to choose.
+/// An array of UTI or file extension groups a user should be able to select.
+///
+/// The format is:
+/// [
+///   [ label, [extension, extension, ...] ],
+///   [ label, [extension, extension, ...] ],
+///   ...
+/// ]
+///
+/// On platforms that don't support selectable groups (e.g., macOS), the
+/// extension lists can be merged. An empty extension array indicates that any
+/// type is allowed; when merging, this should cause all other arrays to be
+/// ignored.
 const String _kAllowedFileTypesKey = 'allowedFileTypes';
 
 /// The text that appears on the panel's confirmation button. If not provided,
@@ -75,7 +88,8 @@ class FileChooserConfigurationOptions {
   // the configuration parameters defined in the channel protocol.
   final String initialDirectory; // ignore: public_member_api_docs
   final String initialFileName; // ignore: public_member_api_docs
-  final List<String> allowedFileTypes; // ignore: public_member_api_docs
+  final List<FileTypeFilterGroup>
+      allowedFileTypes; // ignore: public_member_api_docs
   final bool allowsMultipleSelection; // ignore: public_member_api_docs
   final bool canSelectDirectories; // ignore: public_member_api_docs
   final String confirmButtonText; // ignore: public_member_api_docs
@@ -95,7 +109,8 @@ class FileChooserConfigurationOptions {
       args[_kCanChooseDirectoriesKey] = canSelectDirectories;
     }
     if (allowedFileTypes != null && allowedFileTypes.isNotEmpty) {
-      args[_kAllowedFileTypesKey] = allowedFileTypes;
+      args[_kAllowedFileTypesKey] = allowedFileTypes
+          .map((filter) => [filter.label ?? '', filter.fileExtensions ?? []]);
     }
     if (confirmButtonText != null && confirmButtonText.isNotEmpty) {
       args[_kConfirmButtonTextKey] = confirmButtonText;

--- a/plugins/file_chooser/lib/src/filter_group.dart
+++ b/plugins/file_chooser/lib/src/filter_group.dart
@@ -1,0 +1,28 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A set of allowed file types.
+class FileTypeFilterGroup {
+  /// Creates a new group with the given label and file extensions.
+  const FileTypeFilterGroup({this.label, this.fileExtensions});
+
+  /// The label for the grouping. On platforms that support selectable groups,
+  /// this will be visible to the user for selecting the group.
+  final String label;
+
+  /// A list of allowed file extensions. E.g., ['png', 'jpg', 'jpeg', 'gif'].
+  ///
+  /// A null or empty list indicates any type is allowed.
+  final List<String> fileExtensions;
+}

--- a/plugins/file_chooser/lib/src/utilities.dart
+++ b/plugins/file_chooser/lib/src/utilities.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import 'channel_controller.dart';
+import 'filter_group.dart';
 import 'result.dart';
 
 /// Shows a file chooser for selecting paths to one or more existing files.
@@ -26,7 +27,7 @@ import 'result.dart';
 /// - [confirmButtonText] overrides the button that confirms selection.
 Future<FileChooserResult> showOpenPanel({
   String initialDirectory,
-  List<String> allowedFileTypes,
+  List<FileTypeFilterGroup> allowedFileTypes,
   bool allowsMultipleSelection,
   bool canSelectDirectories,
   String confirmButtonText,
@@ -51,7 +52,7 @@ Future<FileChooserResult> showOpenPanel({
 Future<FileChooserResult> showSavePanel(
     {String initialDirectory,
     String suggestedFileName,
-    List<String> allowedFileTypes,
+    List<FileTypeFilterGroup> allowedFileTypes,
     String confirmButtonText}) async {
   final options = FileChooserConfigurationOptions(
       initialDirectory: initialDirectory,

--- a/plugins/file_chooser/linux/file_chooser_plugin.cc
+++ b/plugins/file_chooser/linux/file_chooser_plugin.cc
@@ -82,23 +82,24 @@ static void ProcessFilters(const EncodableMap &method_args,
                            GtkFileChooser *chooser) {
   const EncodableValue &allowed_file_types =
       ValueOrNull(method_args, kAllowedFileTypesKey);
-  if (allowed_file_types.IsList() && !allowed_file_types.ListValue().empty()) {
-    const std::string file_wildcard = "*.";
-    for (const EncodableValue &filter_info : allowed_file_types.ListValue()) {
-      GtkFileFilter *filter = gtk_file_filter_new();
-      gtk_file_filter_set_name(
-          filter, filter_info.ListValue()[0].StringValue().c_str());
-      EncodableList extensions = filter_info.ListValue()[1].ListValue();
-      if (extensions.empty()) {
-        gtk_file_filter_add_pattern(filter, "*");
-      } else {
-        for (const EncodableValue &extension : extensions) {
-          std::string pattern = file_wildcard + extension.StringValue();
-          gtk_file_filter_add_pattern(filter, pattern.c_str());
-        }
+  if (!allowed_file_types.IsList() || allowed_file_types.ListValue().empty()) {
+    return;
+  }
+  const std::string file_wildcard = "*.";
+  for (const EncodableValue &filter_info : allowed_file_types.ListValue()) {
+    GtkFileFilter *filter = gtk_file_filter_new();
+    gtk_file_filter_set_name(filter,
+                             filter_info.ListValue()[0].StringValue().c_str());
+    EncodableList extensions = filter_info.ListValue()[1].ListValue();
+    if (extensions.empty()) {
+      gtk_file_filter_add_pattern(filter, "*");
+    } else {
+      for (const EncodableValue &extension : extensions) {
+        std::string pattern = file_wildcard + extension.StringValue();
+        gtk_file_filter_add_pattern(filter, pattern.c_str());
       }
-      gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(chooser), filter);
     }
+    gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(chooser), filter);
   }
 }
 

--- a/plugins/file_chooser/macos/Classes/FLEFileChooserPlugin.m
+++ b/plugins/file_chooser/macos/Classes/FLEFileChooserPlugin.m
@@ -53,7 +53,18 @@ static NSString *const kCanChooseDirectoriesKey = @"canChooseDirectories";
     panel.directoryURL = [NSURL URLWithString:arguments[kInitialDirectoryKey]];
   }
   if ([argKeys containsObject:kAllowedFileTypesKey]) {
-    panel.allowedFileTypes = arguments[kAllowedFileTypesKey];
+    // macOS doesn't support filter groups, so combine all allowed types into a flat list.
+    NSMutableArray<NSString*> *allowedTypes = [NSMutableArray array];
+    for (NSArray *filter in arguments[kAllowedFileTypesKey]) {
+      NSArray<NSString*> *extensions = filter[1];
+      // If any group allows all extensions, don't do any filtering.
+      if (extensions.count == 0) {
+        allowedTypes = nil;
+        break;
+      }
+      [allowedTypes addObjectsFromArray:extensions];
+    }
+    panel.allowedFileTypes = allowedTypes;
   }
   if ([argKeys containsObject:kInitialFileNameKey]) {
     panel.nameFieldStringValue = arguments[kInitialFileNameKey];

--- a/plugins/file_chooser/windows/file_chooser_plugin.cpp
+++ b/plugins/file_chooser/windows/file_chooser_plugin.cpp
@@ -119,33 +119,36 @@ class DialogWrapper {
     last_result_ = dialog_->SetOptions(options);
   }
 
-  // Sets the filter for allowed file types to select.
-  void SetAllowedExtensions(const EncodableList &extensions) {
-    // Since the current information from the Dart side is just a flat list
-    // of extensions with no label, build a single filter spec whose name
-    // is a comma-separated list of the extensions. E.g., ['jpeg','jpg','png']
-    // would become:
-    //   pszName: "jpeg, jpg, png"
-    //   pszSpec: "*.jpeg;*.jpg;*.png"
-    // TODO: Make a meaningful filterspec array instead of one mega-filter.
-    // See issue #650.
-    const std::wstring name_delimiter = L", ";
+  // Sets the filters for allowed file types to select.
+  void SetFileTypeFilters(const EncodableList &filters) {
     const std::wstring spec_delimiter = L";";
     const std::wstring file_wildcard = L"*.";
-    std::wstring filter_name;
-    std::wstring filter;
-    for (const EncodableValue &extension_value : extensions) {
-      if (!filter_name.empty()) {
-        filter_name += name_delimiter;
-        filter += spec_delimiter;
+    std::vector<COMDLG_FILTERSPEC> filter_specs;
+    // Temporary ownership of the constructed strings whose data is used in
+    // filter_specs, so that they live until the call to SetFileTypes is done.
+    std::vector<std::wstring> filter_names;
+    std::vector<std::wstring> filter_extensions;
+    for (const EncodableValue &filter_info : allowed_file_types.ListValue()) {
+      filter_names.push_back(WideStringFromChars(
+          filter_info.ListValue()[0].StringValue().c_str()));
+      filter_extensions.push_back(L"");
+      EncodableList extensions = filter_info.ListValue()[1].ListValue();
+      std::wstring &spec = filter_extensions.back();
+      if (extensions.empty()) {
+        spec += "*.*"
+      } else {
+        for (const EncodableValue &extension : extensions) {
+          if (!spec.empty()) {
+            spec += spec_delimiter;
+          }
+          spec += file_wildcard +
+                  WideStringFromChars(extension_value.StringValue().c_str());
+        }
       }
-      std::wstring extension =
-          WideStringFromChars(extension_value.StringValue().c_str());
-      filter_name += extension;
-      filter += file_wildcard + extension;
+      filter_specs.emplace_back({filter_names.back().c_str(), spec.c_str()});
     }
-    COMDLG_FILTERSPEC spec = {filter_name.c_str(), filter.c_str()};
-    last_result_ = dialog_->SetFileTypes(1, &spec);
+    last_result_ =
+        dialog_->SetFileTypes(filter_specs.size(), filter_specs.data());
   }
 
   // Displays the dialog, and returns the selected file or files as an

--- a/plugins/file_chooser/windows/file_chooser_plugin.cpp
+++ b/plugins/file_chooser/windows/file_chooser_plugin.cpp
@@ -128,24 +128,27 @@ class DialogWrapper {
     // filter_specs, so that they live until the call to SetFileTypes is done.
     std::vector<std::wstring> filter_names;
     std::vector<std::wstring> filter_extensions;
-    for (const EncodableValue &filter_info : allowed_file_types.ListValue()) {
+    filter_extensions.reserve(filters.size());
+    filter_names.reserve(filters.size());
+
+    for (const EncodableValue &filter_info : filters) {
       filter_names.push_back(WideStringFromChars(
           filter_info.ListValue()[0].StringValue().c_str()));
       filter_extensions.push_back(L"");
       EncodableList extensions = filter_info.ListValue()[1].ListValue();
       std::wstring &spec = filter_extensions.back();
       if (extensions.empty()) {
-        spec += "*.*"
+        spec += L"*.*";
       } else {
         for (const EncodableValue &extension : extensions) {
           if (!spec.empty()) {
             spec += spec_delimiter;
           }
           spec += file_wildcard +
-                  WideStringFromChars(extension_value.StringValue().c_str());
+                  WideStringFromChars(extension.StringValue().c_str());
         }
       }
-      filter_specs.emplace_back({filter_names.back().c_str(), spec.c_str()});
+      filter_specs.push_back({filter_names.back().c_str(), spec.c_str()});
     }
     last_result_ =
         dialog_->SetFileTypes(filter_specs.size(), filter_specs.data());
@@ -262,7 +265,7 @@ void ShowDialog(
   }
   EncodableValue allowed_types = ValueOrNull(args, kAllowedFileTypesKey);
   if (!allowed_types.IsNull() && !allowed_types.ListValue().empty()) {
-    dialog.SetAllowedExtensions(allowed_types.ListValue());
+    dialog.SetFileTypeFilters(allowed_types.ListValue());
   }
 
   EncodableValue files = dialog.Show(parent_window);

--- a/testbed/lib/main.dart
+++ b/testbed/lib/main.dart
@@ -21,7 +21,7 @@ import 'package:flutter/services.dart';
 
 import 'package:color_panel/color_panel.dart';
 import 'package:example_flutter/keyboard_test_page.dart';
-import 'package:file_chooser/file_chooser.dart' as file_chooser;
+import 'package:file_chooser/file_chooser.dart';
 import 'package:menubar/menubar.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:sample/sample.dart' as sample_plugin;
@@ -309,9 +309,7 @@ class FileChooserTestWidget extends StatelessWidget {
         new FlatButton(
           child: const Text('SAVE'),
           onPressed: () {
-            file_chooser
-                .showSavePanel(suggestedFileName: 'save_test.txt')
-                .then((result) {
+            showSavePanel(suggestedFileName: 'save_test.txt').then((result) {
               Scaffold.of(context).showSnackBar(SnackBar(
                 content: Text(_resultTextForFileChooserOperation(
                     _FileChooserType.save, result)),
@@ -323,13 +321,40 @@ class FileChooserTestWidget extends StatelessWidget {
           child: const Text('OPEN'),
           onPressed: () async {
             String initialDirectory;
-            if (Platform.isMacOS) {
+            if (Platform.isMacOS || Platform.isWindows) {
               initialDirectory =
                   (await getApplicationDocumentsDirectory()).path;
             }
-            final result = await file_chooser.showOpenPanel(
+            final result = await showOpenPanel(
                 allowsMultipleSelection: true,
                 initialDirectory: initialDirectory);
+            Scaffold.of(context).showSnackBar(SnackBar(
+                content: Text(_resultTextForFileChooserOperation(
+                    _FileChooserType.open, result))));
+          },
+        ),
+        new FlatButton(
+          child: const Text('OPEN MEDIA'),
+          onPressed: () async {
+            final result =
+                await showOpenPanel(allowedFileTypes: <FileTypeFilterGroup>[
+              FileTypeFilterGroup(label: 'Images', fileExtensions: <String>[
+                'bmp',
+                'gif',
+                'jpeg',
+                'jpg',
+                'png',
+                'tiff',
+                'webp',
+              ]),
+              FileTypeFilterGroup(label: 'Video', fileExtensions: <String>[
+                'avi',
+                'mov',
+                'mpeg',
+                'mpg',
+                'webm',
+              ]),
+            ]);
             Scaffold.of(context).showSnackBar(SnackBar(
                 content: Text(_resultTextForFileChooserOperation(
                     _FileChooserType.open, result))));
@@ -395,7 +420,7 @@ enum _FileChooserType { save, open }
 
 /// Returns display text reflecting the result of a file chooser operation.
 String _resultTextForFileChooserOperation(
-    _FileChooserType type, file_chooser.FileChooserResult result) {
+    _FileChooserType type, FileChooserResult result) {
   if (result.canceled) {
     return '${type == _FileChooserType.open ? 'Open' : 'Save'} cancelled';
   }

--- a/testbed/macos/Podfile.lock
+++ b/testbed/macos/Podfile.lock
@@ -66,7 +66,7 @@ SPEC CHECKSUMS:
   shared_preferences: 9fec34d1bd906196a4da48fcf6c3ad521cc00b8d
   shared_preferences_macos: 5e5c2839894accb56b7d23328905b757f2bafaf6
   url_launcher: af78307ef9bafff91273b34f1c6c0c86a0004fd7
-  url_launcher_macos: 77182d012b6b515c0955d24ed22b38f79b82a99d
+  url_launcher_macos: 76867a28e24e0b6b98bfd65f157b64108e6d477a
   window_size: 339dafa0b27a95a62a843042038fa6c3c48de195
 
 PODFILE CHECKSUM: 2c44d578a2acaaed0401d0d3bb20d04d4b080703


### PR DESCRIPTION
Allows for more functionality in file chooser filtering on Windows and Linux,
by allowing the specification of filter groups rather than just a flat list of
extensions.

Fixes #650