### PR TITLE
Adds RawKeyEventDataWindows to Testbed

### DIFF
--- a/testbed/lib/keyboard_test_page.dart
+++ b/testbed/lib/keyboard_test_page.dart
@@ -96,6 +96,12 @@ class _KeyboardTestPageState extends State<KeyboardTestPage> {
         logicalKey = data.logicalKey.debugName;
         physicalKey = data.physicalKey.debugName;
         break;
+      case RawKeyEventDataWindows:
+        final RawKeyEventDataWindows data = event.data;
+        keyCode = data.keyCode;
+        logicalKey = data.logicalKey.debugName;
+        physicalKey = data.physicalKey.debugName;
+        break;
       default:
         throw new Exception('Unsupported platform ${event.data.runtimeType}');
     }

--- a/testbed/lib/keyboard_test_page.dart
+++ b/testbed/lib/keyboard_test_page.dart
@@ -88,8 +88,6 @@ class _KeyboardTestPageState extends State<KeyboardTestPage> {
         logicalKey = data.logicalKey.debugName;
         physicalKey = data.physicalKey.debugName;
         break;
-      // TODO(https://github.com/flutter/flutter/issues/37830): The Windows and Linux shells share a
-      // GLFW implementation. Update once RawKeyEventDataWindows is implemented.
       case RawKeyEventDataLinux:
         final RawKeyEventDataLinux data = event.data;
         keyCode = data.keyCode;


### PR DESCRIPTION
Now that https://github.com/flutter/flutter/issues/37710 has landed, we can listen to Windows keys