### PR TITLE
Migrate file selector example to NNBD

### DIFF
--- a/plugins/file_selector/example/analysis_options.yaml
+++ b/plugins/file_selector/example/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../../analysis_options.yaml

--- a/plugins/file_selector/example/lib/get_directory_page.dart
+++ b/plugins/file_selector/example/lib/get_directory_page.dart
@@ -4,13 +4,13 @@ import 'package:flutter/material.dart';
 /// Screen that shows an example of getDirectoryPath
 class GetDirectoryPage extends StatelessWidget {
   void _getDirectoryPath(BuildContext context) async {
-    final String confirmButtonText = 'Choose';
-    final String directoryPath = await FileSelectorPlatform.instance.getDirectoryPath(
+    const confirmButtonText = 'Choose';
+    final directoryPath = await FileSelectorPlatform.instance.getDirectoryPath(
       confirmButtonText: confirmButtonText,
     );
     await showDialog(
       context: context,
-      builder: (context) => TextDisplay(directoryPath),
+      builder: (context) => TextDisplay(directoryPath ?? 'Unknown'),
     );
   }
 
@@ -18,15 +18,13 @@ class GetDirectoryPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text("Open a text file"),
+        title: Text('Open a text file'),
       ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            RaisedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+            ElevatedButton(
               child: Text('Press to ask user to choose a directory'),
               onPressed: () => _getDirectoryPath(context),
             ),
@@ -39,11 +37,11 @@ class GetDirectoryPage extends StatelessWidget {
 
 /// Widget that displays a text file in a dialog
 class TextDisplay extends StatelessWidget {
+  /// Default Constructor
+  const TextDisplay(this.directoryPath);
+
   /// Directory path
   final String directoryPath;
-
-  /// Default Constructor
-  TextDisplay(this.directoryPath);
 
   @override
   Widget build(BuildContext context) {
@@ -55,7 +53,7 @@ class TextDisplay extends StatelessWidget {
         ),
       ),
       actions: [
-        FlatButton(
+        TextButton(
           child: const Text('Close'),
           onPressed: () => Navigator.pop(context),
         ),

--- a/plugins/file_selector/example/lib/get_directory_page.dart
+++ b/plugins/file_selector/example/lib/get_directory_page.dart
@@ -25,7 +25,7 @@ class GetDirectoryPage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
-              child: Text('Press to ask user to choose a directory'),
+              child: const Text('Press to ask user to choose a directory'),
               onPressed: () => _getDirectoryPath(context),
             ),
           ],

--- a/plugins/file_selector/example/lib/home_page.dart
+++ b/plugins/file_selector/example/lib/home_page.dart
@@ -12,37 +12,27 @@ class HomePage extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            RaisedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+            ElevatedButton(
               child: Text('Open a text file'),
               onPressed: () => Navigator.pushNamed(context, '/open/text'),
             ),
             SizedBox(height: 10),
-            RaisedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+            ElevatedButton(
               child: Text('Open an image'),
               onPressed: () => Navigator.pushNamed(context, '/open/image'),
             ),
             SizedBox(height: 10),
-            RaisedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+            ElevatedButton(
               child: Text('Open multiple images'),
               onPressed: () => Navigator.pushNamed(context, '/open/images'),
             ),
             SizedBox(height: 10),
-            RaisedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+            ElevatedButton(
               child: Text('Save a file'),
               onPressed: () => Navigator.pushNamed(context, '/save/text'),
             ),
             SizedBox(height: 10),
-            RaisedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+            ElevatedButton(
               child: Text('Open a get directory dialog'),
               onPressed: () => Navigator.pushNamed(context, '/directory'),
             ),

--- a/plugins/file_selector/example/lib/home_page.dart
+++ b/plugins/file_selector/example/lib/home_page.dart
@@ -13,27 +13,27 @@ class HomePage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
-              child: Text('Open a text file'),
+              child: const Text('Open a text file'),
               onPressed: () => Navigator.pushNamed(context, '/open/text'),
             ),
             SizedBox(height: 10),
             ElevatedButton(
-              child: Text('Open an image'),
+              child: const Text('Open an image'),
               onPressed: () => Navigator.pushNamed(context, '/open/image'),
             ),
             SizedBox(height: 10),
             ElevatedButton(
-              child: Text('Open multiple images'),
+              child: const Text('Open multiple images'),
               onPressed: () => Navigator.pushNamed(context, '/open/images'),
             ),
             SizedBox(height: 10),
             ElevatedButton(
-              child: Text('Save a file'),
+              child: const Text('Save a file'),
               onPressed: () => Navigator.pushNamed(context, '/save/text'),
             ),
             SizedBox(height: 10),
             ElevatedButton(
-              child: Text('Open a get directory dialog'),
+              child: const Text('Open a get directory dialog'),
               onPressed: () => Navigator.pushNamed(context, '/directory'),
             ),
           ],

--- a/plugins/file_selector/example/lib/open_image_page.dart
+++ b/plugins/file_selector/example/lib/open_image_page.dart
@@ -33,7 +33,7 @@ class OpenImagePage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
-              child: Text('Press to open an image file(png, jpg)'),
+              child: const Text('Press to open an image file(png, jpg)'),
               onPressed: () => _openImageFile(context),
             ),
           ],

