### PR TITLE
Use plugin symlinks on Windows and Linux

### DIFF
--- a/example/linux/Makefile
+++ b/example/linux/Makefile
@@ -23,11 +23,10 @@ SYSTEM_LIBRARIES=
 EXTRA_CXXFLAGS=
 EXTRA_CPPFLAGS=
 EXTRA_LDFLAGS=
+# Plugins to include in the build.
+PLUGINS=
 
-# Default build type. For a release build, set BUILD=release.
-# Currently this only sets NDEBUG, which is used to control the flags passed
-# to the Flutter engine in the example shell, and not the complation settings
-# (e.g., optimization level) of the C++ code.
+# Default build type.
 BUILD=debug
 
 FLUTTER_EPHEMERAL_DIR=flutter/ephemeral
@@ -39,6 +38,7 @@ include $(FLUTTER_CONFIG_FILE)
 # Dependency locations
 FLUTTER_APP_DIR=$(CURDIR)/..
 FLUTTER_APP_BUILD_DIR=$(FLUTTER_APP_DIR)/build
+PLUGINS_DIR=$(FLUTTER_EPHEMERAL_DIR)/.plugin_symlinks
 
 OUT_DIR=$(FLUTTER_APP_BUILD_DIR)/linux
 OBJ_DIR=$(OUT_DIR)/obj/$(BUILD)
@@ -56,6 +56,15 @@ ICU_DATA_NAME=icudtl.dat
 ICU_DATA_SOURCE=$(FLUTTER_EPHEMERAL_DIR)/$(ICU_DATA_NAME)
 FLUTTER_ASSETS_NAME=flutter_assets
 FLUTTER_ASSETS_SOURCE=$(FLUTTER_APP_BUILD_DIR)/$(FLUTTER_ASSETS_NAME)
+
+# The name of each plugin library is the name of the plugin with _plugin
+# appended.
+PLUGIN_LIB_NAMES=$(foreach plugin,$(PLUGINS),$(plugin)_plugin)
+PLUGIN_LIBS=$(foreach plugin,$(PLUGIN_LIB_NAMES),$(OUT_DIR)/lib$(plugin).so)
+EXTRA_BUNDLED_LIBRARIES+=$(PLUGIN_LIBS)
+EXTRA_LDFLAGS+=$(patsubst %,-l%,$(PLUGIN_LIB_NAMES))
+# The plugin builds place all published headers in a top-level include/.
+EXTRA_CPPFLAGS+=-I$(OUT_DIR)/include
 
 # Bundle structure
 BUNDLE_OUT_DIR=$(OUT_DIR)/$(BUILD)
@@ -124,8 +133,24 @@ $(BIN_OUT): $(OBJ_FILES) $(ALL_LIBS_OUT)
 	mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OBJ_FILES) $(LDFLAGS) -o $@
 
-$(WRAPPER_SOURCES) $(FLUTTER_LIB) $(ICU_DATA_SOURCE) $(FLUTTER_ASSETS_SOURCE): \
-	| sync
+$(WRAPPER_SOURCES) $(FLUTTER_LIB) $(ICU_DATA_SOURCE) $(FLUTTER_ASSETS_SOURCE) \
+	$(PLUGINS): | sync
+
+# Compilation depends on plugin headers that are copied as part of the
+# plugin builds, so ensure those happen first.
+# TODO: Restructure to avoid the need for this.
+$(OBJ_FILES): | $(EXTRA_BUNDLED_LIBRARIES)
+
+.PHONY: $(PLUGINS)
+$(PLUGINS):
+	make -C $(PLUGINS_DIR)/$@/linux \
+		OUT_DIR=$(OUT_DIR) \
+		FLUTTER_EPHEMERAL_DIR="$(abspath $(FLUTTER_EPHEMERAL_DIR))"
+
+# Plugin library bundling pattern.
+$(BUNDLE_LIB_DIR)/%: $(OUT_DIR)/%
+	mkdir -p $(BUNDLE_LIB_DIR)
+	cp $< $@
 
 $(FLUTTER_LIB_OUT): $(FLUTTER_LIB)
 	mkdir -p $(@D)

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -79,7 +79,7 @@ Adding it to the build system is currently a manual process. To add a plugin:
 - Open your project's `Makefile`
 - Add the plugins you are using to the `PLUGINS` variable near the top
 - Add an explicit build rule for each plugin in the Targets section. For
