### PR TITLE
[window_size] Include cstring

### DIFF
--- a/plugins/window_size/linux/window_size_plugin.cc
+++ b/plugins/window_size/linux/window_size_plugin.cc
@@ -15,6 +15,7 @@
 
 #include <flutter_linux/flutter_linux.h>
 #include <gtk/gtk.h>
+
 #include <cstring>
 
 // See window_size_channel.dart for documentation.

--- a/plugins/window_size/linux/window_size_plugin.cc
+++ b/plugins/window_size/linux/window_size_plugin.cc
@@ -15,6 +15,7 @@
 
 #include <flutter_linux/flutter_linux.h>
 #include <gtk/gtk.h>
+#include <string.h>
 
 // See window_size_channel.dart for documentation.
 const char kChannelName[] = "flutter/windowsize";

--- a/plugins/window_size/linux/window_size_plugin.cc
+++ b/plugins/window_size/linux/window_size_plugin.cc
@@ -15,7 +15,7 @@
 
 #include <flutter_linux/flutter_linux.h>
 #include <gtk/gtk.h>
-#include <string.h>
+#include <cstring>
 
 // See window_size_channel.dart for documentation.
 const char kChannelName[] = "flutter/windowsize";


### PR DESCRIPTION
Hello everyone!

Nice plugin!

But in our gitlab CI the build failed with following error message:
```
/linux/flutter/ephemeral/.plugin_symlinks/window_size/linux/window_size_plugin.cc:345:7: error: use of undeclared identifier 'strcmp'
/linux/flutter/ephemeral/.plugin_symlinks/window_size/linux/window_size_plugin.cc:347:14: error: use of undeclared identifier 'strcmp'
/linux/flutter/ephemeral/.plugin_symlinks/window_size/linux/window_size_plugin.cc:349:14: error: use of undeclared identifier 'strcmp'
/linux/flutter/ephemeral/.plugin_symlinks/window_size/linux/window_size_plugin.cc:351:14: error: use of undeclared identifier 'strcmp'
/linux/flutter/ephemeral/.plugin_symlinks/window_size/linux/window_size_plugin.cc:353:14: error: use of undeclared identifier 'strcmp'
/linux/flutter/ephemeral/.plugin_symlinks/window_size/linux/window_size_plugin.cc:355:14: error: use of undeclared identifier 'strcmp'
/linux/flutter/ephemeral/.plugin_symlinks/window_size/linux/window_size_plugin.cc:357:14: error: use of undeclared identifier 'strcmp'
/linux/flutter/ephemeral/.plugin_symlinks/window_size/linux/window_size_plugin.cc:359:14: error: use of undeclared identifier 'strcmp'
/linux/flutter/ephemeral/.plugin_symlinks/window_size/linux/window_size_plugin.cc:361:14: error: use of undeclared identifier 'strcmp'
Build process failed
```

We are building in a container.

With `#include <string.h>` the container finds `strcmp` and builds with success