### PR TITLE
Check for null on EnableNonClientDpiScaling

### DIFF
--- a/example/windows/win32_window.cc
+++ b/example/windows/win32_window.cc
@@ -34,10 +34,10 @@ void EnableFullDpiSupportIfAvailable(HWND hwnd) {
   auto enable_non_client_dpi_scaling =
       reinterpret_cast<EnableNonClientDpiScaling *>(
           GetProcAddress(user32_module, "EnableNonClientDpiScaling"));
-
-  enable_non_client_dpi_scaling(hwnd);
-
-  FreeLibrary(user32_module);
+  if (enable_non_client_dpi_scaling != nullptr) {
+    enable_non_client_dpi_scaling(hwnd);
+    FreeLibrary(user32_module);
+  }
 }
 }  // namespace
 

--- a/testbed/windows/win32_window.cc
+++ b/testbed/windows/win32_window.cc
@@ -34,10 +34,10 @@ void EnableFullDpiSupportIfAvailable(HWND hwnd) {
   auto enable_non_client_dpi_scaling =
       reinterpret_cast<EnableNonClientDpiScaling *>(
           GetProcAddress(user32_module, "EnableNonClientDpiScaling"));
-
-  enable_non_client_dpi_scaling(hwnd);
-
-  FreeLibrary(user32_module);
+  if (enable_non_client_dpi_scaling != nullptr) {
+    enable_non_client_dpi_scaling(hwnd);
+    FreeLibrary(user32_module);
+  }
 }
 }  // namespace
 


### PR DESCRIPTION
This was causing crashes on Win 7 since that function is not available.