-  instance, for the sampe plugin:
+  instance, for the sample plugin:
   ```
   $(OUT_DIR)/libsample_plugin.so: | sample
   ```

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -75,14 +75,20 @@ $ sudo apt-get install libgtk-3-dev pkg-config
 The `flutter` tool will generate a plugin registrant for you, so you
 won't need to change any C++ code.
 
-Adding it to the build system is still entirely manual, and currently
-quite complicated. Run:
+Adding it to the build system is currently a manual process. To add a plugin:
+- Open your project's `Makefile`
+- Add the plugins you are using to the `PLUGINS` variable near the top
+- Add an explicit build rule for each plugin in the Targets section. For
+  instance, for the sampe plugin:
+  ```
+  $(OUT_DIR)/libsample_plugin.so: | sample
+  ```
+
+Run:
 ```
-$ diff u example/linux/Makefile testbed/linux/Makefile
+$ diff -u example/linux/Makefile testbed/linux/Makefile
 ```
-to see what kinds of changes are necessary to the Makefile, and adapt based
-on the plugins you are using. There may be change to simplify this process
-in the short-to-medium term while a full solution is decided on.
+to see an example of what the changes should look like.
 
 **Note:** The eventual implementation of plugin management for Linux will
 likely be entirely different from this approach.

--- a/plugins/flutter_plugins/url_launcher_fde/linux/Makefile
+++ b/plugins/flutter_plugins/url_launcher_fde/linux/Makefile
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 # The name of the plugin.
-# The primary source file is assumed to be $(PLUGIN_NAME).cc, with
-# $(PLUGIN_NAME).h as the public header meant for inclusion by the application.
-PLUGIN_NAME=url_launcher_plugin
+PLUGIN_NAME=url_launcher_fde_plugin
+# This is changed from the stock Makefile since the class name doesn't match
+# the plugin name. This will need to be made more flexible when Linux plugin
+# structure is revisited.
+PLUGIN_SOURCE_NAME=url_launcher_plugin
 # Any files other than the plugin class files that need to be compiled.
 EXTRA_SOURCES=
 # Extra flags (e.g., for library dependencies).
@@ -62,8 +64,8 @@ WRAPPER_SOURCES= \
 
 # Use abspath for extra sources, which may also contain relative paths (see
 # note above about WRAPPER_ROOT).
-SOURCES=$(PLUGIN_NAME).cc $(WRAPPER_SOURCES) $(abspath $(EXTRA_SOURCES))
-PUBLIC_HEADER=$(PLUGIN_NAME).h
+SOURCES=$(PLUGIN_SOURCE_NAME).cc $(WRAPPER_SOURCES) $(abspath $(EXTRA_SOURCES))
+PUBLIC_HEADER=$(PLUGIN_SOURCE_NAME).h
 
 WRAPPER_INCLUDE_DIR=$(WRAPPER_ROOT)/include
 INCLUDE_DIRS=$(FLUTTER_EPHEMERAL_DIR) $(WRAPPER_INCLUDE_DIR)

--- a/testbed/linux/Makefile
+++ b/testbed/linux/Makefile
@@ -23,19 +23,16 @@ SYSTEM_LIBRARIES=gtk+-3.0 x11
 EXTRA_CXXFLAGS=
 EXTRA_CPPFLAGS=
 EXTRA_LDFLAGS=
+# Plugins to include in the build.
+PLUGINS=\
+	color_panel \
+	file_chooser \
+	menubar \
+	sample \
+	url_launcher_fde \
+	window_size
 
-# The location of the flutter-desktop-embedding repository.
-FDE_ROOT=$(CURDIR)/../..
-# Plugins to include from the flutter-desktop-embedding plugins/ directory.
-PLUGIN_NAMES=color_panel file_chooser menubar sample window_size
-# Additional plugins to include from the plugins/flutter_plugins subdirectory.
-# Do not include the _fde suffix.
-FLUTTER_PLUGIN_NAMES=url_launcher
-
-
-# Default build type. For a release build, set BUILD=release.
-# Currently this only sets NDEBUG, and not the complation settings
-# (e.g., optimization level) of the C++ code.
+# Default build type.
 BUILD=debug
 
 FLUTTER_EPHEMERAL_DIR=flutter/ephemeral
