### PR TITLE
Remove TargetPlatform overrides

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -18,8 +18,6 @@ a standard Flutter project.
 ## Dart Differences from Flutter Template
 
 The `main.dart` and `pubspec.yaml` have minor changes to support desktop:
-* `debugDefaultTargetPlatformOverride` is set to avoid 'Unknown platform'
-  exceptions.
 * The font is explicitly set to Roboto, and Roboto is bundled via
   `pubspec.yaml`, to ensure that text displays on all platforms.
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,17 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {
-  // See https://github.com/flutter/flutter/wiki/Desktop-shells#target-platform-override
-  if (!kIsWeb && (Platform.isLinux || Platform.isWindows)) {
-    debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
-  }
-
   runApp(new MyApp());
 }
 
@@ -42,7 +34,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key, this.title}) : super(key: key);
+  const MyHomePage({Key key, this.title}) : super(key: key);
 
   final String title;
 
@@ -74,7 +66,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             Text(
               '$_counter',
-              style: Theme.of(context).textTheme.display1,
+              style: Theme.of(context).textTheme.headline4,
             ),
           ],
         ),

--- a/testbed/lib/main.dart
+++ b/testbed/lib/main.dart
@@ -14,7 +14,6 @@
 import 'dart:io' show Platform;
 import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -32,11 +31,6 @@ import 'package:window_size/window_size.dart' as window_size;
 const _prefKeyColor = 'color';
 
 void main() {
-  // See https://github.com/flutter/flutter/wiki/Desktop-shells#target-platform-override
-  if (!kIsWeb && (Platform.isLinux || Platform.isWindows)) {
-    debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
-  }
-
   // Try to resize and reposition the window to be half the width and height
   // of its screen, centered horizontally and shifted up from center.
   WidgetsFlutterBinding.ensureInitialized();
@@ -255,7 +249,7 @@ class _MyHomePage extends StatelessWidget {
                     ),
                     new Text(
                       '$counter',
-                      style: Theme.of(context).textTheme.display1,
+                      style: Theme.of(context).textTheme.headline4,
                     ),
                     TextInputTestWidget(),
                     FileChooserTestWidget(),


### PR DESCRIPTION
Now that Linux and Windows are supported by TargetPlatform, remove the
override.

Also fixes a few minor new analyzer issues in the main.dart files.