### PR TITLE
Split FlApplication into its own module.

### DIFF
--- a/testbed/gtk/CMakeLists.txt
+++ b/testbed/gtk/CMakeLists.txt
@@ -33,6 +33,7 @@ pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
 # Application build
 add_executable(${BINARY_NAME}
   "main.cc"
+  "fl_application.cc"
   "window_configuration.cc"
   "${FLUTTER_MANAGED_DIR}/gtk_plugin_registrant.cc"
 )

--- a/testbed/gtk/fl_application.cc
+++ b/testbed/gtk/fl_application.cc
@@ -1,0 +1,42 @@
+#include "fl_application.h"
+
+#include <flutter_linux/flutter_linux.h>
+
+#include "flutter/gtk_plugin_registrant.h"
+#include "window_configuration.h"
+
+struct _FlApplication {
+  GtkApplication parent_instance;
+};
+
+G_DEFINE_TYPE(FlApplication, fl_application, GTK_TYPE_APPLICATION)
+
+// Implements GApplication::activate.
+static void fl_application_activate(GApplication* application) {
+  GtkWindow* window =
+      GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
+  gtk_widget_show(GTK_WIDGET(window));
+  gtk_widget_set_size_request(GTK_WIDGET(window), kFlutterWindowWidth,
+                              kFlutterWindowHeight);
+  gtk_window_set_title(window, kFlutterWindowTitle);
+
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+
+  FlView* view = fl_view_new(project);
+  gtk_widget_show(GTK_WIDGET(view));
+  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
+
+  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+
+  gtk_widget_grab_focus(GTK_WIDGET(view));
+}
+
+static void fl_application_class_init(FlApplicationClass* klass) {
+  G_APPLICATION_CLASS(klass)->activate = fl_application_activate;
+}
+
+static void fl_application_init(FlApplication* self) {}
+
+FlApplication* fl_application_new() {
+  return FL_APPLICATION(g_object_new(fl_application_get_type(), nullptr));
+}

--- a/testbed/gtk/fl_application.h
+++ b/testbed/gtk/fl_application.h
@@ -1,6 +1,18 @@
+#ifndef FLUTTER_FL_APPLICATION_H_
+#define FLUTTER_FL_APPLICATION_H_
+
 #include <gtk/gtk.h>
 
 G_DECLARE_FINAL_TYPE(FlApplication, fl_application, FL, APPLICATION,
                      GtkApplication)
 
+/**
+ * fl_application_new:
+ *
+ * Creates a new Flutter application.
+ *
+ * Returns: a new #FlApplication.
+ */
 FlApplication* fl_application_new();
+
+#endif  // FLUTTER_FL_APPLICATION_H_

--- a/testbed/gtk/fl_application.h
+++ b/testbed/gtk/fl_application.h
@@ -1,0 +1,6 @@
+#include <gtk/gtk.h>
+
+G_DECLARE_FINAL_TYPE(FlApplication, fl_application, FL, APPLICATION,
+                     GtkApplication)
+
+FlApplication* fl_application_new();

--- a/testbed/gtk/main.cc
+++ b/testbed/gtk/main.cc
@@ -1,47 +1,4 @@
-#include <flutter_linux/flutter_linux.h>
-#include <gtk/gtk.h>
-
-#include "flutter/gtk_plugin_registrant.h"
-#include "window_configuration.h"
-
-G_DECLARE_FINAL_TYPE(FlApplication, fl_application, FL, APPLICATION,
-                     GtkApplication)
-
-struct _FlApplication {
-  GtkApplication parent_instance;
-};
-
-G_DEFINE_TYPE(FlApplication, fl_application, GTK_TYPE_APPLICATION)
-
-// Implements GApplication::activate.
-static void fl_application_activate(GApplication* application) {
-  GtkWindow* window =
-      GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
-  gtk_widget_show(GTK_WIDGET(window));
-  gtk_widget_set_size_request(GTK_WIDGET(window), kFlutterWindowWidth,
-                              kFlutterWindowHeight);
-  gtk_window_set_title(window, kFlutterWindowTitle);
-
-  g_autoptr(FlDartProject) project = fl_dart_project_new();
-
-  FlView* view = fl_view_new(project);
-  gtk_widget_show(GTK_WIDGET(view));
-  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
-
-  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
-
-  gtk_widget_grab_focus(GTK_WIDGET(view));
-}
-
-static void fl_application_class_init(FlApplicationClass* klass) {
-  G_APPLICATION_CLASS(klass)->activate = fl_application_activate;
-}
-
-static void fl_application_init(FlApplication* self) {}
-
-static FlApplication* fl_application_new() {
-  return FL_APPLICATION(g_object_new(fl_application_get_type(), nullptr));
-}
+#include "fl_application.h"
 
 int main(int argc, char** argv) {
   g_autoptr(FlApplication) app = fl_application_new();


### PR DESCRIPTION
This fixes a compile warning about an unused FL_IS_APPLICATION.

Fixes #759