@@ -47,6 +44,7 @@ include $(FLUTTER_CONFIG_FILE)
 # Dependency locations
 FLUTTER_APP_DIR=$(CURDIR)/..
 FLUTTER_APP_BUILD_DIR=$(FLUTTER_APP_DIR)/build
+PLUGINS_DIR=$(FLUTTER_EPHEMERAL_DIR)/.plugin_symlinks
 
 OUT_DIR=$(FLUTTER_APP_BUILD_DIR)/linux
 OBJ_DIR=$(OUT_DIR)/obj/$(BUILD)
@@ -65,14 +63,9 @@ ICU_DATA_SOURCE=$(FLUTTER_EPHEMERAL_DIR)/$(ICU_DATA_NAME)
 FLUTTER_ASSETS_NAME=flutter_assets
 FLUTTER_ASSETS_SOURCE=$(FLUTTER_APP_BUILD_DIR)/$(FLUTTER_ASSETS_NAME)
 
-# Plugin-related additions
-# Currently plugins are refenced by direct source path. Eventually this should
-# be pub-based instead as on other platforms.
-PLUGINS_DIR=$(FDE_ROOT)/plugins
-FLUTTER_PLUGINS_DIR=$(PLUGINS_DIR)/flutter_plugins
-# The name of each plugin library is the name of its directory with _plugin
+# The name of each plugin library is the name of the plugin with _plugin
 # appended.
-PLUGIN_LIB_NAMES=$(foreach plugin,$(PLUGIN_NAMES) $(FLUTTER_PLUGIN_NAMES),$(plugin)_plugin)
+PLUGIN_LIB_NAMES=$(foreach plugin,$(PLUGINS),$(plugin)_plugin)
 PLUGIN_LIBS=$(foreach plugin,$(PLUGIN_LIB_NAMES),$(OUT_DIR)/lib$(plugin).so)
 EXTRA_BUNDLED_LIBRARIES+=$(PLUGIN_LIBS)
 EXTRA_LDFLAGS+=$(patsubst %,-l%,$(PLUGIN_LIB_NAMES))
@@ -147,30 +140,24 @@ $(BIN_OUT): $(OBJ_FILES) $(ALL_LIBS_OUT)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OBJ_FILES) $(LDFLAGS) -o $@
 
 $(WRAPPER_SOURCES) $(FLUTTER_LIB) $(ICU_DATA_SOURCE) $(FLUTTER_ASSETS_SOURCE) \
-	$(PLUGIN_NAMES) $(FLUTTER_PLUGIN_NAMES): | sync
+	$(PLUGINS): | sync
 
 # Implicit rules won't match phony targets, so list plugin builds explicitly.
-$(OUT_DIR)/libsample_plugin.so: | sample
 $(OUT_DIR)/libcolor_panel_plugin.so: | color_panel
 $(OUT_DIR)/libfile_chooser_plugin.so: | file_chooser
 $(OUT_DIR)/libmenubar_plugin.so: | menubar
+$(OUT_DIR)/libsample_plugin.so: | sample
+$(OUT_DIR)/liburl_launcher_fde_plugin.so: | url_launcher_fde
 $(OUT_DIR)/libwindow_size_plugin.so: | window_size
-$(OUT_DIR)/liburl_launcher_plugin.so: | url_launcher
 
 # Compilation depends on plugin headers that are copied as part of the
 # plugin builds, so ensure those happen first.
 # TODO: Restructure to avoid the need for this.
-$(OBJ_FILES) : | $(EXTRA_BUNDLED_LIBRARIES)
+$(OBJ_FILES): | $(EXTRA_BUNDLED_LIBRARIES)
 
-.PHONY: $(PLUGIN_NAMES)
-$(PLUGIN_NAMES):
+.PHONY: $(PLUGINS)
+$(PLUGINS):
 	make -C $(PLUGINS_DIR)/$@/linux \
