### PR TITLE
Fix copypasta in README

### DIFF
--- a/plugins/file_selector/file_selector_macos/CHANGELOG.md
+++ b/plugins/file_selector/file_selector_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3
+
+* Fix README
+
 ## 0.0.2
 
 * Update SDK constraint to signal compatibility with null safety.

--- a/plugins/file_selector/file_selector_macos/README.md
+++ b/plugins/file_selector/file_selector_macos/README.md
@@ -28,12 +28,12 @@ You will need to [add an entitlement][2] for either read-only access:
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 ```
-or read/write access:	or read/write access:
+or read/write access:
 ```
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 ```
-depending on your use case.	depending on your use case.
+depending on your use case.
 
 [1]: https://github.com/flutter/plugins/tree/master/packages/file_selector
 [2]: https://flutter.dev/desktop#entitlements-and-the-app-sandbox

--- a/plugins/file_selector/file_selector_macos/README.md
+++ b/plugins/file_selector/file_selector_macos/README.md
@@ -17,7 +17,7 @@ This is what the above means to your `pubspec.yaml`:
 dependencies:
   ...
   file_selector: ^0.7.0
-  file_selector_macos: ^0.0.2
+  file_selector_macos: ^0.0.3
   ...
 ```
 

--- a/plugins/file_selector/file_selector_macos/pubspec.yaml
+++ b/plugins/file_selector/file_selector_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_selector_macos
 description: macOS implementation of the file_selector plugin.
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugins/file_selector/file_selector_macos
 
 flutter:


### PR DESCRIPTION
Removes duplicated text in file_selector_macos README.