### PR TITLE
Fix rounding in color plugin.

### DIFF
--- a/plugins/color_panel/lib/color_panel.dart
+++ b/plugins/color_panel/lib/color_panel.dart
@@ -107,7 +107,7 @@ class ColorPanel {
   /// from 0-255.
   int _colorComponentFloatToInt(num value) {
     const colorMax = 255;
-    return (value * colorMax).toInt();
+    return (value * colorMax).round();
   }
 
   /// Mediates between the platform channel callback and the client callback.


### PR DESCRIPTION
Picking a color like #bf4040 would result in Flutter using the color #bf3f3f.