### PR TITLE
Add a template for the new Linux shell

### DIFF
--- a/linux.tmpl/main.cc
+++ b/linux.tmpl/main.cc
@@ -1,0 +1,24 @@
+#include <gtk/gtk.h>
+
+#include <flutter_linux/flutter_linux.h>
+
+int
+main (int argc, char **argv)
+{
+    gtk_init (&argc, &argv);
+
+    GtkWidget *window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
+    gtk_widget_show (window);
+
+    g_autoptr(FlDartProject) project = fl_dart_project_new (".");
+
+    FlView *view = fl_view_new (project);
+    gtk_widget_show (GTK_WIDGET (view));
+    gtk_container_add (GTK_CONTAINER (window), GTK_WIDGET (view));
+
+    gtk_widget_grab_focus (GTK_WIDGET (view));
+
+    gtk_main ();
+
+    return 0;
+}


### PR DESCRIPTION
This PR is just a quick dump of a minimal application that makes use of the new GTK based Linux Flutter shell. To compile you need to include the GTK headers and link against GTK, which is normally done by using the compiler flags from `pkg-config --cflags --libs gtk+-3.0`.

No Makefile is included, but I guess we should take the existing one and modify that as necessary? Or are we still switching to CMake?