### PR TITLE
Added missing call to CoInitialize

### DIFF
--- a/plugins/file_chooser/windows/file_chooser_plugin.cpp
+++ b/plugins/file_chooser/windows/file_chooser_plugin.cpp
@@ -349,6 +349,7 @@ void FileChooserPlugin::HandleMethodCall(
 
 void FileChooserPluginRegisterWithRegistrar(
     FlutterDesktopPluginRegistrarRef registrar) {
+  CoInitialize(0);
   FileChooserPlugin::RegisterWithRegistrar(
       flutter::PluginRegistrarManager::GetInstance()
           ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));


### PR DESCRIPTION
On Windows (1909 x64 at least), trying to use the "Open" or "Open Media" buttons in the testbed applications results in swallowed exceptions (nothing happening) or crashes

Running in debug mode reveals the root cause: Windows error 0x800401F0
A quick search shows that this happens when trying to use COM methods without a prior call to CoInitialize, to initialize the environment.

This solves the issue for me