### PR TITLE
Remove unneeded libraries from Linux example

### DIFF
--- a/plugins/file_selector/example/linux/flutter/CMakeLists.txt
+++ b/plugins/file_selector/example/linux/flutter/CMakeLists.txt
@@ -24,8 +24,6 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
 pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
 pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0)
-pkg_check_modules(BLKID REQUIRED IMPORTED_TARGET blkid)
-pkg_check_modules(LZMA REQUIRED IMPORTED_TARGET liblzma)
 
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/libflutter_linux_gtk.so")
 

--- a/plugins/file_selector/example/linux/flutter/CMakeLists.txt
+++ b/plugins/file_selector/example/linux/flutter/CMakeLists.txt
@@ -65,8 +65,6 @@ target_link_libraries(flutter INTERFACE
   PkgConfig::GTK
   PkgConfig::GLIB
   PkgConfig::GIO
-  PkgConfig::BLKID
-  PkgConfig::LZMA
 )
 add_dependencies(flutter flutter_assemble)
 


### PR DESCRIPTION
Updates to match https://github.com/flutter/flutter/pull/78415

Avoids having a dependency that `doctor` no longer flags as necessary.

Fixes https://github.com/google/flutter-desktop-embedding/issues/867