### PR TITLE
[file_selector] Ignore empty accept group lists on macOS

### DIFF
--- a/plugins/file_selector/file_selector_macos/macos/Classes/FLEFileSelectorPlugin.m
+++ b/plugins/file_selector/file_selector_macos/macos/Classes/FLEFileSelectorPlugin.m
@@ -56,7 +56,7 @@ id GetNonNullValueForKey( NSDictionary<NSString *, id>* dict, NSString* key) {
     panel.directoryURL = [NSURL URLWithString:initialDirectory];
   }
   NSArray<NSDictionary<NSString*, id>*>* acceptedTypeGroups = GetNonNullValueForKey(arguments, kAcceptedTypeGroupsKey);
-  if (acceptedTypeGroups) {
+  if (acceptedTypeGroups.count > 0) {
     // macOS doesn't support filter groups, so combine all allowed types into a flat list.
     NSMutableArray<NSString *> *allowedTypes = [NSMutableArray array];
     for (NSDictionary *filter in acceptedTypeGroups) {


### PR DESCRIPTION
The null safety migration for file_selector defaults the accept group to
an empty set rather than null, so empty set needs to be treated as no
filter. That's already the case for Windows and Linux; this makes macOS
consistent with that.