### PR TITLE
path_provider in FDE now supports getDownloadsPath on windows

### DIFF
--- a/plugins/flutter_plugins/path_provider_fde/windows/path_provider_plugin.cpp
+++ b/plugins/flutter_plugins/path_provider_fde/windows/path_provider_plugin.cpp
@@ -148,6 +148,15 @@ void PathProviderPlugin::HandleMethodCall(
     }
     flutter::EncodableValue response(path);
     result->Success(&response);
+  } else if (method_call.method_name().compare(
+                 "getDownloadsDirectory") == 0) {
+    std::string path = GetFolderPath(FOLDERID_Downloads);
+    if (path.empty()) {
+      result->Error("Unable to get downloads path");
+      return;
+    }
+    flutter::EncodableValue response(path);
+    result->Success(&response);
   } else {
     result->NotImplemented();
   }


### PR DESCRIPTION
The path_provider_plugin for Windows is still in the FDE repository but works well.
But it misses the `getDownloadsPath` call on Windows which is available for macOS.
This PR fixes this.