### PR TITLE
Use shared_preferences on Linux

### DIFF
--- a/testbed/lib/main.dart
+++ b/testbed/lib/main.dart
@@ -67,7 +67,7 @@ class MyApp extends StatefulWidget {
 
 class _AppState extends State<MyApp> {
   _AppState() {
-    if (Platform.isMacOS) {
+    if (Platform.isMacOS || Platform.isLinux) {
       SharedPreferences.getInstance().then((prefs) {
         if (prefs.containsKey(_prefKeyColor)) {
           setPrimaryColor(Color(prefs.getInt(_prefKeyColor)));
@@ -91,7 +91,7 @@ class _AppState extends State<MyApp> {
   }
 
   void _saveColor() async {
-    if (Platform.isMacOS) {
+    if (Platform.isMacOS || Platform.isLinux) {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setInt(_prefKeyColor, _primaryColor.value);
     }

--- a/testbed/pubspec.yaml
+++ b/testbed/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   path_provider: ^1.6.5
   path_provider_fde:
     path: ../plugins/flutter_plugins/path_provider_fde
-  shared_preferences: ^0.5.6
+  shared_preferences: ^0.5.8
   url_launcher: ^5.5.0
   url_launcher_fde:
     path: ../plugins/flutter_plugins/url_launcher_fde


### PR DESCRIPTION
Now that shared_preferences supports Linux, add it to the existing prefs
usage in testbed.