### PR TITLE
[file_selector] Make SDK constraint non-prerelease

### DIFF
--- a/plugins/file_selector/file_selector_linux/pubspec.yaml
+++ b/plugins/file_selector/file_selector_linux/pubspec.yaml
@@ -11,7 +11,7 @@ flutter:
         pluginClass: FileSelectorPlugin
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.22.0"
 
 dependencies:

--- a/plugins/file_selector/file_selector_macos/pubspec.yaml
+++ b/plugins/file_selector/file_selector_macos/pubspec.yaml
@@ -11,7 +11,7 @@ flutter:
         pluginClass: FileSelectorPlugin
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.22.0"
 
 dependencies:

--- a/plugins/file_selector/file_selector_windows/pubspec.yaml
+++ b/plugins/file_selector/file_selector_windows/pubspec.yaml
@@ -11,7 +11,7 @@ flutter:
         pluginClass: FileSelectorPlugin
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.22.0"
 
 dependencies:


### PR DESCRIPTION
NNBD no longer requires a prerelease constraint. Fixes a publish
warning.