### PR TITLE
[window_size] Add show/hide functionality

### DIFF
--- a/plugins/window_size/lib/src/window_size_channel.dart
+++ b/plugins/window_size/lib/src/window_size_channel.dart
@@ -87,8 +87,8 @@ const String _getWindowMaximumSizeMethod = 'getWindowMaximumSize';
 /// The method name to set the window visibility.
 ///
 /// The argument will be a boolean controlling whether or not the window should
-/// be visibile.
-const String _setWindowVisibileMethod = 'setWindowVisible';
+/// be Visibility.
+const String _setWindowVisibilityMethod = 'setWindowVisibility';
 
 // Keys for screen and window maps returned by _getScreenListMethod.
 
@@ -169,8 +169,8 @@ class WindowSizeChannel {
   }
 
   /// Sets the visibility of the window.
-  void setWindowVisible({required bool visible}) async {
-    await _platformChannel.invokeMethod(_setWindowVisibileMethod, visible);
+  void setWindowVisibility({required bool visible}) async {
+    await _platformChannel.invokeMethod(_setWindowVisibilityMethod, visible);
   }
 
   // Window maximum size unconstrained is passed over the channel as -1.

--- a/plugins/window_size/lib/src/window_size_channel.dart
+++ b/plugins/window_size/lib/src/window_size_channel.dart
@@ -84,6 +84,12 @@ const String _getWindowMinimumSizeMethod = 'getWindowMinimumSize';
 /// unconstrained in that dimension.
 const String _getWindowMaximumSizeMethod = 'getWindowMaximumSize';
 
+/// The method name to set the window visibility.
+///
+/// The argument will be a boolean controlling whether or not the window should
+/// be visibile.
+const String _setWindowVisibileMethod = 'setWindowVisible';
+
 // Keys for screen and window maps returned by _getScreenListMethod.
 
 /// The frame of a screen or window. The value is a list of four doubles:
@@ -160,6 +166,11 @@ class WindowSizeChannel {
   void setWindowMinSize(Size size) async {
     await _platformChannel
         .invokeMethod(_setWindowMinimumSizeMethod, [size.width, size.height]);
+  }
+
+  /// Sets the visibility of the window.
+  void setWindowVisible({required bool visible}) async {
+    await _platformChannel.invokeMethod(_setWindowVisibileMethod, visible);
   }
 
   // Window maximum size unconstrained is passed over the channel as -1.

--- a/plugins/window_size/lib/src/window_size_channel.dart
+++ b/plugins/window_size/lib/src/window_size_channel.dart
@@ -87,7 +87,7 @@ const String _getWindowMaximumSizeMethod = 'getWindowMaximumSize';
 /// The method name to set the window visibility.
 ///
 /// The argument will be a boolean controlling whether or not the window should
-/// be Visibility.
+/// be visible.
 const String _setWindowVisibilityMethod = 'setWindowVisibility';
 
 // Keys for screen and window maps returned by _getScreenListMethod.

--- a/plugins/window_size/lib/src/window_size_utils.dart
+++ b/plugins/window_size/lib/src/window_size_utils.dart
@@ -65,6 +65,11 @@ void setWindowTitle(String title) async {
   WindowSizeChannel.instance.setWindowTitle(title);
 }
 
+/// Shows or hides the window.
+void setWindowVisible({required bool visible}) async {
+  WindowSizeChannel.instance.setWindowVisible(visible: visible);
+}
+
 /// Sets the window title's represented [Uri], of the window containing this Flutter instance.
 ///
 /// Only implemented for macOS. If the URL is a file URL, the

--- a/plugins/window_size/lib/src/window_size_utils.dart
+++ b/plugins/window_size/lib/src/window_size_utils.dart
@@ -66,8 +66,8 @@ void setWindowTitle(String title) async {
 }
 
 /// Shows or hides the window.
-void setWindowVisible({required bool visible}) async {
-  WindowSizeChannel.instance.setWindowVisible(visible: visible);
+void setWindowVisibility({required bool visible}) async {
+  WindowSizeChannel.instance.setWindowVisibility(visible: visible);
 }
 
 /// Sets the window title's represented [Uri], of the window containing this Flutter instance.

--- a/plugins/window_size/linux/window_size_plugin.cc
+++ b/plugins/window_size/linux/window_size_plugin.cc
@@ -26,6 +26,7 @@ const char kSetWindowFrameMethod[] = "setWindowFrame";
 const char kSetWindowMinimumSizeMethod[] = "setWindowMinimumSize";
 const char kSetWindowMaximumSizeMethod[] = "setWindowMaximumSize";
 const char kSetWindowTitleMethod[] = "setWindowTitle";
+const char ksetWindowVisibilityMethod[] = "setWindowVisibility";
 const char kGetWindowMinimumSizeMethod[] = "getWindowMinimumSize";
 const char kGetWindowMaximumSizeMethod[] = "getWindowMaximumSize";
 const char kFrameKey[] = "frame";
@@ -259,6 +260,28 @@ static FlMethodResponse* set_window_title(FlWindowSizePlugin* self,
   return FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
 }
 
+// Sets the window visibility.
+static FlMethodResponse* set_window_visible(FlWindowSizePlugin* self,
+                                          FlValue* args) {
+  if (fl_value_get_type(args) != FL_VALUE_TYPE_BOOL) {
+    return FL_METHOD_RESPONSE(fl_method_error_response_new(
+        kBadArgumentsError, "Expected bool", nullptr));
+  }
+
+  GtkWindow* window = get_window(self);
+  if (window == nullptr) {
+    return FL_METHOD_RESPONSE(
+        fl_method_error_response_new(kNoScreenError, nullptr, nullptr));
+  }
+  if (fl_value_get_bool(args)) {
+    gtk_widget_show(GTK_WIDGET(window));
+  } else {
+    gtk_widget_hide(GTK_WIDGET(window));
+  }
+
+  return FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
+}
+
 // Gets the window minimum size.
 static FlMethodResponse* get_window_minimum_size(FlWindowSizePlugin* self) {
   g_autoptr(FlValue) size = fl_value_new_list();
@@ -302,6 +325,8 @@ static void method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call,
     response = set_window_maximum_size(self, args);
   } else if (strcmp(method, kSetWindowTitleMethod) == 0) {
     response = set_window_title(self, args);
+  } else if (strcmp(method, ksetWindowVisibilityMethod) == 0) {
+    response = set_window_visible(self, args);
   } else if (strcmp(method, kGetWindowMinimumSizeMethod) == 0) {
     response = get_window_minimum_size(self);
   } else if (strcmp(method, kGetWindowMaximumSizeMethod) == 0) {

--- a/plugins/window_size/macos/Classes/FLEWindowSizePlugin.m
+++ b/plugins/window_size/macos/Classes/FLEWindowSizePlugin.m
@@ -25,6 +25,7 @@ static NSString *const kSetWindowMinimumSizeMethod = @"setWindowMinimumSize";
 static NSString *const kSetWindowMaximumSizeMethod = @"setWindowMaximumSize";
 static NSString *const kSetWindowTitleMethod = @"setWindowTitle";
 static NSString *const kSetWindowTitleRepresentedUrlMethod = @"setWindowTitleRepresentedUrl";
+static NSString *const kSetWindowVisibilityMethod = @"setWindowVisibility";
 static NSString *const kGetWindowMinimumSizeMethod = @"getWindowMinimumSize";
 static NSString *const kGetWindowMaximumSizeMethod = @"getWindowMaximumSize";
 static NSString *const kFrameKey = @"frame";
@@ -169,6 +170,14 @@ static double ChannelRepresentationForMaxDimension(double size) {
   } else if ([call.method isEqualToString:kSetWindowTitleRepresentedUrlMethod]) {
     NSURL *representedURL = [NSURL URLWithString:call.arguments];
     self.flutterView.window.representedURL = representedURL;
+    methodResult = nil;
+  } else if ([call.method isEqualToString:kSetWindowVisibilityMethod]) {
+    bool visible = [call.arguments boolValue];
+    if (visible) {
+      [self.flutterView.window makeKeyAndOrderFront:self];
+    } else {
+      [self.flutterView.window orderOut:self];
+    }
     methodResult = nil;
   } else {
     methodResult = FlutterMethodNotImplemented;

--- a/plugins/window_size/windows/window_size_plugin.cpp
+++ b/plugins/window_size/windows/window_size_plugin.cpp
@@ -39,7 +39,7 @@ const char kSetWindowFrameMethod[] = "setWindowFrame";
 const char kSetWindowMinimumSize[] = "setWindowMinimumSize";
 const char kSetWindowMaximumSize[] = "setWindowMaximumSize";
 const char kSetWindowTitleMethod[] = "setWindowTitle";
-const char kSetWindowVisibleMethod[] = "setWindowVisible";
+const char ksetWindowVisibilityMethod[] = "setWindowVisibility";
 const char kFrameKey[] = "frame";
 const char kVisibleFrameKey[] = "visibleFrame";
 const char kScaleFactorKey[] = "scaleFactor";
@@ -104,7 +104,8 @@ EncodableValue GetPlatformChannelRepresentationForWindow(HWND window) {
   }
   RECT frame;
   ::GetWindowRect(window, &frame);
-  HMONITOR window_monitor = ::MonitorFromWindow(window, MONITOR_DEFAULTTOPRIMARY);
+  HMONITOR window_monitor =
+      ::MonitorFromWindow(window, MONITOR_DEFAULTTOPRIMARY);
   double scale_factor = FlutterDesktopGetDpiForHWND(window) / kBaseDpi;
 
   return EncodableValue(EncodableMap{
@@ -186,7 +187,7 @@ void WindowSizePlugin::HandleMethodCall(
   if (method_call.method_name().compare(kGetScreenListMethod) == 0) {
     EncodableValue screens(std::in_place_type<EncodableList>);
     ::EnumDisplayMonitors(nullptr, nullptr, MonitorRepresentationEnumProc,
-                        reinterpret_cast<LPARAM>(&screens));
+                          reinterpret_cast<LPARAM>(&screens));
     result->Success(screens);
   } else if (method_call.method_name().compare(kGetWindowInfoMethod) == 0) {
     result->Success(GetPlatformChannelRepresentationForWindow(
@@ -205,7 +206,7 @@ void WindowSizePlugin::HandleMethodCall(
     int width = static_cast<int>(std::get<double>((*frame_list)[2]));
     int height = static_cast<int>(std::get<double>((*frame_list)[3]));
     ::SetWindowPos(GetRootWindow(registrar_->GetView()), nullptr, x, y, width,
-                 height, SWP_NOACTIVATE | SWP_NOOWNERZORDER);
+                   height, SWP_NOACTIVATE | SWP_NOOWNERZORDER);
     result->Success();
   } else if (method_call.method_name().compare(kSetWindowMinimumSize) == 0) {
     const auto *size = std::get_if<EncodableList>(method_call.arguments());
@@ -234,7 +235,8 @@ void WindowSizePlugin::HandleMethodCall(
             .from_bytes(*title);
     ::SetWindowText(GetRootWindow(registrar_->GetView()), wstr.c_str());
     result->Success();
-  } else if (method_call.method_name().compare(kSetWindowVisibleMethod) == 0) {
+  } else if (method_call.method_name().compare(ksetWindowVisibilityMethod) ==
+             0) {
     const bool *visible = std::get_if<bool>(method_call.arguments());
     if (visible == nullptr) {
       result->Error("Bad arguments", "Expected bool");


### PR DESCRIPTION
Adds 'setWindowVisibility' to show/hide the window.

Needs follow-up documentation; using it correctly for the resize-before-showing-window case is non-trivial on some platforms, and on macOS hiding will exit the app with the default Flutter app delegate configuration.