### PR TITLE
Fix alphabetical key shortcuts.

### DIFF
--- a/plugins/menubar/lib/src/menu_channel.dart
+++ b/plugins/menubar/lib/src/menu_channel.dart
@@ -233,7 +233,7 @@ class MenuChannel {
         }
 
         if (key.keyLabel.isNotEmpty) {
-          channelRepresentation[_kShortcutKeyEquivalent] = key.keyLabel;
+          channelRepresentation[_kShortcutKeyEquivalent] = key.keyLabel.toLowerCase();
         } else {
           final specialKey = _shortcutSpecialKeyValues[key];
           if (specialKey == null) {


### PR DESCRIPTION
Fix alphabetical key shortcuts. A SHIFT modifier key was registered by accident since the keyLabel from a LogicalKeyboardKey in Flutter changed to an upper case value

Fixes https://github.com/google/flutter-desktop-embedding/issues/865