### PR TITLE
Update Linux plugin build for template changes

### DIFF
--- a/plugins/color_panel/linux/CMakeLists.txt
+++ b/plugins/color_panel/linux/CMakeLists.txt
@@ -13,6 +13,9 @@ add_library(${PLUGIN_NAME} SHARED
   "${PLUGIN_NAME}.cc"
 )
 apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)

--- a/plugins/file_chooser/linux/CMakeLists.txt
+++ b/plugins/file_chooser/linux/CMakeLists.txt
@@ -13,6 +13,9 @@ add_library(${PLUGIN_NAME} SHARED
   "${PLUGIN_NAME}.cc"
 )
 apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)

--- a/plugins/flutter_plugins/url_launcher_fde/linux/CMakeLists.txt
+++ b/plugins/flutter_plugins/url_launcher_fde/linux/CMakeLists.txt
@@ -8,6 +8,9 @@ add_library(${PLUGIN_NAME} SHARED
   "url_launcher_plugin.cc"
 )
 apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)

--- a/plugins/menubar/linux/CMakeLists.txt
+++ b/plugins/menubar/linux/CMakeLists.txt
@@ -13,6 +13,9 @@ add_library(${PLUGIN_NAME} SHARED
   "${PLUGIN_NAME}.cc"
 )
 apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)

--- a/plugins/window_size/linux/CMakeLists.txt
+++ b/plugins/window_size/linux/CMakeLists.txt
@@ -13,6 +13,9 @@ add_library(${PLUGIN_NAME} SHARED
   "${PLUGIN_NAME}.cc"
 )
 apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)

--- a/testbed/linux/CMakeLists.txt
+++ b/testbed/linux/CMakeLists.txt
@@ -3,6 +3,8 @@ project(runner LANGUAGES CXX)
 
 set(BINARY_NAME "testbed")
 
+cmake_policy(SET CMP0063 NEW)
+
 set(CMAKE_INSTALL_RPATH "\$ORIGIN")
 
 # Configure build options.

--- a/testbed/linux/flutter/CMakeLists.txt
+++ b/testbed/linux/flutter/CMakeLists.txt
@@ -65,6 +65,8 @@ add_library(flutter_wrapper_plugin STATIC
 apply_standard_settings(flutter_wrapper_plugin)
 set_target_properties(flutter_wrapper_plugin PROPERTIES
   POSITION_INDEPENDENT_CODE ON)
+set_target_properties(flutter_wrapper_plugin PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
 target_link_libraries(flutter_wrapper_plugin PUBLIC flutter)
 target_include_directories(flutter_wrapper_plugin PUBLIC
   "${WRAPPER_ROOT}/include"


### PR DESCRIPTION
The linux template build files were updated to use hidden as the default
visibity. This updates all plugins, and testbed, to match.

Fixes undefined behavior in testbed (commonly, crash on launch) on Linux
due to unintended sharing of the plugin manager across plugins.