### PR TITLE
Misc. Windows code cleanup

### DIFF
--- a/example/windows/Runner.vcxproj
+++ b/example/windows/Runner.vcxproj
@@ -70,7 +70,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>flutter_windows.dll.lib;Shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -115,7 +115,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/example/windows/Runner.vcxproj
+++ b/example/windows/Runner.vcxproj
@@ -72,6 +72,7 @@
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>flutter_windows.dll.lib;Shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -118,6 +119,7 @@
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/example/windows/Runner.vcxproj
+++ b/example/windows/Runner.vcxproj
@@ -64,13 +64,14 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <AdditionalDependencies>flutter_windows.dll.lib;Shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -107,7 +108,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -116,6 +117,7 @@
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/example/windows/main.cpp
+++ b/example/windows/main.cpp
@@ -48,8 +48,8 @@ std::string GetExecutableDirectory() {
 
 }  // namespace
 
-int APIENTRY wWinMain(_In_ HINSTANCE, _In_opt_ HINSTANCE, _In_ LPWSTR,
-                      _In_ int) {
+int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
+                      _In_ wchar_t *command_line, _In_ int show_command) {
   // Attach to console when present (e.g., 'flutter run') or create a
   // new console when running with a debugger.
   if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent()) {

--- a/example/windows/main.cpp
+++ b/example/windows/main.cpp
@@ -48,8 +48,8 @@ std::string GetExecutableDirectory() {
 
 }  // namespace
 
-int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE prev, wchar_t *command_line,
-                      int show_command) {
+int APIENTRY wWinMain(_In_ HINSTANCE, _In_opt_ HINSTANCE, _In_ LPWSTR,
+                      _In_ int) {
   // Attach to console when present (e.g., 'flutter run') or create a
   // new console when running with a debugger.
   if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent()) {

--- a/example/windows/main.cpp
+++ b/example/windows/main.cpp
@@ -90,7 +90,7 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE prev, wchar_t *command_line,
   std::chrono::nanoseconds wait_duration(0);
   // Run until the window is closed.
   while (window.GetHandle() != nullptr) {
-    MsgWaitForMultipleObjects(0, NULL, FALSE,
+    MsgWaitForMultipleObjects(0, nullptr, FALSE,
                               static_cast<DWORD>(wait_duration.count() / 1000),
                               QS_ALLINPUT);
     MSG message;

--- a/example/windows/win32_window.cc
+++ b/example/windows/win32_window.cc
@@ -13,7 +13,7 @@ namespace {
 // constant for machines running at 100% scaling.
 constexpr int kBaseDpi = 96;
 
-constexpr LPCWSTR kClassName = L"CLASSNAME";
+constexpr const wchar_t kClassName[] = L"CLASSNAME";
 
 // Scale helper to convert logical scaler values to physical using passed in
 // scale factor
@@ -70,12 +70,11 @@ LRESULT CALLBACK Win32Window::WndProc(HWND const window, UINT const message,
                                       WPARAM const wparam,
                                       LPARAM const lparam) noexcept {
   if (message == WM_NCCREATE) {
-    auto cs = reinterpret_cast<CREATESTRUCT *>(lparam);
+    auto window_struct = reinterpret_cast<CREATESTRUCT *>(lparam);
     SetWindowLongPtr(window, GWLP_USERDATA,
-                     reinterpret_cast<LONG_PTR>(cs->lpCreateParams));
+                     reinterpret_cast<LONG_PTR>(window_struct->lpCreateParams));
 
-    auto that = static_cast<Win32Window *>(cs->lpCreateParams);
-
+    auto that = static_cast<Win32Window *>(window_struct->lpCreateParams);
     that->window_handle_ = window;
   } else if (Win32Window *that = GetThisFromHandle(window)) {
     return that->MessageHandler(window, message, wparam, lparam);

--- a/example/windows/win32_window.cc
+++ b/example/windows/win32_window.cc
@@ -21,6 +21,16 @@ int Scale(int source, double scale_factor) {
   return static_cast<int>(source * scale_factor);
 }
 
+// Returns the DPI for the monitor containing, or closest to, |point|.
+UINT GetDpiForMonitorAtPoint(const Win32Window::Point &point) {
+  const POINT target_point = {static_cast<LONG>(point.x),
+                              static_cast<LONG>(point.y)};
+  HMONITOR monitor = MonitorFromPoint(target_point, MONITOR_DEFAULTTONEAREST);
+  UINT dpi_x = 0, dpi_y = 0;
+  GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpi_x, &dpi_y);
+  return dpi_x;
+}
+
 }  // namespace
 
 Win32Window::Win32Window() {}
@@ -33,12 +43,8 @@ bool Win32Window::CreateAndShow(const std::wstring &title, const Point &origin,
 
   WNDCLASS window_class = RegisterWindowClass();
 
-  HMONITOR defaut_monitor =
-      MonitorFromWindow(nullptr, MONITOR_DEFAULTTOPRIMARY);
-  UINT dpi_x = 0, dpi_y = 0;
-  GetDpiForMonitor(defaut_monitor, MDT_EFFECTIVE_DPI, &dpi_x, &dpi_y);
-
-  double scale_factor = static_cast<double>(dpi_x) / kBaseDpi;
+  double scale_factor =
+      static_cast<double>(GetDpiForMonitorAtPoint(origin)) / kBaseDpi;
 
   HWND window = CreateWindow(
       window_class.lpszClassName, title.c_str(),
@@ -140,7 +146,7 @@ Win32Window *Win32Window::GetThisFromHandle(HWND const window) noexcept {
 
 void Win32Window::SetChildContent(HWND content) {
   child_content_ = content;
-  auto res = SetParent(content, window_handle_);
+  SetParent(content, window_handle_);
   RECT frame;
   GetClientRect(window_handle_, &frame);
 

--- a/example/windows/win32_window.h
+++ b/example/windows/win32_window.h
@@ -31,7 +31,7 @@ class Win32Window {
   };
 
   Win32Window();
-  ~Win32Window();
+  virtual ~Win32Window();
 
   // Creates and shows a win32 window with |title| and position and size using
   // |origin| and |size|. New windows are created on the default monitor. Window

--- a/plugins/file_chooser/windows/file_chooser.vcxproj
+++ b/plugins/file_chooser/windows/file_chooser.vcxproj
@@ -79,6 +79,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -120,6 +121,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/file_chooser/windows/file_chooser.vcxproj
+++ b/plugins/file_chooser/windows/file_chooser.vcxproj
@@ -75,7 +75,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>
@@ -115,7 +115,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>

--- a/plugins/file_chooser/windows/file_chooser.vcxproj
+++ b/plugins/file_chooser/windows/file_chooser.vcxproj
@@ -79,7 +79,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -121,7 +121,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/file_chooser/windows/file_chooser.vcxproj
+++ b/plugins/file_chooser/windows/file_chooser.vcxproj
@@ -72,12 +72,13 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -110,7 +111,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -118,6 +119,7 @@
       <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/file_chooser/windows/file_chooser_plugin.cpp
+++ b/plugins/file_chooser/windows/file_chooser_plugin.cpp
@@ -150,8 +150,8 @@ class DialogWrapper {
       }
       filter_specs.push_back({filter_names.back().c_str(), spec.c_str()});
     }
-    last_result_ =
-        dialog_->SetFileTypes(filter_specs.size(), filter_specs.data());
+    last_result_ = dialog_->SetFileTypes(static_cast<UINT>(filter_specs.size()),
+                                         filter_specs.data());
   }
 
   // Displays the dialog, and returns the selected file or files as an

--- a/plugins/file_chooser/windows/file_chooser_plugin.cpp
+++ b/plugins/file_chooser/windows/file_chooser_plugin.cpp
@@ -57,7 +57,7 @@ std::wstring WideStringFromChars(const char *chars) {
 // Returns the path for |shell_item| as a UTF-8 string, or an
 // empty string on failure.
 std::string GetPathForShellItem(IShellItem *shell_item) {
-  PWSTR wide_path = nullptr;
+  wchar_t *wide_path = nullptr;
   if (!SUCCEEDED(shell_item->GetDisplayName(SIGDN_FILESYSPATH, &wide_path))) {
     return "";
   }

--- a/plugins/flutter_plugins/path_provider_fde/windows/path_provider_fde.vcxproj
+++ b/plugins/flutter_plugins/path_provider_fde/windows/path_provider_fde.vcxproj
@@ -79,6 +79,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -120,6 +121,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/flutter_plugins/path_provider_fde/windows/path_provider_fde.vcxproj
+++ b/plugins/flutter_plugins/path_provider_fde/windows/path_provider_fde.vcxproj
@@ -75,7 +75,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>
@@ -115,7 +115,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>

--- a/plugins/flutter_plugins/path_provider_fde/windows/path_provider_fde.vcxproj
+++ b/plugins/flutter_plugins/path_provider_fde/windows/path_provider_fde.vcxproj
@@ -79,7 +79,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -121,7 +121,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/flutter_plugins/path_provider_fde/windows/path_provider_fde.vcxproj
+++ b/plugins/flutter_plugins/path_provider_fde/windows/path_provider_fde.vcxproj
@@ -72,12 +72,13 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -110,7 +111,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -118,6 +119,7 @@
       <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/flutter_plugins/path_provider_fde/windows/path_provider_plugin.cpp
+++ b/plugins/flutter_plugins/path_provider_fde/windows/path_provider_plugin.cpp
@@ -37,7 +37,7 @@ std::string StdStringFromWideChars(wchar_t *wide_chars) {
 // Gets the path to the given folder ID, without verifying that it exists,
 // or an empty string on failure.
 std::string GetFolderPath(REFKNOWNFOLDERID folder_id) {
-  PWSTR wide_path = nullptr;
+  wchar_t *wide_path = nullptr;
   if (!SUCCEEDED(SHGetKnownFolderPath(folder_id, KF_FLAG_DONT_VERIFY, nullptr,
                                       &wide_path))) {
     return "";
@@ -113,8 +113,8 @@ void PathProviderPlugin::HandleMethodCall(
     const flutter::MethodCall<EncodableValue> &method_call,
     std::unique_ptr<flutter::MethodResult<EncodableValue>> result) {
   if (method_call.method_name().compare("getTemporaryDirectory") == 0) {
-    TCHAR path_buffer[MAX_PATH];
-    UINT length = GetTempPath(MAX_PATH, path_buffer);
+    wchar_t path_buffer[MAX_PATH];
+    DWORD length = GetTempPath(MAX_PATH, path_buffer);
     if (length == 0 || length > MAX_PATH) {
       result->Error("Unable to get temporary path");
       return;

--- a/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
+++ b/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
@@ -78,6 +78,7 @@
       <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -118,6 +119,7 @@
       <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
+++ b/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
@@ -79,6 +79,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -120,6 +121,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
+++ b/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
@@ -75,7 +75,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>
@@ -115,7 +115,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>

--- a/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
+++ b/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_fde.vcxproj
@@ -79,7 +79,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -121,7 +121,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_plugin.cpp
+++ b/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_plugin.cpp
@@ -13,11 +13,13 @@
 // limitations under the License.
 #include "url_launcher_plugin.h"
 
+// Must be before VersionHelpers.h
+#include <windows.h>
+
 #include <VersionHelpers.h>
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar.h>
 #include <flutter/standard_method_codec.h>
-#include <windows.h>
 
 #include <memory>
 #include <sstream>

--- a/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_plugin.cpp
+++ b/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_plugin.cpp
@@ -13,12 +13,12 @@
 // limitations under the License.
 #include "url_launcher_plugin.h"
 
-#include <windows.h>
-
 #include <VersionHelpers.h>
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar.h>
 #include <flutter/standard_method_codec.h>
+#include <windows.h>
+
 #include <memory>
 #include <sstream>
 
@@ -93,8 +93,8 @@ void UrlLauncherPlugin::HandleMethodCall(
                                  // truncation from 'HINSTANCE' to 'int'
 #pragma warning(disable : 4302)  // warning C4302: 'type cast': truncation from
                                  // 'HINSTANCE' to 'int'
-    int status =
-        reinterpret_cast<int>(ShellExecute(NULL, TEXT("open"), wurl.c_str(), NULL, NULL, SW_SHOWNORMAL));
+    int status = reinterpret_cast<int>(ShellExecute(
+        nullptr, TEXT("open"), wurl.c_str(), nullptr, nullptr, SW_SHOWNORMAL));
 #pragma warning(pop)
 
     if (status <= 32) {

--- a/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_plugin.cpp
+++ b/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_plugin.cpp
@@ -90,14 +90,8 @@ void UrlLauncherPlugin::HandleMethodCall(
     size_t outSize;
     mbstowcs_s(&outSize, &wurl[0], size, url.c_str(), size - 1);
 
-#pragma warning(push)
-#pragma warning(disable : 4311)  // warning C4311: 'type cast': pointer
-                                 // truncation from 'HINSTANCE' to 'int'
-#pragma warning(disable : 4302)  // warning C4302: 'type cast': truncation from
-                                 // 'HINSTANCE' to 'int'
-    int status = reinterpret_cast<int>(ShellExecute(
-        nullptr, TEXT("open"), wurl.c_str(), nullptr, nullptr, SW_SHOWNORMAL));
-#pragma warning(pop)
+    int status = static_cast<int>(reinterpret_cast<INT_PTR>(ShellExecute(
+        nullptr, TEXT("open"), wurl.c_str(), nullptr, nullptr, SW_SHOWNORMAL)));
 
     if (status <= 32) {
       std::ostringstream error_message;

--- a/plugins/sample/README.md
+++ b/plugins/sample/README.md
@@ -29,7 +29,6 @@ almost certainly not work with the final Flutter Windows and Linux support.
 ### Windows
 
 - Change `sample` in all the filenames to your plugin's name.
-- Change the `ProjectName` in plugin.vcxproj to your plugin's name.
 - Change the `FlutterPluginName` in `PluginInfo.props` to your plugin's name.
 - Look for comments containing `***` in the `.h` and `.cpp` file, and update
   the code as described in the comment.

--- a/plugins/sample/README.md
+++ b/plugins/sample/README.md
@@ -29,6 +29,7 @@ almost certainly not work with the final Flutter Windows and Linux support.
 ### Windows
 
 - Change `sample` in all the filenames to your plugin's name.
+- Change the `ProjectName` in plugin.vcxproj to your plugin's name.
 - Change the `FlutterPluginName` in `PluginInfo.props` to your plugin's name.
 - Look for comments containing `***` in the `.h` and `.cpp` file, and update
   the code as described in the comment.

--- a/plugins/sample/windows/sample.vcxproj
+++ b/plugins/sample/windows/sample.vcxproj
@@ -79,6 +79,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -120,6 +121,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/sample/windows/sample.vcxproj
+++ b/plugins/sample/windows/sample.vcxproj
@@ -75,7 +75,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>
@@ -115,7 +115,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>

--- a/plugins/sample/windows/sample.vcxproj
+++ b/plugins/sample/windows/sample.vcxproj
@@ -79,7 +79,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -121,7 +121,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/sample/windows/sample.vcxproj
+++ b/plugins/sample/windows/sample.vcxproj
@@ -72,12 +72,13 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -110,7 +111,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -118,6 +119,7 @@
       <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/window_size/windows/window_size.vcxproj
+++ b/plugins/window_size/windows/window_size.vcxproj
@@ -79,6 +79,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -120,6 +121,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/window_size/windows/window_size.vcxproj
+++ b/plugins/window_size/windows/window_size.vcxproj
@@ -75,7 +75,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>
@@ -115,7 +115,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>

--- a/plugins/window_size/windows/window_size.vcxproj
+++ b/plugins/window_size/windows/window_size.vcxproj
@@ -79,7 +79,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -121,7 +121,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/window_size/windows/window_size.vcxproj
+++ b/plugins/window_size/windows/window_size.vcxproj
@@ -72,12 +72,13 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -110,7 +111,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -118,6 +119,7 @@
       <PreprocessorDefinitions>NDEBUG;FLUTTER_PLUGIN_IMPL;_WINDOWS;_USRDLL;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>false</ExceptionHandling>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/plugins/window_size/windows/window_size_plugin.cpp
+++ b/plugins/window_size/windows/window_size_plugin.cpp
@@ -77,8 +77,8 @@ EncodableValue GetPlatformChannelRepresentationForMonitor(HMONITOR monitor) {
   });
 }
 
-BOOL CALLBACK MonitorRepresentationEnumProc(HMONITOR monitor, HDC, RECT *,
-                                            LPARAM list_ref) {
+BOOL CALLBACK MonitorRepresentationEnumProc(HMONITOR monitor, HDC hdc,
+                                            LPRECT clip, LPARAM list_ref) {
   EncodableValue *monitors = reinterpret_cast<EncodableValue *>(list_ref);
   monitors->ListValue().push_back(
       GetPlatformChannelRepresentationForMonitor(monitor));

--- a/plugins/window_size/windows/window_size_plugin.cpp
+++ b/plugins/window_size/windows/window_size_plugin.cpp
@@ -49,8 +49,10 @@ EncodableValue GetPlatformChannelRepresentationForRect(const RECT &rect) {
   return EncodableValue(EncodableList{
       EncodableValue(static_cast<double>(rect.left)),
       EncodableValue(static_cast<double>(rect.top)),
-      EncodableValue(static_cast<double>(rect.right - rect.left)),
-      EncodableValue(static_cast<double>(rect.bottom - rect.top)),
+      EncodableValue(static_cast<double>(rect.right) -
+                     static_cast<double>(rect.left)),
+      EncodableValue(static_cast<double>(rect.bottom) -
+                     static_cast<double>(rect.top)),
   });
 }
 
@@ -76,8 +78,8 @@ EncodableValue GetPlatformChannelRepresentationForMonitor(HMONITOR monitor) {
   });
 }
 
-BOOL CALLBACK MonitorRepresentationEnumProc(HMONITOR monitor, HDC hdc,
-                                            RECT *clip, LPARAM list_ref) {
+BOOL CALLBACK MonitorRepresentationEnumProc(HMONITOR monitor, HDC, RECT *,
+                                            LPARAM list_ref) {
   EncodableValue *monitors = reinterpret_cast<EncodableValue *>(list_ref);
   monitors->ListValue().push_back(
       GetPlatformChannelRepresentationForMonitor(monitor));

--- a/plugins/window_size/windows/window_size_plugin.cpp
+++ b/plugins/window_size/windows/window_size_plugin.cpp
@@ -14,7 +14,6 @@
 #include "window_size_plugin.h"
 
 #include <ShellScalingApi.h>
-#include <VersionHelpers.h>
 #include <flutter/flutter_view.h>
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>

--- a/testbed/windows/Runner.vcxproj
+++ b/testbed/windows/Runner.vcxproj
@@ -72,7 +72,7 @@
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>flutter_windows.dll.lib;Shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -119,7 +119,7 @@
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/testbed/windows/Runner.vcxproj
+++ b/testbed/windows/Runner.vcxproj
@@ -70,7 +70,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>flutter_windows.dll.lib;Shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -115,7 +115,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/testbed/windows/Runner.vcxproj
+++ b/testbed/windows/Runner.vcxproj
@@ -72,6 +72,7 @@
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>flutter_windows.dll.lib;Shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -118,6 +119,7 @@
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/wd4100 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/testbed/windows/Runner.vcxproj
+++ b/testbed/windows/Runner.vcxproj
@@ -64,13 +64,14 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <AdditionalDependencies>flutter_windows.dll.lib;Shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -107,7 +108,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -116,6 +117,7 @@
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/testbed/windows/main.cpp
+++ b/testbed/windows/main.cpp
@@ -48,8 +48,8 @@ std::string GetExecutableDirectory() {
 
 }  // namespace
 
-int APIENTRY wWinMain(_In_ HINSTANCE, _In_opt_ HINSTANCE, _In_ LPWSTR,
-                      _In_ int) {
+int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
+                      _In_ wchar_t *command_line, _In_ int show_command) {
   // Attach to console when present (e.g., 'flutter run') or create a
   // new console when running with a debugger.
   if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent()) {

--- a/testbed/windows/main.cpp
+++ b/testbed/windows/main.cpp
@@ -35,7 +35,7 @@ std::string GetExecutableDirectory() {
     std::cerr << "Couldn't locate executable" << std::endl;
     return "";
   }
-  std::wstring_convert<std::codecvt_utf8<wchar_t>> wide_to_utf8;
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> wide_to_utf8;
   std::string executable_path = wide_to_utf8.to_bytes(buffer);
   size_t last_separator_position = executable_path.find_last_of('\\');
   if (last_separator_position == std::string::npos) {
@@ -48,8 +48,8 @@ std::string GetExecutableDirectory() {
 
 }  // namespace
 
-int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE prev, wchar_t *command_line,
-                      int show_command) {
+int APIENTRY wWinMain(_In_ HINSTANCE, _In_opt_ HINSTANCE, _In_ LPWSTR,
+                      _In_ int) {
   // Attach to console when present (e.g., 'flutter run') or create a
   // new console when running with a debugger.
   if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent()) {

--- a/testbed/windows/main.cpp
+++ b/testbed/windows/main.cpp
@@ -93,7 +93,7 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE prev, wchar_t *command_line,
   std::chrono::nanoseconds wait_duration(0);
   // Run until the window is closed.
   while (window.GetHandle() != nullptr) {
-    MsgWaitForMultipleObjects(0, NULL, FALSE,
+    MsgWaitForMultipleObjects(0, nullptr, FALSE,
                               static_cast<DWORD>(wait_duration.count() / 1000),
                               QS_ALLINPUT);
     MSG message;

--- a/testbed/windows/win32_window.cc
+++ b/testbed/windows/win32_window.cc
@@ -146,7 +146,7 @@ Win32Window *Win32Window::GetThisFromHandle(HWND const window) noexcept {
 
 void Win32Window::SetChildContent(HWND content) {
   child_content_ = content;
-  auto res = SetParent(content, window_handle_);
+  SetParent(content, window_handle_);
   RECT frame;
   GetClientRect(window_handle_, &frame);
 

--- a/testbed/windows/win32_window.cc
+++ b/testbed/windows/win32_window.cc
@@ -13,7 +13,7 @@ namespace {
 // constant for machines running at 100% scaling.
 constexpr int kBaseDpi = 96;
 
-constexpr LPCWSTR kClassName = L"CLASSNAME";
+constexpr const wchar_t kClassName[] = L"CLASSNAME";
 
 // Scale helper to convert logical scaler values to physical using passed in
 // scale factor
@@ -70,12 +70,11 @@ LRESULT CALLBACK Win32Window::WndProc(HWND const window, UINT const message,
                                       WPARAM const wparam,
                                       LPARAM const lparam) noexcept {
   if (message == WM_NCCREATE) {
-    auto cs = reinterpret_cast<CREATESTRUCT *>(lparam);
+    auto window_struct = reinterpret_cast<CREATESTRUCT *>(lparam);
     SetWindowLongPtr(window, GWLP_USERDATA,
-                     reinterpret_cast<LONG_PTR>(cs->lpCreateParams));
+                     reinterpret_cast<LONG_PTR>(window_struct->lpCreateParams));
 
-    auto that = static_cast<Win32Window *>(cs->lpCreateParams);
-
+    auto that = static_cast<Win32Window *>(window_struct->lpCreateParams);
     that->window_handle_ = window;
   } else if (Win32Window *that = GetThisFromHandle(window)) {
     return that->MessageHandler(window, message, wparam, lparam);
@@ -118,7 +117,7 @@ Win32Window::MessageHandler(HWND hwnd, UINT const message, WPARAM const wparam,
 
     // Messages that are directly forwarded to embedding.
     case WM_FONTCHANGE:
-      SendMessage(child_content_, WM_FONTCHANGE, NULL, NULL);
+      SendMessage(child_content_, WM_FONTCHANGE, nullptr, nullptr);
       return 0;
   }
 

--- a/testbed/windows/win32_window.cc
+++ b/testbed/windows/win32_window.cc
@@ -21,6 +21,16 @@ int Scale(int source, double scale_factor) {
   return static_cast<int>(source * scale_factor);
 }
 
+// Returns the DPI for the monitor containing, or closest to, |point|.
+UINT GetDpiForMonitorAtPoint(const Win32Window::Point &point) {
+  const POINT target_point = {static_cast<LONG>(point.x),
+                              static_cast<LONG>(point.y)};
+  HMONITOR monitor = MonitorFromPoint(target_point, MONITOR_DEFAULTTONEAREST);
+  UINT dpi_x = 0, dpi_y = 0;
+  GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpi_x, &dpi_y);
+  return dpi_x;
+}
+
 }  // namespace
 
 Win32Window::Win32Window() {}
@@ -33,12 +43,8 @@ bool Win32Window::CreateAndShow(const std::wstring &title, const Point &origin,
 
   WNDCLASS window_class = RegisterWindowClass();
 
-  HMONITOR defaut_monitor =
-      MonitorFromWindow(nullptr, MONITOR_DEFAULTTOPRIMARY);
-  UINT dpi_x = 0, dpi_y = 0;
-  GetDpiForMonitor(defaut_monitor, MDT_EFFECTIVE_DPI, &dpi_x, &dpi_y);
-
-  double scale_factor = static_cast<double>(dpi_x) / kBaseDpi;
+  double scale_factor =
+      static_cast<double>(GetDpiForMonitorAtPoint(origin)) / kBaseDpi;
 
   HWND window = CreateWindow(
       window_class.lpszClassName, title.c_str(),
@@ -117,7 +123,7 @@ Win32Window::MessageHandler(HWND hwnd, UINT const message, WPARAM const wparam,
 
     // Messages that are directly forwarded to embedding.
     case WM_FONTCHANGE:
-      SendMessage(child_content_, WM_FONTCHANGE, nullptr, nullptr);
+      SendMessage(child_content_, WM_FONTCHANGE, NULL, NULL);
       return 0;
   }
 

--- a/testbed/windows/win32_window.h
+++ b/testbed/windows/win32_window.h
@@ -31,7 +31,7 @@ class Win32Window {
   };
 
   Win32Window();
-  ~Win32Window();
+  virtual ~Win32Window();
 
   // Creates and shows a win32 window with |title| and position and size using
   // |origin| and |size|. New windows are created on the default monitor. Window


### PR DESCRIPTION
This is a complete pass over all the code and projects, making a variety of changes:
- Updating style to better match Google style for Windows code (e.g., avoiding LP* types)
- Increasing the warning level for everything from W3 to W4
- Enabling warnings as errors (WX)
- Fixing all warnings
  - Including correctly disabling exceptions in STL via a Define
- clang-formatted some missed files

Fixes #662 
Fixes #582 
Addresses Windows portion of #343 