### PR TITLE
Add implements to file_selector_*

### DIFF
--- a/plugins/file_selector/file_selector_linux/pubspec.yaml
+++ b/plugins/file_selector/file_selector_linux/pubspec.yaml
@@ -5,6 +5,7 @@ homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugin
 
 flutter:
   plugin:
+    implements: file_selector
     platforms:
       linux:
         pluginClass: FileSelectorPlugin

--- a/plugins/file_selector/file_selector_macos/pubspec.yaml
+++ b/plugins/file_selector/file_selector_macos/pubspec.yaml
@@ -5,6 +5,7 @@ homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugin
 
 flutter:
   plugin:
+    implements: file_selector
     platforms:
       macos:
         pluginClass: FileSelectorPlugin

--- a/plugins/file_selector/file_selector_windows/pubspec.yaml
+++ b/plugins/file_selector/file_selector_windows/pubspec.yaml
@@ -5,6 +5,7 @@ homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugin
 
 flutter:
   plugin:
+    implements: file_selector
     platforms:
       windows:
         pluginClass: FileSelectorPlugin


### PR DESCRIPTION
Recent versions of Flutter warn if this key isn't present.