--- a/plugins/file_selector/example/lib/open_image_page.dart
+++ b/plugins/file_selector/example/lib/open_image_page.dart
@@ -6,14 +6,15 @@ import 'package:flutter/material.dart';
 /// Screen that shows an example of openFiles
 class OpenImagePage extends StatelessWidget {
   void _openImageFile(BuildContext context) async {
-    final XTypeGroup typeGroup = XTypeGroup(
+    final typeGroup = XTypeGroup(
       label: 'images',
       extensions: ['jpg', 'png'],
     );
-    final List<XFile> files = await FileSelectorPlatform.instance.openFiles(acceptedTypeGroups: [typeGroup]);
-    final XFile file = files[0];
-    final String fileName = file.name;
-    final String filePath = file.path;
+    final files = await FileSelectorPlatform.instance
+        .openFiles(acceptedTypeGroups: [typeGroup]);
+    final file = files[0];
+    final fileName = file.name!;
+    final filePath = file.path!;
 
     await showDialog(
       context: context,
@@ -25,15 +26,13 @@ class OpenImagePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text("Open an image"),
+        title: Text('Open an image'),
       ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            RaisedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+            ElevatedButton(
               child: Text('Press to open an image file(png, jpg)'),
               onPressed: () => _openImageFile(context),
             ),
@@ -46,14 +45,14 @@ class OpenImagePage extends StatelessWidget {
 
 /// Widget that displays a text file in a dialog
 class ImageDisplay extends StatelessWidget {
+  /// Default Constructor
+  const ImageDisplay(this.fileName, this.filePath);
+
   /// Image's name
   final String fileName;
 
   /// Image's path
   final String filePath;
-
-  /// Default Constructor
-  ImageDisplay(this.fileName, this.filePath);
 
   @override
   Widget build(BuildContext context) {
@@ -63,7 +62,7 @@ class ImageDisplay extends StatelessWidget {
       // while on other platforms it is a system path.
       content: kIsWeb ? Image.network(filePath) : Image.file(File(filePath)),
       actions: [
-        FlatButton(
+        TextButton(
           child: const Text('Close'),
           onPressed: () {
             Navigator.pop(context);

--- a/plugins/file_selector/example/lib/open_multiple_images_page.dart
+++ b/plugins/file_selector/example/lib/open_multiple_images_page.dart
@@ -6,15 +6,16 @@ import 'package:flutter/material.dart';
 /// Screen that shows an example of openFiles
 class OpenMultipleImagesPage extends StatelessWidget {
   void _openImageFile(BuildContext context) async {
-    final XTypeGroup jpgsTypeGroup = XTypeGroup(
+    final jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
       extensions: ['jpg', 'jpeg'],
     );
-    final XTypeGroup pngTypeGroup = XTypeGroup(
+    final pngTypeGroup = XTypeGroup(
       label: 'PNGs',
       extensions: ['png'],
     );
-    final List<XFile> files = await FileSelectorPlatform.instance.openFiles(acceptedTypeGroups: [
+    final files =
+        await FileSelectorPlatform.instance.openFiles(acceptedTypeGroups: [
       jpgsTypeGroup,
       pngTypeGroup,
     ]);
@@ -28,15 +29,13 @@ class OpenMultipleImagesPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text("Open multiple images"),
+        title: Text('Open multiple images'),
       ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            RaisedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+            ElevatedButton(
               child: Text('Press to open multiple images (png, jpg)'),
               onPressed: () => _openImageFile(context),
             ),
@@ -49,11 +48,11 @@ class OpenMultipleImagesPage extends StatelessWidget {
 
 /// Widget that displays a text file in a dialog
 class MultipleImagesDisplay extends StatelessWidget {
+  /// Default Constructor
+  const MultipleImagesDisplay(this.files);
+
   /// The files containing the images
   final List<XFile> files;
-
-  /// Default Constructor
-  MultipleImagesDisplay(this.files);
 
   @override
   Widget build(BuildContext context) {
@@ -67,14 +66,14 @@ class MultipleImagesDisplay extends StatelessWidget {
             ...files.map(
               (file) => Flexible(
                   child: kIsWeb
-                      ? Image.network(file.path)
-                      : Image.file(File(file.path))),
+                      ? Image.network(file.path!)
+                      : Image.file(File(file.path!))),
             )
           ],
         ),
       ),
       actions: [
-        FlatButton(
+        TextButton(
           child: const Text('Close'),
           onPressed: () {
             Navigator.pop(context);

--- a/plugins/file_selector/example/lib/open_multiple_images_page.dart
+++ b/plugins/file_selector/example/lib/open_multiple_images_page.dart
@@ -36,7 +36,7 @@ class OpenMultipleImagesPage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
-              child: Text('Press to open multiple images (png, jpg)'),
+              child: const Text('Press to open multiple images (png, jpg)'),
               onPressed: () => _openImageFile(context),
             ),
           ],

--- a/plugins/file_selector/example/lib/open_text_page.dart
+++ b/plugins/file_selector/example/lib/open_text_page.dart
@@ -33,7 +33,7 @@ class OpenTextPage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
-              child: Text('Press to open a text file (json, txt)'),
+              child: const Text('Press to open a text file (json, txt)'),
               onPressed: () => _openTextFile(context),
             ),
           ],

--- a/plugins/file_selector/example/lib/open_text_page.dart
+++ b/plugins/file_selector/example/lib/open_text_page.dart
@@ -4,13 +4,17 @@ import 'package:flutter/material.dart';
 /// Screen that shows an example of openFile
 class OpenTextPage extends StatelessWidget {
   void _openTextFile(BuildContext context) async {
-    final XTypeGroup typeGroup = XTypeGroup(
+    final typeGroup = XTypeGroup(
       label: 'text',
       extensions: ['txt', 'json'],
     );
-    final XFile file = await FileSelectorPlatform.instance.openFile(acceptedTypeGroups: [typeGroup]);
-    final String fileName = file.name;
-    final String fileContent = await file.readAsString();
+    final file = await FileSelectorPlatform.instance
+        .openFile(acceptedTypeGroups: [typeGroup]);
+    if (file == null) {
+      return;
+    }
+    final fileName = file.name!;
+    final fileContent = await file.readAsString();
 
     await showDialog(
       context: context,
@@ -22,15 +26,13 @@ class OpenTextPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text("Open a text file"),
+        title: Text('Open a text file'),
       ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            RaisedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+            ElevatedButton(
               child: Text('Press to open a text file (json, txt)'),
               onPressed: () => _openTextFile(context),
             ),
@@ -43,14 +45,14 @@ class OpenTextPage extends StatelessWidget {
 
 /// Widget that displays a text file in a dialog
 class TextDisplay extends StatelessWidget {
+  /// Default Constructor
+  const TextDisplay(this.fileName, this.fileContent);
+
   /// File's name
   final String fileName;
 
   /// File to display
   final String fileContent;
-
-  /// Default Constructor
-  TextDisplay(this.fileName, this.fileContent);
 
   @override
   Widget build(BuildContext context) {
@@ -62,7 +64,7 @@ class TextDisplay extends StatelessWidget {
         ),
       ),
       actions: [
-        FlatButton(
+        TextButton(
           child: const Text('Close'),
           onPressed: () => Navigator.pop(context),
         ),

--- a/plugins/file_selector/example/lib/save_text_page.dart
+++ b/plugins/file_selector/example/lib/save_text_page.dart
@@ -55,7 +55,7 @@ class SaveTextPage extends StatelessWidget {
             ),
             SizedBox(height: 10),
             ElevatedButton(
-              child: Text('Press to save a text file'),
+              child: const Text('Press to save a text file'),
               onPressed: _saveFile,
             ),
           ],

--- a/plugins/file_selector/example/lib/save_text_page.dart
+++ b/plugins/file_selector/example/lib/save_text_page.dart
@@ -8,12 +8,15 @@ class SaveTextPage extends StatelessWidget {
   final TextEditingController _contentController = TextEditingController();
 
   void _saveFile() async {
-    final String path = await FileSelectorPlatform.instance.getSavePath();
-    final String text = _contentController.text;
-    final String fileName = _nameController.text;
-    final Uint8List fileData = Uint8List.fromList(text.codeUnits);
-    final String fileMimeType = 'text/plain';
-    final XFile textFile =
+    final path = await FileSelectorPlatform.instance.getSavePath();
+    if (path == null) {
+      return;
+    }
+    final text = _contentController.text;
+    final fileName = _nameController.text;
+    final fileData = Uint8List.fromList(text.codeUnits);
+    const fileMimeType = 'text/plain';
+    final textFile =
         XFile.fromData(fileData, mimeType: fileMimeType, name: fileName);
     await textFile.saveTo(path);
   }
@@ -22,7 +25,7 @@ class SaveTextPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text("Save text into a file"),
+        title: Text('Save text into a file'),
       ),
       body: Center(
         child: Column(
@@ -51,11 +54,9 @@ class SaveTextPage extends StatelessWidget {
               ),
             ),
             SizedBox(height: 10),
-            RaisedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+            ElevatedButton(
               child: Text('Press to save a text file'),
-              onPressed: () => _saveFile(),
+              onPressed: _saveFile,
             ),
           ],
         ),

--- a/plugins/file_selector/example/pubspec.lock
+++ b/plugins/file_selector/example/pubspec.lock
@@ -7,91 +7,84 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.3"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.5"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.3"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.5"
+    version: "1.15.0"
   cross_file:
     dependency: transitive
     description:
       name: cross_file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.3"
+    version: "0.3.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.3"
+    version: "1.2.0"
   file_selector_linux:
     dependency: "direct main"
     description:
       path: "../file_selector_linux"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
   file_selector_macos:
     dependency: "direct main"
     description:
       path: "../file_selector_macos"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.3"
   file_selector_platform_interface:
     dependency: "direct main"
     description:
       name: file_selector_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.0"
   file_selector_windows:
     dependency: "direct main"
     description:
       path: "../file_selector_windows"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -108,49 +101,49 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.2"
+    version: "0.13.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.3"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.6"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.3"
+    version: "1.8.0"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.2"
+    version: "1.10.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "2.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -162,56 +155,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.4"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.6"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.3"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.6"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.5"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.5"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
-  flutter: ">=1.22.0 <2.0.0"
+  dart: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.22.0"

--- a/plugins/file_selector/example/pubspec.yaml
+++ b/plugins/file_selector/example/pubspec.yaml
@@ -1,30 +1,16 @@
 name: example
-description: A new Flutter project.
-
-# The following line prevents the package from being accidentally published to
-# pub.dev using `pub publish`. This is preferred for private packages.
+description: Local testbed for desktop file_selector implementations.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
-  file_selector_platform_interface: ^1.0.2
+  file_selector_platform_interface: ^2.0.0
   file_selector_linux:
     path: ../file_selector_linux
   file_selector_macos:
@@ -32,52 +18,9 @@ dependencies:
   file_selector_windows:
     path: ../file_selector_windows
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
-
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
Just to make absoulety sure that there are no issues with the platform
implementations for NNBD (e.g., bad dependency versions).

Also tidies up the example for this repo's analysis_options.yaml, since
it was written against flutter/plugins originally which has different
settings, as well as replacing some deprecated material buttons.