-		OUT_DIR=$(OUT_DIR) \
-		FLUTTER_EPHEMERAL_DIR="$(abspath $(FLUTTER_EPHEMERAL_DIR))"
-
-.PHONY: $(FLUTTER_PLUGIN_NAMES)
-$(FLUTTER_PLUGIN_NAMES):
-	make -C $(FLUTTER_PLUGINS_DIR)/$@_fde/linux \
 		OUT_DIR=$(OUT_DIR) \
 		FLUTTER_EPHEMERAL_DIR="$(abspath $(FLUTTER_EPHEMERAL_DIR))"
 

--- a/testbed/windows/Runner.sln
+++ b/testbed/windows/Runner.sln
@@ -13,29 +13,29 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Runner", "Runner.vcxproj", 
 		{D9433AE2-FB49-48D8-A6F9-3C71021E73E4} = {D9433AE2-FB49-48D8-A6F9-3C71021E73E4}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sample", "..\..\plugins\sample\windows\plugin.vcxproj", "{95E21B2C-C18A-4CED-8509-585CB2570FDE}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sample", "Flutter\ephemeral\.plugin_symlinks\sample\windows\plugin.vcxproj", "{95E21B2C-C18A-4CED-8509-585CB2570FDE}"
 	ProjectSection(ProjectDependencies) = postProject
 		{6419BF13-6ECD-4CD2-9E85-E566A1F03F8F} = {6419BF13-6ECD-4CD2-9E85-E566A1F03F8F}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "url_launcher_fde", "..\..\plugins\flutter_plugins\url_launcher_fde\windows\plugin.vcxproj", "{18F565CD-7BD5-459C-9FEB-2E2379E88105}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "url_launcher_fde", "Flutter\ephemeral\.plugin_symlinks\url_launcher_fde\windows\plugin.vcxproj", "{18F565CD-7BD5-459C-9FEB-2E2379E88105}"
 	ProjectSection(ProjectDependencies) = postProject
 		{6419BF13-6ECD-4CD2-9E85-E566A1F03F8F} = {6419BF13-6ECD-4CD2-9E85-E566A1F03F8F}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Flutter Build", "FlutterBuild.vcxproj", "{6419BF13-6ECD-4CD2-9E85-E566A1F03F8F}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "path_provider_fde", "..\..\plugins\flutter_plugins\path_provider_fde\windows\plugin.vcxproj", "{FE855771-7D30-42F7-938E-C57B2AEA68D8}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "path_provider_fde", "Flutter\ephemeral\.plugin_symlinks\path_provider_fde\windows\plugin.vcxproj", "{FE855771-7D30-42F7-938E-C57B2AEA68D8}"
 	ProjectSection(ProjectDependencies) = postProject
 		{6419BF13-6ECD-4CD2-9E85-E566A1F03F8F} = {6419BF13-6ECD-4CD2-9E85-E566A1F03F8F}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "window_size", "..\..\plugins\window_size\windows\plugin.vcxproj", "{9FDE4FCF-34A0-48B0-818B-877485F2AFEB}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "window_size", "Flutter\ephemeral\.plugin_symlinks\window_size\windows\plugin.vcxproj", "{9FDE4FCF-34A0-48B0-818B-877485F2AFEB}"
 	ProjectSection(ProjectDependencies) = postProject
 		{6419BF13-6ECD-4CD2-9E85-E566A1F03F8F} = {6419BF13-6ECD-4CD2-9E85-E566A1F03F8F}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "file_chooser", "..\..\plugins\file_chooser\windows\plugin.vcxproj", "{D9433AE2-FB49-48D8-A6F9-3C71021E73E4}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "file_chooser", "Flutter\ephemeral\.plugin_symlinks\file_chooser\windows\plugin.vcxproj", "{D9433AE2-FB49-48D8-A6F9-3C71021E73E4}"
 	ProjectSection(ProjectDependencies) = postProject
 		{6419BF13-6ECD-4CD2-9E85-E566A1F03F8F} = {6419BF13-6ECD-4CD2-9E85-E566A1F03F8F}
 	EndProjectSection


### PR DESCRIPTION
Switches Windows and Linux to using the new plugin symlinks. This eliminates
the need for project files/makefiles to have developer-specific paths
(especially if pulled via pub).

Now that the plugin plumbing is mostly generic for Linux, most of it in moved
into the example Makefile so that the changes necessary to use plugins are
much more targeted. Updates the documentation for using plugins on Linux
to be more specific now that the process is more straightforward.

Part of #578