### PR TITLE
Update file_selector SDK constraints

### DIFF
--- a/plugins/file_selector/README.md
+++ b/plugins/file_selector/README.md
@@ -12,5 +12,5 @@ flutter/plugins and endorsed.
 
 Unlike other FDE plugins these are published normally, since they have a
 long-term support path. As with any unundorsed plugin, you need to
-depend directly on the implementation package (e.g., `file_selector_windows`)
+depend directly on the implementation package ([`file_selector_linux`](https://pub.dev/packages/file_selector_linux), [`file_selector_macos`](https://pub.dev/packages/file_selector_macos), and/or [`file_selector_windows`](https://pub.dev/packages/file_selector_windows))
 as well as the app-facing package (`file_selector`) in your `pubspec.yaml`.

--- a/plugins/file_selector/README.md
+++ b/plugins/file_selector/README.md
@@ -14,3 +14,5 @@ Unlike other FDE plugins these are published normally, since they have a
 long-term support path. As with any unundorsed plugin, you need to
 depend directly on the implementation package ([`file_selector_linux`](https://pub.dev/packages/file_selector_linux), [`file_selector_macos`](https://pub.dev/packages/file_selector_macos), and/or [`file_selector_windows`](https://pub.dev/packages/file_selector_windows))
 as well as the app-facing package (`file_selector`) in your `pubspec.yaml`.
+
+See the implementation packages' READMEs for platform-specific notes.

--- a/plugins/file_selector/file_selector_linux/CHANGELOG.md
+++ b/plugins/file_selector/file_selector_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+* Update SDK constraint to signal compatibility with null safety.
+
 ## 0.0.1
 
 * Initial Linux implementation of `file_selector`.

--- a/plugins/file_selector/file_selector_linux/README.md
+++ b/plugins/file_selector/file_selector_linux/README.md
@@ -17,7 +17,7 @@ This is what the above means to your `pubspec.yaml`:
 dependencies:
   ...
   file_selector: ^0.7.0
-  file_selector_linux: ^0.0.1
+  file_selector_linux: ^0.0.2
   ...
 ```
 

--- a/plugins/file_selector/file_selector_linux/pubspec.yaml
+++ b/plugins/file_selector/file_selector_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_selector_linux
 description: Liunx implementation of the file_selector plugin.
-version: 0.0.1
+version: 0.0.2
 homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugins/file_selector/file_selector_linux
 
 flutter:
@@ -10,7 +10,7 @@ flutter:
         pluginClass: FileSelectorPlugin
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.22.0"
 
 dependencies:

--- a/plugins/file_selector/file_selector_macos/CHANGELOG.md
+++ b/plugins/file_selector/file_selector_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+* Update SDK constraint to signal compatibility with null safety.
+
 ## 0.0.1
 
 * Initial macOS implementation of `file_selector`.

--- a/plugins/file_selector/file_selector_macos/README.md
+++ b/plugins/file_selector/file_selector_macos/README.md
@@ -17,7 +17,7 @@ This is what the above means to your `pubspec.yaml`:
 dependencies:
   ...
   file_selector: ^0.7.0
-  file_selector_macos: ^0.0.1
+  file_selector_macos: ^0.0.2
   ...
 ```
 

--- a/plugins/file_selector/file_selector_macos/pubspec.yaml
+++ b/plugins/file_selector/file_selector_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_selector_macos
 description: macOS implementation of the file_selector plugin.
-version: 0.0.1
+version: 0.0.2
 homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugins/file_selector/file_selector_macos
 
 flutter:
@@ -10,7 +10,7 @@ flutter:
         pluginClass: FileSelectorPlugin
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.22.0"
 
 dependencies:

--- a/plugins/file_selector/file_selector_windows/CHANGELOG.md
+++ b/plugins/file_selector/file_selector_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+* Update SDK constraint to signal compatibility with null safety.
+
 ## 0.0.1
 
 * Initial Windows implementation of `file_selector`.

--- a/plugins/file_selector/file_selector_windows/README.md
+++ b/plugins/file_selector/file_selector_windows/README.md
@@ -17,7 +17,7 @@ This is what the above means to your `pubspec.yaml`:
 dependencies:
   ...
   file_selector: ^0.7.0
-  file_selector_windows: ^0.0.1
+  file_selector_windows: ^0.0.2
   ...
 ```
 

--- a/plugins/file_selector/file_selector_windows/pubspec.yaml
+++ b/plugins/file_selector/file_selector_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_selector_windows
 description: Windows implementation of the file_selector plugin.
-version: 0.0.1
+version: 0.0.2
 homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugins/file_selector/file_selector_windows
 
 flutter:
@@ -10,7 +10,7 @@ flutter:
         pluginClass: FileSelectorPlugin
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.22.0"
 
 dependencies:


### PR DESCRIPTION
Rev the SDK constraint on the file_selector implementation packages to
indicate compatibility with null safety. No code changes necessary,
since there is no Dart code.