### PR TITLE
Fixes #855

### DIFF
--- a/plugins/window_size/macos/Classes/FLEWindowSizePlugin.m
+++ b/plugins/window_size/macos/Classes/FLEWindowSizePlugin.m
@@ -36,7 +36,7 @@ static NSString *const kScreenKey = @"screen";
 /**
  * Returns the max Y coordinate across all screens.
  */
-CGFloat GetMaxScreenY() {
+CGFloat GetMaxScreenY(void) {
   CGFloat maxY = 0;
   for (NSScreen *screen in [NSScreen screens]) {
     maxY = MAX(maxY, CGRectGetMaxY(screen.frame));


### PR DESCRIPTION
This change avoids the compiler warning: this old-style function definition is not preceded by a prototype, when building the plugin window_size for macOS