### PR TITLE
Adjust plugin metadata

### DIFF
--- a/plugins/color_panel/pubspec.yaml
+++ b/plugins/color_panel/pubspec.yaml
@@ -1,8 +1,10 @@
 name: color_panel
 description: Provides access to the platform's native color picker.
 version: 0.0.1
-author: Flutter Desktop Embedding Developers <flutter-desktop-embedding-dev@googlegroups.com>
-homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugins/color_panel
+
+# Do not publish this plugin. See:
+# https://github.com/google/flutter-desktop-embedding/blob/master/plugins/README.md#using-plugins
+publish_to: none
 
 flutter:
   plugin:

--- a/plugins/file_chooser/pubspec.yaml
+++ b/plugins/file_chooser/pubspec.yaml
@@ -1,8 +1,10 @@
 name: file_chooser
 description: Displays native platform open and save panels.
 version: 0.1.0
-author: Flutter Desktop Embedding Developers <flutter-desktop-embedding-dev@googlegroups.com>
-homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugins/file_chooser
+
+# Do not publish this plugin. See:
+# https://github.com/google/flutter-desktop-embedding/blob/master/plugins/README.md#using-plugins
+publish_to: none
 
 flutter:
   plugin:

--- a/plugins/flutter_plugins/path_provider_fde/pubspec.yaml
+++ b/plugins/flutter_plugins/path_provider_fde/pubspec.yaml
@@ -1,8 +1,10 @@
 name: path_provider_fde
 description: Temporary desktop implmentations of path_provider from flutter/plugins
 version: 0.0.1
-author: Flutter Desktop Embedding Developers <flutter-desktop-embedding-dev@googlegroups.com>
-homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugins/flutter_plugins/path_provider_fde
+
+# Do not publish this plugin. See:
+# https://github.com/google/flutter-desktop-embedding/blob/master/plugins/README.md#using-plugins
+publish_to: none
 
 flutter:
   plugin:

--- a/plugins/flutter_plugins/url_launcher_fde/pubspec.yaml
+++ b/plugins/flutter_plugins/url_launcher_fde/pubspec.yaml
@@ -1,8 +1,10 @@
 name: url_launcher_fde
 description: Temporary desktop implmentations of url_launcher from flutter/plugins
 version: 0.0.1
-author: Flutter Desktop Embedding Developers <flutter-desktop-embedding-dev@googlegroups.com>
-homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugins/flutter_plugins/url_launcher_fde
+
+# Do not publish this plugin. See:
+# https://github.com/google/flutter-desktop-embedding/blob/master/plugins/README.md#using-plugins
+publish_to: none
 
 flutter:
   plugin:

--- a/plugins/menubar/pubspec.yaml
+++ b/plugins/menubar/pubspec.yaml
@@ -1,8 +1,10 @@
 name: menubar
 description: Provides the ability to add native menubar items with Dart callbacks.
 version: 0.0.1
-author: Flutter Desktop Embedding Developers <flutter-desktop-embedding-dev@googlegroups.com>
-homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugins/menubar
+
+# Do not publish this plugin. See:
+# https://github.com/google/flutter-desktop-embedding/blob/master/plugins/README.md#using-plugins
+publish_to: none
 
 flutter:
   plugin:

--- a/plugins/window_size/pubspec.yaml
+++ b/plugins/window_size/pubspec.yaml
@@ -1,8 +1,10 @@
 name: window_size
 description: Allows resizing and repositioning the window containing Flutter.
 version: 0.0.1
-author: Flutter Desktop Embedding Developers <flutter-desktop-embedding-dev@googlegroups.com>
-homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugins/window_size
+
+# Do not publish this plugin. See:
+# https://github.com/google/flutter-desktop-embedding/blob/master/plugins/README.md#using-plugins
+publish_to: none
 
 flutter:
   plugin:

--- a/testbed/lib/main.dart
+++ b/testbed/lib/main.dart
@@ -18,13 +18,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:color_panel/color_panel.dart';
-import 'package:example_flutter/keyboard_test_page.dart';
 import 'package:file_chooser/file_chooser.dart';
 import 'package:menubar/menubar.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 import 'package:window_size/window_size.dart' as window_size;
+
+import 'keyboard_test_page.dart';
 
 // The shared_preferences key for the testbed's color.
 const _prefKeyColor = 'color';

--- a/testbed/pubspec.yaml
+++ b/testbed/pubspec.yaml
@@ -1,5 +1,5 @@
-name: example_flutter
-description: An example project for flutter-desktop-embedding.
+name: testbed
+description: A test project for flutter-desktop-embedding.
 
 environment:
   sdk: '>=2.0.0 <3.0.0'

--- a/testbed/test/widget_test.dart
+++ b/testbed/test/widget_test.dart
@@ -7,7 +7,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:example_flutter/main.dart';
+import 'package:testbed/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (tester) async {


### PR DESCRIPTION
Plugins from FDE should not be published. Add a hurdle so that anyone
who thinks doing so is a good idea, against the explicit guidance of
both this project and the Flutter for desktop documentation, has to go out
of their way to do so.

Also removes the deprecated author, and the homepage (since no published
plugin should ever be linking here).