### PR TITLE
Add canLaunch to Windows url_launcher

### DIFF
--- a/plugins/flutter_plugins/url_launcher_fde/README.md
+++ b/plugins/flutter_plugins/url_launcher_fde/README.md
@@ -11,8 +11,3 @@ this plugin is and how to use it.
 - [x] Windows
 
 macOS and Linux are already supported by `url_launcher`.
-
-## Caveats
-
-Only `launch` is implemented, so the common pattern of calling `launch` only if
-`canLaunch` returns true will not work.

--- a/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_plugin.cpp
+++ b/plugins/flutter_plugins/url_launcher_fde/windows/url_launcher_plugin.cpp
@@ -13,21 +13,57 @@
 // limitations under the License.
 #include "include/url_launcher_fde/url_launcher_plugin.h"
 
-// Must be before VersionHelpers.h
-#include <windows.h>
-
-#include <VersionHelpers.h>
+#include <Windows.h>
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
 #include <flutter/standard_method_codec.h>
 
 #include <memory>
 #include <sstream>
+#include <string>
 
 namespace {
 
 using flutter::EncodableMap;
 using flutter::EncodableValue;
+
+// Converts the given UTF-8 string to UTF-16.
+std::wstring Utf16FromUtf8(const std::string &utf8_string) {
+  if (utf8_string.empty()) {
+    return std::wstring();
+  }
+  int target_length =
+      ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8_string.data(),
+                            static_cast<int>(utf8_string.length()), nullptr, 0);
+  if (target_length == 0) {
+    return std::wstring();
+  }
+  std::wstring utf16_string;
+  utf16_string.resize(target_length);
+  int converted_length =
+      ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8_string.data(),
+                            static_cast<int>(utf8_string.length()),
+                            utf16_string.data(), target_length);
+  if (converted_length == 0) {
+    return std::wstring();
+  }
+  return utf16_string;
+}
+
+// Returns the URL argument from |method_call| if it is present, otherwise
+// returns an empty string.
+std::string GetUrlArgument(
+    const flutter::MethodCall<EncodableValue> &method_call) {
+  std::string url;
+  const auto *arguments = std::get_if<EncodableMap>(method_call.arguments());
+  if (arguments) {
+    auto url_it = arguments->find(EncodableValue("url"));
+    if (url_it != arguments->end()) {
+      url = std::get<std::string>(url_it->second);
+    }
+  }
+  return url;
+}
 
 class UrlLauncherPlugin : public flutter::Plugin {
  public:
@@ -70,28 +106,16 @@ void UrlLauncherPlugin::HandleMethodCall(
     const flutter::MethodCall<EncodableValue> &method_call,
     std::unique_ptr<flutter::MethodResult<EncodableValue>> result) {
   if (method_call.method_name().compare("launch") == 0) {
-    std::string url;
-    const auto *arguments = std::get_if<EncodableMap>(method_call.arguments());
-    if (arguments) {
-      auto url_it = arguments->find(EncodableValue("url"));
-      if (url_it != arguments->end()) {
-        url = std::get<std::string>(url_it->second);
-      }
-    }
+    std::string url = GetUrlArgument(method_call);
     if (url.empty()) {
       result->Error("argument_error", "No URL provided");
       return;
     }
+    std::wstring url_wide = Utf16FromUtf8(url);
 
-    // launch a URL on Windows
-    size_t size = url.length() + 1;
-    std::wstring wurl;
-    wurl.reserve(size);
-    size_t outSize;
-    mbstowcs_s(&outSize, &wurl[0], size, url.c_str(), size - 1);
-
-    int status = static_cast<int>(reinterpret_cast<INT_PTR>(ShellExecute(
-        nullptr, TEXT("open"), wurl.c_str(), nullptr, nullptr, SW_SHOWNORMAL)));
+    int status = static_cast<int>(reinterpret_cast<INT_PTR>(
+        ::ShellExecute(nullptr, TEXT("open"), url_wide.c_str(), nullptr,
+                       nullptr, SW_SHOWNORMAL)));
 
     if (status <= 32) {
       std::ostringstream error_message;
@@ -101,6 +125,27 @@ void UrlLauncherPlugin::HandleMethodCall(
       return;
     }
     EncodableValue response(true);
+    result->Success(&response);
+  } else if (method_call.method_name().compare("canLaunch") == 0) {
+    std::string url = GetUrlArgument(method_call);
+    if (url.empty()) {
+      result->Error("argument_error", "No URL provided");
+      return;
+    }
+
+    bool can_launch = false;
+    size_t separator_location = url.find(":");
+    if (separator_location != std::string::npos) {
+      std::wstring scheme = Utf16FromUtf8(url.substr(0, separator_location));
+      HKEY key = nullptr;
+      if (::RegOpenKeyEx(HKEY_CLASSES_ROOT, scheme.c_str(), 0, KEY_QUERY_VALUE,
+                         &key) == ERROR_SUCCESS) {
+        can_launch = ::RegQueryValueEx(key, L"URL Protocol", nullptr, nullptr,
+                                       nullptr, nullptr) == ERROR_SUCCESS;
+        ::RegCloseKey(key);
+      }
+    }
+    EncodableValue response(can_launch);
     result->Success(&response);
   } else {
     result->NotImplemented();

--- a/testbed/lib/main.dart
+++ b/testbed/lib/main.dart
@@ -365,9 +365,11 @@ class URLLauncherTestWidget extends StatelessWidget {
         new FlatButton(
           child: const Text('OPEN ON GITHUB'),
           onPressed: () async {
-            final result = await url_launcher
-                .launch('https://github.com/google/flutter-desktop-embedding');
-            assert(result);
+            const url = 'https://github.com/google/flutter-desktop-embedding';
+            if (await url_launcher.canLaunch(url)) {
+              final result = await url_launcher.launch(url);
+              assert(result);
+            }
           },
         ),
       ],


### PR DESCRIPTION
Checks the registry for a url protocol entry for the given scheme when
checking to see if a URL can be launched.

This gives better parity with the other platforms, and means that the
url_launcher-documentation-recommended pattern of checking canLaunch
before calling launch won't fail on Windows.