### PR TITLE
[window_size] Fix getWindowMinSize in Linux

### DIFF
--- a/plugins/window_size/linux/window_size_plugin.cc
+++ b/plugins/window_size/linux/window_size_plugin.cc
@@ -285,10 +285,21 @@ static FlMethodResponse* set_window_visible(FlWindowSizePlugin* self,
 // Gets the window minimum size.
 static FlMethodResponse* get_window_minimum_size(FlWindowSizePlugin* self) {
   g_autoptr(FlValue) size = fl_value_new_list();
-  fl_value_append_take(size,
-                       fl_value_new_float(self->window_geometry.min_width));
-  fl_value_append_take(size,
-                       fl_value_new_float(self->window_geometry.min_height));
+
+  gint min_width = self->window_geometry.min_width;
+  gint min_height = self->window_geometry.min_height;
+
+  // GTK uses -1 for the requisition size (the size GTK has calculated).
+  // Report this as zero (smallest possible) so this doesn't look like Size(-1, -1).
+  if (min_width < 0) {
+    min_width = 0;
+  }
+  if (min_height < 0) {
+    min_height = 0;
+  }
+
+  fl_value_append_take(size, fl_value_new_float(min_width));
+  fl_value_append_take(size, fl_value_new_float(min_height));
 
   return FL_METHOD_RESPONSE(fl_method_success_response_new(size));
 }


### PR DESCRIPTION
The GTK default is (-1, -1), which looks like Size(-1, -1) to Flutter.
GTK uses -1 for requisition size (the size GTK has calculated), so we map that to (0, 0).