### PR TITLE
[menubar] Update to work with Flutter 3

### DIFF
--- a/plugins/menubar/lib/menubar.dart
+++ b/plugins/menubar/lib/menubar.dart
@@ -11,5 +11,5 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-export 'src/menu_item.dart';
+export 'src/native_menu_item.dart';
 export 'src/set_application_menu.dart';

--- a/plugins/menubar/lib/src/native_menu_item.dart
+++ b/plugins/menubar/lib/src/native_menu_item.dart
@@ -13,36 +13,28 @@
 // limitations under the License.
 import 'package:flutter/widgets.dart';
 
-/// A callback provided to [MenuItem] to handle menu selection.
-typedef MenuSelectedCallback = void Function();
-
 /// The base type for an individual menu item that can be shown in a menu.
-abstract class AbstractMenuItem {
+abstract class AbstractNativeMenuItem {
   /// Creates a new menu item with the give label.
-  const AbstractMenuItem(this.label);
+  const AbstractNativeMenuItem(this.label);
 
   /// The displayed label for the menu item.
   final String label;
 }
 
 /// A standard menu item, with no submenus.
-class MenuItem extends AbstractMenuItem {
+class NativeMenuItem extends AbstractNativeMenuItem {
   /// Creates a new menu item with the given [label] and options.
-  ///
-  /// Note that onClicked should generally be set unless [enabled] is false,
-  /// or the menu item will be selectable but not do anything.
-  const MenuItem({
+  const NativeMenuItem({
     required String label,
     this.shortcut,
-    this.enabled = true,
-    this.onClicked,
+    this.onSelected,
   }) : super(label);
 
   /// The callback to call whenever the menu item is selected.
-  final MenuSelectedCallback? onClicked;
-
-  /// Whether or not the menu item is enabled.
-  final bool enabled;
+  ///
+  /// If null, the menu item is disabled.
+  final VoidCallback? onSelected;
 
   /// The shortcut/accelerator for the menu item, if any.
   ///
@@ -58,16 +50,17 @@ class MenuItem extends AbstractMenuItem {
 /// A menu item continaing a submenu.
 ///
 /// The item itself can't be selected, it just displays the submenu.
-class Submenu extends AbstractMenuItem {
+class NativeSubmenu extends AbstractNativeMenuItem {
   /// Creates a new submenu with the given [label] and [children].
-  const Submenu({required String label, required this.children}) : super(label);
+  const NativeSubmenu({required String label, required this.children})
+      : super(label);
 
   /// The menu items contained in the submenu.
-  final List<AbstractMenuItem> children;
+  final List<AbstractNativeMenuItem> children;
 }
 
 /// A menu item that serves as a divider, generally drawn as a line.
-class MenuDivider extends AbstractMenuItem {
+class NativeMenuDivider extends AbstractNativeMenuItem {
   /// Creates a new divider item.
-  const MenuDivider() : super('');
+  const NativeMenuDivider() : super('');
 }

--- a/plugins/menubar/lib/src/set_application_menu.dart
+++ b/plugins/menubar/lib/src/set_application_menu.dart
@@ -14,12 +14,12 @@
 import 'dart:async';
 
 import 'menu_channel.dart';
-import 'menu_item.dart';
+import 'native_menu_item.dart';
 
 /// Sets the application menu for the app based on the [menuSpec].
 ///
-/// Adjacent [MenuDivider]s will be coalesced, leading and/or trailing
-/// [MenuDivider]s will be removed.
-Future<Null> setApplicationMenu(List<Submenu> menuSpec) async {
+/// Adjacent [NativeMenuDivider]s will be coalesced, leading and/or trailing
+/// [NativeMenuDivider]s will be removed.
+Future<Null> setApplicationMenu(List<NativeSubmenu> menuSpec) async {
   await MenuChannel.instance.setMenu(menuSpec);
 }

--- a/plugins/menubar/pubspec.yaml
+++ b/plugins/menubar/pubspec.yaml
@@ -1,6 +1,6 @@
 name: menubar
 description: Provides the ability to add native menubar items with Dart callbacks.
-version: 0.1.0
+version: 0.2.0
 
 # Do not publish this plugin. See:
 # https://github.com/google/flutter-desktop-embedding/blob/master/plugins/README.md#using-plugins

--- a/testbed/lib/keyboard_test_page.dart
+++ b/testbed/lib/keyboard_test_page.dart
@@ -113,7 +113,7 @@ class _KeyboardTestPageState extends State<KeyboardTestPage> {
     setState(() {
       _messages.add(message);
     });
-    SchedulerBinding.instance?.addPostFrameCallback((_) {
+    SchedulerBinding.instance.addPostFrameCallback((_) {
       _scrollController.jumpTo(
         _scrollController.position.maxScrollExtent,
       );

--- a/testbed/lib/main.dart
+++ b/testbed/lib/main.dart
@@ -86,62 +86,66 @@ class _AppState extends State<MyApp> {
   /// Rebuilds the native menu bar based on the current state.
   void updateMenubar() {
     setApplicationMenu([
-      Submenu(label: 'Color', children: [
-        MenuItem(
+      NativeSubmenu(label: 'Color', children: [
+        NativeMenuItem(
             label: 'Reset',
-            enabled: _primaryColor != Colors.blue,
             shortcut: LogicalKeySet(
                 LogicalKeyboardKey.meta, LogicalKeyboardKey.backspace),
-            onClicked: () {
-              setPrimaryColor(Colors.blue);
-            }),
-        MenuDivider(),
-        Submenu(label: 'Presets', children: [
-          MenuItem(
+            onSelected: _primaryColor == Colors.blue
+                ? null
+                : () {
+                    setPrimaryColor(Colors.blue);
+                  }),
+        NativeMenuDivider(),
+        NativeSubmenu(label: 'Presets', children: [
+          NativeMenuItem(
               label: 'Red',
-              enabled: _primaryColor != Colors.red,
               shortcut: LogicalKeySet(LogicalKeyboardKey.meta,
                   LogicalKeyboardKey.shift, LogicalKeyboardKey.keyR),
-              onClicked: () {
-                setPrimaryColor(Colors.red);
-              }),
-          MenuItem(
+              onSelected: _primaryColor == Colors.red
+                  ? null
+                  : () {
+                      setPrimaryColor(Colors.red);
+                    }),
+          NativeMenuItem(
               label: 'Green',
-              enabled: _primaryColor != Colors.green,
               shortcut: LogicalKeySet(LogicalKeyboardKey.meta,
                   LogicalKeyboardKey.alt, LogicalKeyboardKey.keyG),
-              onClicked: () {
-                setPrimaryColor(Colors.green);
-              }),
-          MenuItem(
+              onSelected: _primaryColor == Colors.green
+                  ? null
+                  : () {
+                      setPrimaryColor(Colors.green);
+                    }),
+          NativeMenuItem(
               label: 'Purple',
-              enabled: _primaryColor != Colors.deepPurple,
               shortcut: LogicalKeySet(LogicalKeyboardKey.meta,
                   LogicalKeyboardKey.control, LogicalKeyboardKey.keyP),
-              onClicked: () {
-                setPrimaryColor(Colors.deepPurple);
-              }),
+              onSelected: _primaryColor == Colors.deepPurple
+                  ? null
+                  : () {
+                      setPrimaryColor(Colors.deepPurple);
+                    }),
         ])
       ]),
-      Submenu(label: 'Counter', children: [
-        MenuItem(
+      NativeSubmenu(label: 'Counter', children: [
+        NativeMenuItem(
             label: 'Reset',
-            enabled: _counter != 0,
             shortcut: LogicalKeySet(
                 LogicalKeyboardKey.meta, LogicalKeyboardKey.digit0),
-            onClicked: () {
-              _setCounter(0);
-            }),
-        MenuDivider(),
-        MenuItem(
+            onSelected: _counter == 0
+                ? null
+                : () {
+                    _setCounter(0);
+                  }),
+        NativeMenuDivider(),
+        NativeMenuItem(
             label: 'Increment',
             shortcut: LogicalKeySet(LogicalKeyboardKey.f2),
-            onClicked: incrementCounter),
-        MenuItem(
+            onSelected: incrementCounter),
+        NativeMenuItem(
             label: 'Decrement',
-            enabled: _counter > 0,
             shortcut: LogicalKeySet(LogicalKeyboardKey.f1),
-            onClicked: _decrementCounter),
+            onSelected: _counter == 0 ? null : _decrementCounter),
       ]),
     ]);
   }
@@ -151,12 +155,12 @@ class _AppState extends State<MyApp> {
     // Any time the state changes, the menu needs to be rebuilt.
     updateMenubar();
 
+    final theme = ThemeData();
     return MaterialApp(
       title: 'Flutter Demo',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-        primaryColor: _primaryColor,
-        accentColor: _primaryColor,
+      theme: theme.copyWith(
+        colorScheme: theme.colorScheme
+            .copyWith(primary: _primaryColor, secondary: _primaryColor),
       ),
       darkTheme: ThemeData.dark(),
       home: _MyHomePage(title: 'Flutter Demo Home Page', counter: _counter),

--- a/testbed/linux/flutter/generated_plugin_registrant.cc
+++ b/testbed/linux/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
 #include <menubar/menubar_plugin.h>

--- a/testbed/linux/flutter/generated_plugin_registrant.h
+++ b/testbed/linux/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/testbed/linux/flutter/generated_plugins.cmake
+++ b/testbed/linux/flutter/generated_plugins.cmake
@@ -7,6 +7,9 @@ list(APPEND FLUTTER_PLUGIN_LIST
   window_size
 )
 
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -15,3 +18,8 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/linux plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/testbed/macos/Podfile.lock
+++ b/testbed/macos/Podfile.lock
@@ -19,10 +19,10 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/window_size/macos
 
 SPEC CHECKSUMS:
-  FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
+  FlutterMacOS: ae6af50a8ea7d6103d888583d46bd8328a7e9811
   menubar: 4e3d461d62d775540277ce6639acafe2a111a231
   window_size: 339dafa0b27a95a62a843042038fa6c3c48de195
 
 PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.11.3

--- a/testbed/pubspec.yaml
+++ b/testbed/pubspec.yaml
@@ -3,7 +3,7 @@ description: A test project for flutter-desktop-embedding.
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'
-  flutter: '>=1.22.0-10.0.pre'
+  flutter: '>=3.0.0'
 
 dependencies:
   flutter:

--- a/testbed/windows/flutter/generated_plugin_registrant.cc
+++ b/testbed/windows/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
 #include <menubar/menubar_plugin.h>

--- a/testbed/windows/flutter/generated_plugin_registrant.h
+++ b/testbed/windows/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/testbed/windows/flutter/generated_plugins.cmake
+++ b/testbed/windows/flutter/generated_plugins.cmake
@@ -7,6 +7,9 @@ list(APPEND FLUTTER_PLUGIN_LIST
   window_size
 )
 
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -15,3 +18,8 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)


### PR DESCRIPTION
Updates the `menubar` plugin to work with Flutter 3. This does not yet
add interoperability with the new built-in menubar support, it just
makes the existing plugin usable with Flutter 3:
- Renames `MenuItem` to `NativeMenuItem` to avoid a collision with the
  new framework class of the same name. (Renames rather than using
  prefixing to reduce potential confusion.)
- Adds `Native` to other related classes for consistency.
- To begin aligning with the built-in version, renames `onClicked` to
  `onSelected`, and eliminated `enabled` in favor of checking
  `onSelected` for null.

Other minor updates:
- Updates use of deprecated color specification in testbed.
- Applies tool-generated changes to various testbed files.
- Updates for binding nullability changes.
- Eliminated the unnecessary `MenuSelectedCallback` typedef.

Fixes https://github.com/google/flutter-desktop-embedding/issues/902