### PR TITLE
[file_selector] Add Linux-specific Dart implementation

### DIFF
--- a/plugins/file_selector/analysis_options.yaml
+++ b/plugins/file_selector/analysis_options.yaml
@@ -1,0 +1,248 @@
+# This is a copy of the flutter/plugins analysis options file, to avoid
+# needing to make a lot of Dart style changes when moving the plugin.
+
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+  errors:
+    # treat missing required parameters as a warning (not a hint)
+    missing_required_param: warning
+    # treat missing returns as a warning (not a hint)
+    missing_return: warning
+    # allow having TODO comments in the code
+    todo: ignore
+    # allow self-reference to deprecated members (we do this because otherwise we have
+    # to annotate every member in every test, assert, etc, when we deprecate something)
+    deprecated_member_use_from_same_package: ignore
+    # Ignore analyzer hints for updating pubspecs when using Future or
+    # Stream and not importing dart:async
+    # Please see https://github.com/flutter/flutter/pull/24528 for details.
+    sdk_version_async_exported_from_core: ignore
+    # Turned off until null-safe rollout is complete.
+    unnecessary_null_comparison: ignore
+    ### Local flutter/plugins changes ###
+    # Allow null checks for as long as mixed mode is officially supported.
+    always_require_non_null_named_parameters: false # not needed with nnbd
+  exclude:
+    # Ignore generated files
+    - '**/*.g.dart'
+    - 'lib/src/generated/*.dart'
+    - '**/*.mocks.dart' # Mockito @GenerateMocks
+    - '**/*.pigeon.dart' # Pigeon generated file
+
+linter:
+  rules:
+    # This list is derived from the list of all available lints located at
+    # https://github.com/dart-lang/linter/blob/master/example/all.yaml
+    - always_declare_return_types
+    - always_put_control_body_on_new_line
+    # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
+    - always_require_non_null_named_parameters
+    - always_specify_types
+    # - always_use_package_imports # we do this commonly
+    - annotate_overrides
+    # - avoid_annotating_with_dynamic # conflicts with always_specify_types
+    - avoid_bool_literals_in_conditional_expressions
+    # - avoid_catches_without_on_clauses # blocked on https://github.com/dart-lang/linter/issues/3023
+    # - avoid_catching_errors # blocked on https://github.com/dart-lang/linter/issues/3023
+    - avoid_classes_with_only_static_members
+    - avoid_double_and_int_checks
+    # - avoid_dynamic_calls # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    - avoid_empty_else
+    - avoid_equals_and_hash_code_on_mutable_classes
+    - avoid_escaping_inner_quotes
+    - avoid_field_initializers_in_const_classes
+    # - avoid_final_parameters # incompatible with prefer_final_parameters
+    - avoid_function_literals_in_foreach_calls
+    # - avoid_implementing_value_types # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    - avoid_init_to_null
+    - avoid_js_rounded_ints
+    # - avoid_multiple_declarations_per_line # seems to be a stylistic choice we don't subscribe to
+    - avoid_null_checks_in_equality_operators
+    # - avoid_positional_boolean_parameters # would have been nice to enable this but by now there's too many places that break it
+    # - avoid_print # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
+    - avoid_redundant_argument_values
+    - avoid_relative_lib_imports
+    - avoid_renaming_method_parameters
+    - avoid_return_types_on_setters
+    # - avoid_returning_null # still violated by some pre-nnbd code that we haven't yet migrated
+    - avoid_returning_null_for_future
+    - avoid_returning_null_for_void
+    # - avoid_returning_this # there are enough valid reasons to return `this` that this lint ends up with too many false positives
+    - avoid_setters_without_getters
+    - avoid_shadowing_type_parameters
+    - avoid_single_cascade_in_expression_statements
+    - avoid_slow_async_io
+    - avoid_type_to_string
+    - avoid_types_as_parameter_names
+    # - avoid_types_on_closure_parameters # conflicts with always_specify_types
+    - avoid_unnecessary_containers
+    - avoid_unused_constructor_parameters
+    - avoid_void_async
+    # - avoid_web_libraries_in_flutter # we use web libraries in web-specific code, and our tests prevent us from using them elsewhere
+    - await_only_futures
+    - camel_case_extensions
+    - camel_case_types
+    - cancel_subscriptions
+    # - cascade_invocations # doesn't match the typical style of this repo
+    - cast_nullable_to_non_nullable
+    # - close_sinks # not reliable enough
+    # - comment_references # blocked on https://github.com/dart-lang/linter/issues/1142
+    # - conditional_uri_does_not_exist # not yet tested
+    # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
+    - control_flow_in_finally
+    # - curly_braces_in_flow_control_structures # not required by flutter style
+    # - depend_on_referenced_packages # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    - deprecated_consistency
+    # - diagnostic_describe_all_properties # enabled only at the framework level (packages/flutter/lib)
+    - directives_ordering
+    # - do_not_use_environment # there are appropriate times to use the environment, especially in our tests and build logic
+    - empty_catches
+    - empty_constructor_bodies
+    - empty_statements
+    - eol_at_end_of_file
+    - exhaustive_cases
+    - file_names
+    - flutter_style_todos
+    - hash_and_equals
+    - implementation_imports
+    # - invariant_booleans # too many false positives: https://github.com/dart-lang/linter/issues/811
+    - iterable_contains_unrelated_type
+    # - join_return_with_assignment # not required by flutter style
+    - leading_newlines_in_multiline_strings
+    - library_names
+    - library_prefixes
+    - library_private_types_in_public_api
+    # - lines_longer_than_80_chars # not required by flutter style
+    - list_remove_unrelated_type
+    # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/linter/issues/453
+    - missing_whitespace_between_adjacent_strings
+    - no_adjacent_strings_in_list
+    # - no_default_cases # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    - no_duplicate_case_values
+    - no_leading_underscores_for_library_prefixes
+    # - no_leading_underscores_for_local_identifiers # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    - no_logic_in_create_state
+    # - no_runtimeType_toString # ok in tests; we enable this only in packages/
+    - non_constant_identifier_names
+    - noop_primitive_operations
+    - null_check_on_nullable_type_parameter
+    - null_closures
+    # - omit_local_variable_types # opposite of always_specify_types
+    # - one_member_abstracts # too many false positives
+    # - only_throw_errors # this does get disabled in a few places where we have legacy code that uses strings et al # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    - overridden_fields
+    - package_api_docs
+    - package_names
+    - package_prefixed_library_names
+    # - parameter_assignments # we do this commonly
+    - prefer_adjacent_string_concatenation
+    - prefer_asserts_in_initializer_lists
+    # - prefer_asserts_with_message # not required by flutter style
+    - prefer_collection_literals
+    - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
+    # - prefer_constructors_over_static_methods # far too many false positives
+    - prefer_contains
+    # - prefer_double_quotes # opposite of prefer_single_quotes
+    - prefer_equal_for_default_values
+    # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
+    - prefer_final_fields
+    - prefer_final_in_for_each
+    - prefer_final_locals
+    # - prefer_final_parameters # we should enable this one day when it can be auto-fixed (https://github.com/dart-lang/linter/issues/3104), see also parameter_assignments
+    - prefer_for_elements_to_map_fromIterable
+    - prefer_foreach
+    - prefer_function_declarations_over_variables
+    - prefer_generic_function_type_aliases
+    - prefer_if_elements_to_conditional_expressions
+    - prefer_if_null_operators
+    - prefer_initializing_formals
+    - prefer_inlined_adds
+    # - prefer_int_literals # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#use-double-literals-for-double-constants
+    - prefer_interpolation_to_compose_strings
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_is_not_operator
+    - prefer_iterable_whereType
+    # - prefer_mixin # Has false positives, see https://github.com/dart-lang/linter/issues/3018
+    # - prefer_null_aware_method_calls # "call()" is confusing to people new to the language since it's not documented anywhere
+    - prefer_null_aware_operators
+    # - prefer_relative_imports # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    - prefer_single_quotes
+    - prefer_spread_collections
+    - prefer_typing_uninitialized_variables
+    - prefer_void_to_null
+    - provide_deprecation_message
+    # - public_member_api_docs # enabled on a case-by-case basis; see e.g. packages/analysis_options.yaml
+    - recursive_getters
+    # - require_trailing_commas # blocked on https://github.com/dart-lang/sdk/issues/47441
+    - secure_pubspec_urls
+    # - sized_box_for_whitespace # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    # - sized_box_shrink_expand # not yet tested
+    - slash_for_doc_comments
+    - sort_child_properties_last
+    - sort_constructors_first
+    # - sort_pub_dependencies # prevents separating pinned transitive dependencies
+    - sort_unnamed_constructors_first
+    - test_types_in_equals
+    - throw_in_finally
+    - tighten_type_of_initializing_formals
+    # - type_annotate_public_apis # subset of always_specify_types
+    - type_init_formals
+    # - unawaited_futures # too many false positives, especially with the way AnimationController works
+    # - unnecessary_await_in_return # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    - unnecessary_brace_in_string_interps
+    - unnecessary_const
+    - unnecessary_constructor_name
+    # - unnecessary_final # conflicts with prefer_final_locals
+    - unnecessary_getters_setters
+    # - unnecessary_lambdas # has false positives: https://github.com/dart-lang/linter/issues/498
+    - unnecessary_late
+    - unnecessary_new
+    - unnecessary_null_aware_assignments
+    - unnecessary_null_checks
+    - unnecessary_null_in_if_null_operators
+    - unnecessary_nullable_for_final_variable_declarations
+    - unnecessary_overrides
+    - unnecessary_parenthesis
+    # - unnecessary_raw_strings # what's "necessary" is a matter of opinion; consistency across strings can help readability more than this lint
+    - unnecessary_statements
+    - unnecessary_string_escapes
+    - unnecessary_string_interpolations
+    - unnecessary_this
+    - unrelated_type_equality_checks
+    - unsafe_html
+    # - use_build_context_synchronously # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    # - use_colored_box # not yet tested
+    # - use_decorated_box # not yet tested
+    # - use_enums # not yet tested
+    - use_full_hex_values_for_flutter_colors
+    - use_function_type_syntax_for_parameters
+    - use_if_null_to_convert_nulls_to_bools
+    - use_is_even_rather_than_modulo
+    - use_key_in_widget_constructors
+    - use_late_for_private_fields_and_variables
+    # - use_named_constants # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    - use_raw_strings
+    - use_rethrow_when_possible
+    - use_setters_to_change_properties
+    # - use_string_buffers # has false positives: https://github.com/dart-lang/sdk/issues/34182
+    - use_super_parameters
+    - use_test_throws_matchers
+    # - use_to_and_as_if_applicable # has false positives, so we prefer to catch this by code-review
+    - valid_regexps
+    - void_checks
+    ### Local flutter/plugins additions ###
+    # These are from flutter/flutter/packages, so will need to be preserved
+    # separately when moving to a shared file.
+    - no_runtimeType_toString # use objectRuntimeType from package:foundation
+    - public_member_api_docs # see https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#documentation-dartdocs-javadocs-etc
+    # Flutter has a specific use case for dependencies that are intentionally
+    # not sorted, which doesn't apply to this repo.
+    - sort_pub_dependencies

--- a/plugins/file_selector/file_selector_linux/example/analysis_options.yaml
+++ b/plugins/file_selector/file_selector_linux/example/analysis_options.yaml
@@ -1,1 +1,0 @@
-include: ../../../../analysis_options.yaml

--- a/plugins/file_selector/file_selector_linux/example/lib/get_directory_page.dart
+++ b/plugins/file_selector/file_selector_linux/example/lib/get_directory_page.dart
@@ -1,16 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/material.dart';
 
-/// Screen that shows an example of getDirectoryPath
+/// Screen that allows the user to select a directory using `getDirectoryPath`,
+///  then displays the selected directory in a dialog.
 class GetDirectoryPage extends StatelessWidget {
-  void _getDirectoryPath(BuildContext context) async {
-    const confirmButtonText = 'Choose';
-    final directoryPath = await FileSelectorPlatform.instance.getDirectoryPath(
+  /// Default Constructor
+  const GetDirectoryPage({Key? key}) : super(key: key);
+
+  Future<void> _getDirectoryPath(BuildContext context) async {
+    const String confirmButtonText = 'Choose';
+    final String? directoryPath =
+        await FileSelectorPlatform.instance.getDirectoryPath(
       confirmButtonText: confirmButtonText,
     );
-    await showDialog(
+    if (directoryPath == null) {
+      // Operation was canceled by the user.
+      return;
+    }
+    await showDialog<void>(
       context: context,
-      builder: (context) => TextDisplay(directoryPath ?? 'Unknown'),
+      builder: (BuildContext context) => TextDisplay(directoryPath),
     );
   }
 
@@ -18,13 +31,20 @@ class GetDirectoryPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Open a text file'),
+        title: const Text('Open a text file'),
       ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
+                primary: Colors.blue,
+                // ignore: deprecated_member_use
+                onPrimary: Colors.white,
+              ),
               child: const Text('Press to ask user to choose a directory'),
               onPressed: () => _getDirectoryPath(context),
             ),
@@ -35,24 +55,24 @@ class GetDirectoryPage extends StatelessWidget {
   }
 }
 
-/// Widget that displays a text file in a dialog
+/// Widget that displays a text file in a dialog.
 class TextDisplay extends StatelessWidget {
-  /// Default Constructor
-  const TextDisplay(this.directoryPath);
+  /// Creates a `TextDisplay`.
+  const TextDisplay(this.directoryPath, {Key? key}) : super(key: key);
 
-  /// Directory path
+  /// The path selected in the dialog.
   final String directoryPath;
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text('Selected Directory'),
+      title: const Text('Selected Directory'),
       content: Scrollbar(
         child: SingleChildScrollView(
           child: Text(directoryPath),
         ),
       ),
-      actions: [
+      actions: <Widget>[
         TextButton(
           child: const Text('Close'),
           onPressed: () => Navigator.pop(context),

--- a/plugins/file_selector/file_selector_linux/example/lib/home_page.dart
+++ b/plugins/file_selector/file_selector_linux/example/lib/home_page.dart
@@ -1,38 +1,57 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 
-/// Home Page of the application
+/// Home Page of the application.
 class HomePage extends StatelessWidget {
+  /// Default Constructor
+  const HomePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
+    final ButtonStyle style = ElevatedButton.styleFrom(
+      // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+      // ignore: deprecated_member_use
+      primary: Colors.blue,
+      // ignore: deprecated_member_use
+      onPrimary: Colors.white,
+    );
     return Scaffold(
       appBar: AppBar(
-        title: Text('File Selector Demo Home Page'),
+        title: const Text('File Selector Demo Home Page'),
       ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
+              style: style,
               child: const Text('Open a text file'),
               onPressed: () => Navigator.pushNamed(context, '/open/text'),
             ),
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             ElevatedButton(
+              style: style,
               child: const Text('Open an image'),
               onPressed: () => Navigator.pushNamed(context, '/open/image'),
             ),
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             ElevatedButton(
+              style: style,
               child: const Text('Open multiple images'),
               onPressed: () => Navigator.pushNamed(context, '/open/images'),
             ),
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             ElevatedButton(
+              style: style,
               child: const Text('Save a file'),
               onPressed: () => Navigator.pushNamed(context, '/save/text'),
             ),
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             ElevatedButton(
+              style: style,
               child: const Text('Open a get directory dialog'),
               onPressed: () => Navigator.pushNamed(context, '/directory'),
             ),

--- a/plugins/file_selector/file_selector_linux/example/lib/main.dart
+++ b/plugins/file_selector/file_selector_linux/example/lib/main.dart
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 
 import 'get_directory_page.dart';
@@ -8,11 +12,14 @@ import 'open_text_page.dart';
 import 'save_text_page.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(const MyApp());
 }
 
-/// MyApp is the Main Application
+/// MyApp is the Main Application.
 class MyApp extends StatelessWidget {
+  /// Default Constructor
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -21,13 +28,14 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      home: HomePage(),
-      routes: {
-        '/open/image': (context) => OpenImagePage(),
-        '/open/images': (context) => OpenMultipleImagesPage(),
-        '/open/text': (context) => OpenTextPage(),
-        '/save/text': (context) => SaveTextPage(),
-        '/directory': (context) => GetDirectoryPage(),
+      home: const HomePage(),
+      routes: <String, WidgetBuilder>{
+        '/open/image': (BuildContext context) => const OpenImagePage(),
+        '/open/images': (BuildContext context) =>
+            const OpenMultipleImagesPage(),
+        '/open/text': (BuildContext context) => const OpenTextPage(),
+        '/save/text': (BuildContext context) => SaveTextPage(),
+        '/directory': (BuildContext context) => const GetDirectoryPage(),
       },
     );
   }

--- a/plugins/file_selector/file_selector_linux/example/lib/main.dart
+++ b/plugins/file_selector/file_selector_linux/example/lib/main.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 
 import 'get_directory_page.dart';
 import 'home_page.dart';
-import 'open_text_page.dart';
 import 'open_image_page.dart';
 import 'open_multiple_images_page.dart';
+import 'open_text_page.dart';
 import 'save_text_page.dart';
 
 void main() {

--- a/plugins/file_selector/file_selector_linux/example/lib/open_image_page.dart
+++ b/plugins/file_selector/file_selector_linux/example/lib/open_image_page.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
-import 'package:flutter/foundation.dart';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// Screen that shows an example of openFiles

--- a/plugins/file_selector/file_selector_linux/example/lib/open_image_page.dart
+++ b/plugins/file_selector/file_selector_linux/example/lib/open_image_page.dart
@@ -1,24 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:io';
+
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-/// Screen that shows an example of openFiles
+/// Screen that allows the user to select an image file using
+/// `openFiles`, then displays the selected images in a gallery dialog.
 class OpenImagePage extends StatelessWidget {
-  void _openImageFile(BuildContext context) async {
-    final typeGroup = XTypeGroup(
-      label: 'images',
-      extensions: ['jpg', 'png'],
-    );
-    final files = await FileSelectorPlatform.instance
-        .openFiles(acceptedTypeGroups: [typeGroup]);
-    final file = files[0];
-    final fileName = file.name;
-    final filePath = file.path;
+  /// Default Constructor
+  const OpenImagePage({Key? key}) : super(key: key);
 
-    await showDialog(
+  Future<void> _openImageFile(BuildContext context) async {
+    final XTypeGroup typeGroup = XTypeGroup(
+      label: 'images',
+      extensions: <String>['jpg', 'png'],
+    );
+    final XFile? file = await FileSelectorPlatform.instance
+        .openFile(acceptedTypeGroups: <XTypeGroup>[typeGroup]);
+    if (file == null) {
+      // Operation was canceled by the user.
+      return;
+    }
+    final String fileName = file.name;
+    final String filePath = file.path;
+
+    await showDialog<void>(
       context: context,
-      builder: (context) => ImageDisplay(fileName, filePath),
+      builder: (BuildContext context) => ImageDisplay(fileName, filePath),
     );
   }
 
@@ -26,13 +38,20 @@ class OpenImagePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Open an image'),
+        title: const Text('Open an image'),
       ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
+                primary: Colors.blue,
+                // ignore: deprecated_member_use
+                onPrimary: Colors.white,
+              ),
               child: const Text('Press to open an image file(png, jpg)'),
               onPressed: () => _openImageFile(context),
             ),
@@ -43,15 +62,16 @@ class OpenImagePage extends StatelessWidget {
   }
 }
 
-/// Widget that displays a text file in a dialog
+/// Widget that displays an image in a dialog.
 class ImageDisplay extends StatelessWidget {
-  /// Default Constructor
-  const ImageDisplay(this.fileName, this.filePath);
+  /// Default Constructor.
+  const ImageDisplay(this.fileName, this.filePath, {Key? key})
+      : super(key: key);
 
-  /// Image's name
+  /// The name of the selected file.
   final String fileName;
 
-  /// Image's path
+  /// The path to the selected file.
   final String filePath;
 
   @override
@@ -61,7 +81,7 @@ class ImageDisplay extends StatelessWidget {
       // On web the filePath is a blob url
       // while on other platforms it is a system path.
       content: kIsWeb ? Image.network(filePath) : Image.file(File(filePath)),
-      actions: [
+      actions: <Widget>[
         TextButton(
           child: const Text('Close'),
           onPressed: () {

--- a/plugins/file_selector/file_selector_linux/example/lib/open_multiple_images_page.dart
+++ b/plugins/file_selector/file_selector_linux/example/lib/open_multiple_images_page.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
-import 'package:flutter/foundation.dart';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// Screen that shows an example of openFiles

--- a/plugins/file_selector/file_selector_linux/example/lib/open_multiple_images_page.dart
+++ b/plugins/file_selector/file_selector_linux/example/lib/open_multiple_images_page.dart
@@ -1,27 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:io';
+
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-/// Screen that shows an example of openFiles
+/// Screen that allows the user to select multiple image files using
+/// `openFiles`, then displays the selected images in a gallery dialog.
 class OpenMultipleImagesPage extends StatelessWidget {
-  void _openImageFile(BuildContext context) async {
-    final jpgsTypeGroup = XTypeGroup(
+  /// Default Constructor
+  const OpenMultipleImagesPage({Key? key}) : super(key: key);
+
+  Future<void> _openImageFile(BuildContext context) async {
+    final XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
-      extensions: ['jpg', 'jpeg'],
+      extensions: <String>['jpg', 'jpeg'],
     );
-    final pngTypeGroup = XTypeGroup(
+    final XTypeGroup pngTypeGroup = XTypeGroup(
       label: 'PNGs',
-      extensions: ['png'],
+      extensions: <String>['png'],
     );
-    final files =
-        await FileSelectorPlatform.instance.openFiles(acceptedTypeGroups: [
+    final List<XFile> files = await FileSelectorPlatform.instance
+        .openFiles(acceptedTypeGroups: <XTypeGroup>[
       jpgsTypeGroup,
       pngTypeGroup,
     ]);
-    await showDialog(
+    if (files.isEmpty) {
+      // Operation was canceled by the user.
+      return;
+    }
+    await showDialog<void>(
       context: context,
-      builder: (context) => MultipleImagesDisplay(files),
+      builder: (BuildContext context) => MultipleImagesDisplay(files),
     );
   }
 
@@ -29,13 +42,20 @@ class OpenMultipleImagesPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Open multiple images'),
+        title: const Text('Open multiple images'),
       ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
+                primary: Colors.blue,
+                // ignore: deprecated_member_use
+                onPrimary: Colors.white,
+              ),
               child: const Text('Press to open multiple images (png, jpg)'),
               onPressed: () => _openImageFile(context),
             ),
@@ -46,25 +66,25 @@ class OpenMultipleImagesPage extends StatelessWidget {
   }
 }
 
-/// Widget that displays a text file in a dialog
+/// Widget that displays a text file in a dialog.
 class MultipleImagesDisplay extends StatelessWidget {
-  /// Default Constructor
-  const MultipleImagesDisplay(this.files);
+  /// Default Constructor.
+  const MultipleImagesDisplay(this.files, {Key? key}) : super(key: key);
 
-  /// The files containing the images
+  /// The files containing the images.
   final List<XFile> files;
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text('Gallery'),
+      title: const Text('Gallery'),
       // On web the filePath is a blob url
       // while on other platforms it is a system path.
       content: Center(
         child: Row(
           children: <Widget>[
             ...files.map(
-              (file) => Flexible(
+              (XFile file) => Flexible(
                   child: kIsWeb
                       ? Image.network(file.path)
                       : Image.file(File(file.path))),
@@ -72,7 +92,7 @@ class MultipleImagesDisplay extends StatelessWidget {
           ],
         ),
       ),
-      actions: [
+      actions: <Widget>[
         TextButton(
           child: const Text('Close'),
           onPressed: () {

--- a/plugins/file_selector/file_selector_linux/example/lib/open_text_page.dart
+++ b/plugins/file_selector/file_selector_linux/example/lib/open_text_page.dart
@@ -1,24 +1,33 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/material.dart';
 
-/// Screen that shows an example of openFile
+/// Screen that allows the user to select a text file using `openFile`, then
+/// displays its contents in a dialog.
 class OpenTextPage extends StatelessWidget {
-  void _openTextFile(BuildContext context) async {
-    final typeGroup = XTypeGroup(
+  /// Default Constructor
+  const OpenTextPage({Key? key}) : super(key: key);
+
+  Future<void> _openTextFile(BuildContext context) async {
+    final XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
-      extensions: ['txt', 'json'],
+      extensions: <String>['txt', 'json'],
     );
-    final file = await FileSelectorPlatform.instance
-        .openFile(acceptedTypeGroups: [typeGroup]);
+    final XFile? file = await FileSelectorPlatform.instance
+        .openFile(acceptedTypeGroups: <XTypeGroup>[typeGroup]);
     if (file == null) {
+      // Operation was canceled by the user.
       return;
     }
-    final fileName = file.name;
-    final fileContent = await file.readAsString();
+    final String fileName = file.name;
+    final String fileContent = await file.readAsString();
 
-    await showDialog(
+    await showDialog<void>(
       context: context,
-      builder: (context) => TextDisplay(fileName, fileContent),
+      builder: (BuildContext context) => TextDisplay(fileName, fileContent),
     );
   }
 
@@ -26,13 +35,20 @@ class OpenTextPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Open a text file'),
+        title: const Text('Open a text file'),
       ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
+                primary: Colors.blue,
+                // ignore: deprecated_member_use
+                onPrimary: Colors.white,
+              ),
               child: const Text('Press to open a text file (json, txt)'),
               onPressed: () => _openTextFile(context),
             ),
@@ -43,15 +59,16 @@ class OpenTextPage extends StatelessWidget {
   }
 }
 
-/// Widget that displays a text file in a dialog
+/// Widget that displays a text file in a dialog.
 class TextDisplay extends StatelessWidget {
-  /// Default Constructor
-  const TextDisplay(this.fileName, this.fileContent);
+  /// Default Constructor.
+  const TextDisplay(this.fileName, this.fileContent, {Key? key})
+      : super(key: key);
 
-  /// File's name
+  /// The name of the selected file.
   final String fileName;
 
-  /// File to display
+  /// The contents of the text file.
   final String fileContent;
 
   @override
@@ -63,7 +80,7 @@ class TextDisplay extends StatelessWidget {
           child: Text(fileContent),
         ),
       ),
-      actions: [
+      actions: <Widget>[
         TextButton(
           child: const Text('Close'),
           onPressed: () => Navigator.pop(context),

--- a/plugins/file_selector/file_selector_linux/example/lib/save_text_page.dart
+++ b/plugins/file_selector/file_selector_linux/example/lib/save_text_page.dart
@@ -1,24 +1,33 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:typed_data';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/material.dart';
 
-/// Page for showing an example of saving with file_selector
+/// Screen that allows the user to select a save location using `getSavePath`,
+/// then writes text to a file at that location.
 class SaveTextPage extends StatelessWidget {
+  /// Default Constructor
+  SaveTextPage({Key? key}) : super(key: key);
+
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _contentController = TextEditingController();
 
-  void _saveFile() async {
-    final fileName = _nameController.text;
-    final path = await FileSelectorPlatform.instance.getSavePath(
+  Future<void> _saveFile() async {
+    final String fileName = _nameController.text;
+    final String? path = await FileSelectorPlatform.instance.getSavePath(
+      // Operation was canceled by the user.
       suggestedName: fileName,
     );
     if (path == null) {
       return;
     }
-    final text = _contentController.text;
-    final fileData = Uint8List.fromList(text.codeUnits);
-    const fileMimeType = 'text/plain';
-    final textFile =
+    final String text = _contentController.text;
+    final Uint8List fileData = Uint8List.fromList(text.codeUnits);
+    const String fileMimeType = 'text/plain';
+    final XFile textFile =
         XFile.fromData(fileData, mimeType: fileMimeType, name: fileName);
     await textFile.saveTo(path);
   }
@@ -27,7 +36,7 @@ class SaveTextPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Save text into a file'),
+        title: const Text('Save text into a file'),
       ),
       body: Center(
         child: Column(
@@ -39,7 +48,7 @@ class SaveTextPage extends StatelessWidget {
                 minLines: 1,
                 maxLines: 12,
                 controller: _nameController,
-                decoration: InputDecoration(
+                decoration: const InputDecoration(
                   hintText: '(Optional) Suggest File Name',
                 ),
               ),
@@ -50,15 +59,22 @@ class SaveTextPage extends StatelessWidget {
                 minLines: 1,
                 maxLines: 12,
                 controller: _contentController,
-                decoration: InputDecoration(
+                decoration: const InputDecoration(
                   hintText: 'Enter File Contents',
                 ),
               ),
             ),
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             ElevatedButton(
-              child: const Text('Press to save a text file'),
+              style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
+                primary: Colors.blue,
+                // ignore: deprecated_member_use
+                onPrimary: Colors.white,
+              ),
               onPressed: _saveFile,
+              child: const Text('Press to save a text file'),
             ),
           ],
         ),

--- a/plugins/file_selector/file_selector_linux/example/pubspec.yaml
+++ b/plugins/file_selector/file_selector_linux/example/pubspec.yaml
@@ -7,12 +7,11 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
-
-  file_selector_platform_interface: ^2.0.0
   file_selector_linux:
     path: ../
+  file_selector_platform_interface: ^2.0.0
+  flutter:
+    sdk: flutter
 
 dev_dependencies:
   flutter_test:

--- a/plugins/file_selector/file_selector_linux/lib/file_selector_linux.dart
+++ b/plugins/file_selector/file_selector_linux/lib/file_selector_linux.dart
@@ -1,0 +1,96 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/services.dart';
+
+const MethodChannel _channel =
+    MethodChannel('plugins.flutter.io/file_selector');
+
+/// An implementation of [FileSelectorPlatform] for Linux.
+class FileSelectorLinux extends FileSelectorPlatform {
+  /// The MethodChannel that is being used by this implementation of the plugin.
+  @visibleForTesting
+  MethodChannel get channel => _channel;
+
+  /// Registers the Linux implementation.
+  static void registerWith() {
+    FileSelectorPlatform.instance = FileSelectorLinux();
+  }
+
+  @override
+  Future<XFile?> openFile({
+    List<XTypeGroup>? acceptedTypeGroups,
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    final List<String>? path = await _channel.invokeListMethod<String>(
+      'openFile',
+      <String, dynamic>{
+        'acceptedTypeGroups': acceptedTypeGroups
+            ?.map((XTypeGroup group) => group.toJSON())
+            .toList(),
+        'initialDirectory': initialDirectory,
+        'confirmButtonText': confirmButtonText,
+        'multiple': false,
+      },
+    );
+    return path == null ? null : XFile(path.first);
+  }
+
+  @override
+  Future<List<XFile>> openFiles({
+    List<XTypeGroup>? acceptedTypeGroups,
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    final List<String>? pathList = await _channel.invokeListMethod<String>(
+      'openFile',
+      <String, dynamic>{
+        'acceptedTypeGroups': acceptedTypeGroups
+            ?.map((XTypeGroup group) => group.toJSON())
+            .toList(),
+        'initialDirectory': initialDirectory,
+        'confirmButtonText': confirmButtonText,
+        'multiple': true,
+      },
+    );
+    return pathList?.map((String path) => XFile(path)).toList() ?? <XFile>[];
+  }
+
+  @override
+  Future<String?> getSavePath({
+    List<XTypeGroup>? acceptedTypeGroups,
+    String? initialDirectory,
+    String? suggestedName,
+    String? confirmButtonText,
+  }) async {
+    return _channel.invokeMethod<String>(
+      'getSavePath',
+      <String, dynamic>{
+        'acceptedTypeGroups': acceptedTypeGroups
+            ?.map((XTypeGroup group) => group.toJSON())
+            .toList(),
+        'initialDirectory': initialDirectory,
+        'suggestedName': suggestedName,
+        'confirmButtonText': confirmButtonText,
+      },
+    );
+  }
+
+  @override
+  Future<String?> getDirectoryPath({
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    return _channel.invokeMethod<String>(
+      'getDirectoryPath',
+      <String, dynamic>{
+        'initialDirectory': initialDirectory,
+        'confirmButtonText': confirmButtonText,
+      },
+    );
+  }
+}

--- a/plugins/file_selector/file_selector_linux/lib/file_selector_linux.dart
+++ b/plugins/file_selector/file_selector_linux/lib/file_selector_linux.dart
@@ -113,9 +113,7 @@ class FileSelectorLinux extends FileSelectorPlatform {
 }
 
 List<Map<String, Object>> _serializeTypeGroups(List<XTypeGroup>? groups) {
-  return (groups ?? <XTypeGroup>[])
-      .map((XTypeGroup group) => _serializeTypeGroup(group))
-      .toList();
+  return (groups ?? <XTypeGroup>[]).map(_serializeTypeGroup).toList();
 }
 
 Map<String, Object> _serializeTypeGroup(XTypeGroup group) {

--- a/plugins/file_selector/file_selector_linux/lib/file_selector_linux.dart
+++ b/plugins/file_selector/file_selector_linux/lib/file_selector_linux.dart
@@ -123,6 +123,7 @@ Map<String, Object> _serializeTypeGroup(XTypeGroup group) {
     _typeGroupLabelKey: group.label ?? '',
   };
   if (group.allowsAny) {
+    serialization[_typeGroupExtensionsKey] = <String>['*'];
   } else {
     if ((group.extensions?.isEmpty ?? true) &&
         (group.mimeTypes?.isEmpty ?? true)) {
@@ -132,7 +133,10 @@ Map<String, Object> _serializeTypeGroup(XTypeGroup group) {
           'if anything is non-empty.');
     }
     if (group.extensions?.isNotEmpty ?? false) {
-      serialization[_typeGroupExtensionsKey] = group.extensions ?? <String>[];
+      serialization[_typeGroupExtensionsKey] = group.extensions
+              ?.map((String extension) => '*.$extension')
+              .toList() ??
+          <String>[];
     }
     if (group.mimeTypes?.isNotEmpty ?? false) {
       serialization[_typeGroupMimeTypesKey] = group.mimeTypes ?? <String>[];

--- a/plugins/file_selector/file_selector_linux/lib/file_selector_linux.dart
+++ b/plugins/file_selector/file_selector_linux/lib/file_selector_linux.dart
@@ -9,6 +9,20 @@ import 'package:flutter/services.dart';
 const MethodChannel _channel =
     MethodChannel('plugins.flutter.dev/file_selector_linux');
 
+const String _typeGroupLabelKey = 'label';
+const String _typeGroupExtensionsKey = 'extensions';
+const String _typeGroupMimeTypesKey = 'mimeTypes';
+
+const String _openFileMethod = 'openFile';
+const String _getSavePathMethod = 'getSavePath';
+const String _getDirectoryPathMethod = 'getDirectoryPath';
+
+const String _acceptedTypeGroupsKey = 'acceptedTypeGroups';
+const String _confirmButtonTextKey = 'confirmButtonText';
+const String _initialDirectoryKey = 'initialDirectory';
+const String _multipleKey = 'multiple';
+const String _suggestedNameKey = 'suggestedName';
+
 /// An implementation of [FileSelectorPlatform] for Linux.
 class FileSelectorLinux extends FileSelectorPlatform {
   /// The MethodChannel that is being used by this implementation of the plugin.
@@ -27,14 +41,14 @@ class FileSelectorLinux extends FileSelectorPlatform {
     String? confirmButtonText,
   }) async {
     final List<String>? path = await _channel.invokeListMethod<String>(
-      'openFile',
+      _openFileMethod,
       <String, dynamic>{
-        'acceptedTypeGroups': acceptedTypeGroups
+        _acceptedTypeGroupsKey: acceptedTypeGroups
             ?.map((XTypeGroup group) => group.toJSON())
             .toList(),
         'initialDirectory': initialDirectory,
-        'confirmButtonText': confirmButtonText,
-        'multiple': false,
+        _confirmButtonTextKey: confirmButtonText,
+        _multipleKey: false,
       },
     );
     return path == null ? null : XFile(path.first);
@@ -47,14 +61,14 @@ class FileSelectorLinux extends FileSelectorPlatform {
     String? confirmButtonText,
   }) async {
     final List<String>? pathList = await _channel.invokeListMethod<String>(
-      'openFile',
+      _openFileMethod,
       <String, dynamic>{
-        'acceptedTypeGroups': acceptedTypeGroups
+        _acceptedTypeGroupsKey: acceptedTypeGroups
             ?.map((XTypeGroup group) => group.toJSON())
             .toList(),
-        'initialDirectory': initialDirectory,
-        'confirmButtonText': confirmButtonText,
-        'multiple': true,
+        _initialDirectoryKey: initialDirectory,
+        _confirmButtonTextKey: confirmButtonText,
+        _multipleKey: true,
       },
     );
     return pathList?.map((String path) => XFile(path)).toList() ?? <XFile>[];
@@ -68,14 +82,14 @@ class FileSelectorLinux extends FileSelectorPlatform {
     String? confirmButtonText,
   }) async {
     return _channel.invokeMethod<String>(
-      'getSavePath',
+      _getSavePathMethod,
       <String, dynamic>{
-        'acceptedTypeGroups': acceptedTypeGroups
+        _acceptedTypeGroupsKey: acceptedTypeGroups
             ?.map((XTypeGroup group) => group.toJSON())
             .toList(),
-        'initialDirectory': initialDirectory,
-        'suggestedName': suggestedName,
-        'confirmButtonText': confirmButtonText,
+        _initialDirectoryKey: initialDirectory,
+        _suggestedNameKey: suggestedName,
+        _confirmButtonTextKey: confirmButtonText,
       },
     );
   }
@@ -86,10 +100,10 @@ class FileSelectorLinux extends FileSelectorPlatform {
     String? confirmButtonText,
   }) async {
     return _channel.invokeMethod<String>(
-      'getDirectoryPath',
+      _getDirectoryPathMethod,
       <String, dynamic>{
-        'initialDirectory': initialDirectory,
-        'confirmButtonText': confirmButtonText,
+        _initialDirectoryKey: initialDirectory,
+        _confirmButtonTextKey: confirmButtonText,
       },
     );
   }

--- a/plugins/file_selector/file_selector_linux/lib/file_selector_linux.dart
+++ b/plugins/file_selector/file_selector_linux/lib/file_selector_linux.dart
@@ -7,7 +7,7 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
 
 const MethodChannel _channel =
-    MethodChannel('plugins.flutter.io/file_selector');
+    MethodChannel('plugins.flutter.dev/file_selector_linux');
 
 /// An implementation of [FileSelectorPlatform] for Linux.
 class FileSelectorLinux extends FileSelectorPlatform {

--- a/plugins/file_selector/file_selector_linux/linux/file_selector_plugin.cc
+++ b/plugins/file_selector/file_selector_linux/linux/file_selector_plugin.cc
@@ -10,7 +10,7 @@
 #include "file_selector_plugin_private.h"
 
 // From method_channel_file_selector.dart
-const char kChannelName[] = "plugins.flutter.io/file_selector";
+const char kChannelName[] = "plugins.flutter.dev/file_selector_linux";
 
 const char kOpenFileMethod[] = "openFile";
 const char kGetSavePathMethod[] = "getSavePath";

--- a/plugins/file_selector/file_selector_linux/linux/file_selector_plugin.cc
+++ b/plugins/file_selector/file_selector_linux/linux/file_selector_plugin.cc
@@ -9,7 +9,7 @@
 
 #include "file_selector_plugin_private.h"
 
-// From method_channel_file_selector.dart
+// From file_selector_linux.dart
 const char kChannelName[] = "plugins.flutter.dev/file_selector_linux";
 
 const char kOpenFileMethod[] = "openFile";
@@ -22,7 +22,6 @@ const char kInitialDirectoryKey[] = "initialDirectory";
 const char kMultipleKey[] = "multiple";
 const char kSuggestedNameKey[] = "suggestedName";
 
-// From x_type_group.dart
 const char kTypeGroupLabelKey[] = "label";
 const char kTypeGroupExtensionsKey[] = "extensions";
 const char kTypeGroupMimeTypesKey[] = "mimeTypes";

--- a/plugins/file_selector/file_selector_linux/linux/file_selector_plugin.cc
+++ b/plugins/file_selector/file_selector_linux/linux/file_selector_plugin.cc
@@ -43,10 +43,6 @@ G_DEFINE_TYPE(FlFileSelectorPlugin, fl_file_selector_plugin, G_TYPE_OBJECT)
 
 // Converts a type group received from Flutter into a GTK file filter.
 static GtkFileFilter* type_group_to_filter(FlValue* value) {
-  if (fl_value_get_type(value) != FL_VALUE_TYPE_MAP) {
-    return nullptr;
-  }
-
   g_autoptr(GtkFileFilter) filter = gtk_file_filter_new();
 
   FlValue* label = fl_value_lookup_string(value, kTypeGroupLabelKey);
@@ -54,18 +50,13 @@ static GtkFileFilter* type_group_to_filter(FlValue* value) {
     gtk_file_filter_set_name(filter, fl_value_get_string(label));
   }
 
-  bool has_filter = false;
   FlValue* extensions = fl_value_lookup_string(value, kTypeGroupExtensionsKey);
   if (extensions != nullptr &&
       fl_value_get_type(extensions) == FL_VALUE_TYPE_LIST) {
     for (size_t i = 0; i < fl_value_get_length(extensions); i++) {
       FlValue* v = fl_value_get_list_value(extensions, i);
-      if (fl_value_get_type(v) != FL_VALUE_TYPE_STRING) return nullptr;
-
-      g_autofree gchar* pattern =
-          g_strdup_printf("*.%s", fl_value_get_string(v));
+      const gchar* pattern = fl_value_get_string(v);
       gtk_file_filter_add_pattern(filter, pattern);
-      has_filter = true;
     }
   }
   FlValue* mime_types = fl_value_lookup_string(value, kTypeGroupMimeTypesKey);
@@ -73,15 +64,9 @@ static GtkFileFilter* type_group_to_filter(FlValue* value) {
       fl_value_get_type(mime_types) == FL_VALUE_TYPE_LIST) {
     for (size_t i = 0; i < fl_value_get_length(mime_types); i++) {
       FlValue* v = fl_value_get_list_value(mime_types, i);
-      if (fl_value_get_type(v) != FL_VALUE_TYPE_STRING) return nullptr;
-
       const gchar* pattern = fl_value_get_string(v);
       gtk_file_filter_add_mime_type(filter, pattern);
-      has_filter = true;
     }
-  }
-  if (!has_filter) {
-    gtk_file_filter_add_pattern(filter, "*");
   }
 
   return GTK_FILE_FILTER(g_object_ref(filter));

--- a/plugins/file_selector/file_selector_linux/linux/test/file_selector_plugin_test.cc
+++ b/plugins/file_selector/file_selector_linux/linux/test/file_selector_plugin_test.cc
@@ -59,9 +59,9 @@ TEST(FileSelectorPlugin, TestOpenWithFilter) {
 
   {
     g_autoptr(FlValue) image_group_extensions = fl_value_new_list();
-    fl_value_append_take(image_group_extensions, fl_value_new_string("png"));
-    fl_value_append_take(image_group_extensions, fl_value_new_string("gif"));
-    fl_value_append_take(image_group_extensions, fl_value_new_string("jgpeg"));
+    fl_value_append_take(image_group_extensions, fl_value_new_string("*.png"));
+    fl_value_append_take(image_group_extensions, fl_value_new_string("*.gif"));
+    fl_value_append_take(image_group_extensions, fl_value_new_string("*.jgpeg"));
     g_autoptr(FlValue) image_group = fl_value_new_map();
     fl_value_set_string_take(image_group, "label",
                              fl_value_new_string("Images"));
@@ -70,8 +70,11 @@ TEST(FileSelectorPlugin, TestOpenWithFilter) {
   }
 
   {
+    g_autoptr(FlValue) any_group_extensions = fl_value_new_list();
+    fl_value_append_take(any_group_extensions, fl_value_new_string("*"));
     g_autoptr(FlValue) any_group = fl_value_new_map();
     fl_value_set_string_take(any_group, "label", fl_value_new_string("Any"));
+    fl_value_set_string(any_group, "extensions", any_group_extensions);
     fl_value_append(type_groups, any_group);
   }
 

--- a/plugins/file_selector/file_selector_linux/pubspec.yaml
+++ b/plugins/file_selector/file_selector_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_selector_linux
 description: Liunx implementation of the file_selector plugin.
-version: 0.0.2+1
+version: 0.0.3
 homepage: https://github.com/google/flutter-desktop-embedding/tree/master/plugins/file_selector/file_selector_linux
 
 flutter:
@@ -9,11 +9,18 @@ flutter:
     platforms:
       linux:
         pluginClass: FileSelectorPlugin
+        dartPluginClass: FileSelectorLinux
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.22.0"
 
 dependencies:
+  cross_file: ^0.3.1
+  file_selector_platform_interface: ^2.1.0
   flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
     sdk: flutter

--- a/plugins/file_selector/file_selector_linux/test/file_selector_linux_test.dart
+++ b/plugins/file_selector/file_selector_linux/test/file_selector_linux_test.dart
@@ -53,12 +53,12 @@ void main() {
             'acceptedTypeGroups': <Map<String, dynamic>>[
               <String, Object>{
                 'label': 'text',
-                'extensions': <String>['txt'],
+                'extensions': <String>['*.txt'],
                 'mimeTypes': <String>['text/plain'],
               },
               <String, Object>{
                 'label': 'image',
-                'extensions': <String>['jpg'],
+                'extensions': <String>['*.jpg'],
                 'mimeTypes': <String>['image/jpg'],
               },
             ],
@@ -125,6 +125,7 @@ void main() {
             'acceptedTypeGroups': <Map<String, dynamic>>[
               <String, Object>{
                 'label': 'any',
+                'extensions': <String>['*'],
               },
             ],
             'initialDirectory': null,
@@ -162,12 +163,12 @@ void main() {
             'acceptedTypeGroups': <Map<String, dynamic>>[
               <String, Object>{
                 'label': 'text',
-                'extensions': <String>['txt'],
+                'extensions': <String>['*.txt'],
                 'mimeTypes': <String>['text/plain'],
               },
               <String, Object>{
                 'label': 'image',
-                'extensions': <String>['jpg'],
+                'extensions': <String>['*.jpg'],
                 'mimeTypes': <String>['image/jpg'],
               },
             ],
@@ -234,6 +235,7 @@ void main() {
             'acceptedTypeGroups': <Map<String, dynamic>>[
               <String, Object>{
                 'label': 'any',
+                'extensions': <String>['*'],
               },
             ],
             'initialDirectory': null,
@@ -272,12 +274,12 @@ void main() {
             'acceptedTypeGroups': <Map<String, dynamic>>[
               <String, Object>{
                 'label': 'text',
-                'extensions': <String>['txt'],
+                'extensions': <String>['*.txt'],
                 'mimeTypes': <String>['text/plain'],
               },
               <String, Object>{
                 'label': 'image',
-                'extensions': <String>['jpg'],
+                'extensions': <String>['*.jpg'],
                 'mimeTypes': <String>['image/jpg'],
               },
             ],
@@ -344,6 +346,7 @@ void main() {
             'acceptedTypeGroups': <Map<String, dynamic>>[
               <String, Object>{
                 'label': 'any',
+                'extensions': <String>['*'],
               },
             ],
             'initialDirectory': null,

--- a/plugins/file_selector/file_selector_linux/test/file_selector_linux_test.dart
+++ b/plugins/file_selector/file_selector_linux/test/file_selector_linux_test.dart
@@ -99,6 +99,41 @@ void main() {
         ],
       );
     });
+
+    test('throws for a type group that does not support Linux', () async {
+      final XTypeGroup group = XTypeGroup(
+        label: 'images',
+        webWildCards: <String>['images/*'],
+      );
+
+      await expectLater(
+          plugin.openFile(acceptedTypeGroups: <XTypeGroup>[group]),
+          throwsArgumentError);
+    });
+
+    test('passes a wildcard group correctly', () async {
+      final XTypeGroup group = XTypeGroup(
+        label: 'any',
+      );
+
+      await plugin.openFile(acceptedTypeGroups: <XTypeGroup>[group]);
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('openFile', arguments: <String, dynamic>{
+            'acceptedTypeGroups': <Map<String, dynamic>>[
+              <String, Object>{
+                'label': 'any',
+              },
+            ],
+            'initialDirectory': null,
+            'confirmButtonText': null,
+            'multiple': false,
+          }),
+        ],
+      );
+    });
   });
 
   group('#openFiles', () {
@@ -169,6 +204,41 @@ void main() {
             'initialDirectory': null,
             'confirmButtonText': 'Open File',
             'multiple': true,
+          }),
+        ],
+      );
+    });
+
+    test('throws for a type group that does not support Linux', () async {
+      final XTypeGroup group = XTypeGroup(
+        label: 'images',
+        webWildCards: <String>['images/*'],
+      );
+
+      await expectLater(
+          plugin.openFile(acceptedTypeGroups: <XTypeGroup>[group]),
+          throwsArgumentError);
+    });
+
+    test('passes a wildcard group correctly', () async {
+      final XTypeGroup group = XTypeGroup(
+        label: 'any',
+      );
+
+      await plugin.openFile(acceptedTypeGroups: <XTypeGroup>[group]);
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('openFile', arguments: <String, dynamic>{
+            'acceptedTypeGroups': <Map<String, dynamic>>[
+              <String, Object>{
+                'label': 'any',
+              },
+            ],
+            'initialDirectory': null,
+            'confirmButtonText': null,
+            'multiple': false,
           }),
         ],
       );
@@ -244,6 +314,41 @@ void main() {
             'initialDirectory': null,
             'suggestedName': null,
             'confirmButtonText': 'Open File',
+          }),
+        ],
+      );
+    });
+
+    test('throws for a type group that does not support Linux', () async {
+      final XTypeGroup group = XTypeGroup(
+        label: 'images',
+        webWildCards: <String>['images/*'],
+      );
+
+      await expectLater(
+          plugin.openFile(acceptedTypeGroups: <XTypeGroup>[group]),
+          throwsArgumentError);
+    });
+
+    test('passes a wildcard group correctly', () async {
+      final XTypeGroup group = XTypeGroup(
+        label: 'any',
+      );
+
+      await plugin.openFile(acceptedTypeGroups: <XTypeGroup>[group]);
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('openFile', arguments: <String, dynamic>{
+            'acceptedTypeGroups': <Map<String, dynamic>>[
+              <String, Object>{
+                'label': 'any',
+              },
+            ],
+            'initialDirectory': null,
+            'confirmButtonText': null,
+            'multiple': false,
           }),
         ],
       );

--- a/plugins/file_selector/file_selector_linux/test/file_selector_linux_test.dart
+++ b/plugins/file_selector/file_selector_linux/test/file_selector_linux_test.dart
@@ -37,11 +37,12 @@ void main() {
       );
 
       final XTypeGroup groupTwo = XTypeGroup(
-          label: 'image',
-          extensions: <String>['jpg'],
-          mimeTypes: <String>['image/jpg'],
-          macUTIs: <String>['public.image'],
-          webWildCards: <String>['image/*']);
+        label: 'image',
+        extensions: <String>['jpg'],
+        mimeTypes: <String>['image/jpg'],
+        macUTIs: <String>['public.image'],
+        webWildCards: <String>['image/*'],
+      );
 
       await plugin.openFile(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
 
@@ -50,8 +51,16 @@ void main() {
         <Matcher>[
           isMethodCall('openFile', arguments: <String, dynamic>{
             'acceptedTypeGroups': <Map<String, dynamic>>[
-              group.toJSON(),
-              groupTwo.toJSON()
+              <String, Object>{
+                'label': 'text',
+                'extensions': <String>['txt'],
+                'mimeTypes': <String>['text/plain'],
+              },
+              <String, Object>{
+                'label': 'image',
+                'extensions': <String>['jpg'],
+                'mimeTypes': <String>['image/jpg'],
+              },
             ],
             'initialDirectory': null,
             'confirmButtonText': null,
@@ -68,7 +77,6 @@ void main() {
         log,
         <Matcher>[
           isMethodCall('openFile', arguments: <String, dynamic>{
-            'acceptedTypeGroups': null,
             'initialDirectory': '/example/directory',
             'confirmButtonText': null,
             'multiple': false,
@@ -84,7 +92,6 @@ void main() {
         log,
         <Matcher>[
           isMethodCall('openFile', arguments: <String, dynamic>{
-            'acceptedTypeGroups': null,
             'initialDirectory': null,
             'confirmButtonText': 'Open File',
             'multiple': false,
@@ -104,11 +111,12 @@ void main() {
       );
 
       final XTypeGroup groupTwo = XTypeGroup(
-          label: 'image',
-          extensions: <String>['jpg'],
-          mimeTypes: <String>['image/jpg'],
-          macUTIs: <String>['public.image'],
-          webWildCards: <String>['image/*']);
+        label: 'image',
+        extensions: <String>['jpg'],
+        mimeTypes: <String>['image/jpg'],
+        macUTIs: <String>['public.image'],
+        webWildCards: <String>['image/*'],
+      );
 
       await plugin.openFiles(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
 
@@ -117,8 +125,16 @@ void main() {
         <Matcher>[
           isMethodCall('openFile', arguments: <String, dynamic>{
             'acceptedTypeGroups': <Map<String, dynamic>>[
-              group.toJSON(),
-              groupTwo.toJSON()
+              <String, Object>{
+                'label': 'text',
+                'extensions': <String>['txt'],
+                'mimeTypes': <String>['text/plain'],
+              },
+              <String, Object>{
+                'label': 'image',
+                'extensions': <String>['jpg'],
+                'mimeTypes': <String>['image/jpg'],
+              },
             ],
             'initialDirectory': null,
             'confirmButtonText': null,
@@ -135,7 +151,6 @@ void main() {
         log,
         <Matcher>[
           isMethodCall('openFile', arguments: <String, dynamic>{
-            'acceptedTypeGroups': null,
             'initialDirectory': '/example/directory',
             'confirmButtonText': null,
             'multiple': true,
@@ -151,7 +166,6 @@ void main() {
         log,
         <Matcher>[
           isMethodCall('openFile', arguments: <String, dynamic>{
-            'acceptedTypeGroups': null,
             'initialDirectory': null,
             'confirmButtonText': 'Open File',
             'multiple': true,
@@ -171,11 +185,12 @@ void main() {
       );
 
       final XTypeGroup groupTwo = XTypeGroup(
-          label: 'image',
-          extensions: <String>['jpg'],
-          mimeTypes: <String>['image/jpg'],
-          macUTIs: <String>['public.image'],
-          webWildCards: <String>['image/*']);
+        label: 'image',
+        extensions: <String>['jpg'],
+        mimeTypes: <String>['image/jpg'],
+        macUTIs: <String>['public.image'],
+        webWildCards: <String>['image/*'],
+      );
 
       await plugin
           .getSavePath(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
@@ -185,8 +200,16 @@ void main() {
         <Matcher>[
           isMethodCall('getSavePath', arguments: <String, dynamic>{
             'acceptedTypeGroups': <Map<String, dynamic>>[
-              group.toJSON(),
-              groupTwo.toJSON()
+              <String, Object>{
+                'label': 'text',
+                'extensions': <String>['txt'],
+                'mimeTypes': <String>['text/plain'],
+              },
+              <String, Object>{
+                'label': 'image',
+                'extensions': <String>['jpg'],
+                'mimeTypes': <String>['image/jpg'],
+              },
             ],
             'initialDirectory': null,
             'suggestedName': null,
@@ -203,7 +226,6 @@ void main() {
         log,
         <Matcher>[
           isMethodCall('getSavePath', arguments: <String, dynamic>{
-            'acceptedTypeGroups': null,
             'initialDirectory': '/example/directory',
             'suggestedName': null,
             'confirmButtonText': null,
@@ -219,7 +241,6 @@ void main() {
         log,
         <Matcher>[
           isMethodCall('getSavePath', arguments: <String, dynamic>{
-            'acceptedTypeGroups': null,
             'initialDirectory': null,
             'suggestedName': null,
             'confirmButtonText': 'Open File',

--- a/plugins/file_selector/file_selector_linux/test/file_selector_linux_test.dart
+++ b/plugins/file_selector/file_selector_linux/test/file_selector_linux_test.dart
@@ -1,0 +1,260 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file_selector_linux/file_selector_linux.dart';
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FileSelectorLinux plugin;
+  late List<MethodCall> log;
+
+  setUp(() {
+    plugin = FileSelectorLinux();
+    log = <MethodCall>[];
+    plugin.channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      log.add(methodCall);
+      return null;
+    });
+  });
+
+  test('registers instance', () {
+    FileSelectorLinux.registerWith();
+    expect(FileSelectorPlatform.instance, isA<FileSelectorLinux>());
+  });
+
+  group('#openFile', () {
+    test('passes the accepted type groups correctly', () async {
+      final XTypeGroup group = XTypeGroup(
+        label: 'text',
+        extensions: <String>['txt'],
+        mimeTypes: <String>['text/plain'],
+        macUTIs: <String>['public.text'],
+      );
+
+      final XTypeGroup groupTwo = XTypeGroup(
+          label: 'image',
+          extensions: <String>['jpg'],
+          mimeTypes: <String>['image/jpg'],
+          macUTIs: <String>['public.image'],
+          webWildCards: <String>['image/*']);
+
+      await plugin.openFile(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('openFile', arguments: <String, dynamic>{
+            'acceptedTypeGroups': <Map<String, dynamic>>[
+              group.toJSON(),
+              groupTwo.toJSON()
+            ],
+            'initialDirectory': null,
+            'confirmButtonText': null,
+            'multiple': false,
+          }),
+        ],
+      );
+    });
+
+    test('passes initialDirectory correctly', () async {
+      await plugin.openFile(initialDirectory: '/example/directory');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('openFile', arguments: <String, dynamic>{
+            'acceptedTypeGroups': null,
+            'initialDirectory': '/example/directory',
+            'confirmButtonText': null,
+            'multiple': false,
+          }),
+        ],
+      );
+    });
+
+    test('passes confirmButtonText correctly', () async {
+      await plugin.openFile(confirmButtonText: 'Open File');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('openFile', arguments: <String, dynamic>{
+            'acceptedTypeGroups': null,
+            'initialDirectory': null,
+            'confirmButtonText': 'Open File',
+            'multiple': false,
+          }),
+        ],
+      );
+    });
+  });
+
+  group('#openFiles', () {
+    test('passes the accepted type groups correctly', () async {
+      final XTypeGroup group = XTypeGroup(
+        label: 'text',
+        extensions: <String>['txt'],
+        mimeTypes: <String>['text/plain'],
+        macUTIs: <String>['public.text'],
+      );
+
+      final XTypeGroup groupTwo = XTypeGroup(
+          label: 'image',
+          extensions: <String>['jpg'],
+          mimeTypes: <String>['image/jpg'],
+          macUTIs: <String>['public.image'],
+          webWildCards: <String>['image/*']);
+
+      await plugin.openFiles(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('openFile', arguments: <String, dynamic>{
+            'acceptedTypeGroups': <Map<String, dynamic>>[
+              group.toJSON(),
+              groupTwo.toJSON()
+            ],
+            'initialDirectory': null,
+            'confirmButtonText': null,
+            'multiple': true,
+          }),
+        ],
+      );
+    });
+
+    test('passes initialDirectory correctly', () async {
+      await plugin.openFiles(initialDirectory: '/example/directory');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('openFile', arguments: <String, dynamic>{
+            'acceptedTypeGroups': null,
+            'initialDirectory': '/example/directory',
+            'confirmButtonText': null,
+            'multiple': true,
+          }),
+        ],
+      );
+    });
+
+    test('passes confirmButtonText correctly', () async {
+      await plugin.openFiles(confirmButtonText: 'Open File');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('openFile', arguments: <String, dynamic>{
+            'acceptedTypeGroups': null,
+            'initialDirectory': null,
+            'confirmButtonText': 'Open File',
+            'multiple': true,
+          }),
+        ],
+      );
+    });
+  });
+
+  group('#getSavePath', () {
+    test('passes the accepted type groups correctly', () async {
+      final XTypeGroup group = XTypeGroup(
+        label: 'text',
+        extensions: <String>['txt'],
+        mimeTypes: <String>['text/plain'],
+        macUTIs: <String>['public.text'],
+      );
+
+      final XTypeGroup groupTwo = XTypeGroup(
+          label: 'image',
+          extensions: <String>['jpg'],
+          mimeTypes: <String>['image/jpg'],
+          macUTIs: <String>['public.image'],
+          webWildCards: <String>['image/*']);
+
+      await plugin
+          .getSavePath(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getSavePath', arguments: <String, dynamic>{
+            'acceptedTypeGroups': <Map<String, dynamic>>[
+              group.toJSON(),
+              groupTwo.toJSON()
+            ],
+            'initialDirectory': null,
+            'suggestedName': null,
+            'confirmButtonText': null,
+          }),
+        ],
+      );
+    });
+
+    test('passes initialDirectory correctly', () async {
+      await plugin.getSavePath(initialDirectory: '/example/directory');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getSavePath', arguments: <String, dynamic>{
+            'acceptedTypeGroups': null,
+            'initialDirectory': '/example/directory',
+            'suggestedName': null,
+            'confirmButtonText': null,
+          }),
+        ],
+      );
+    });
+
+    test('passes confirmButtonText correctly', () async {
+      await plugin.getSavePath(confirmButtonText: 'Open File');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getSavePath', arguments: <String, dynamic>{
+            'acceptedTypeGroups': null,
+            'initialDirectory': null,
+            'suggestedName': null,
+            'confirmButtonText': 'Open File',
+          }),
+        ],
+      );
+    });
+  });
+
+  group('#getDirectoryPath', () {
+    test('passes initialDirectory correctly', () async {
+      await plugin.getDirectoryPath(initialDirectory: '/example/directory');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
+            'initialDirectory': '/example/directory',
+            'confirmButtonText': null,
+          }),
+        ],
+      );
+    });
+    test('passes confirmButtonText correctly', () async {
+      await plugin.getDirectoryPath(confirmButtonText: 'Open File');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
+            'initialDirectory': null,
+            'confirmButtonText': 'Open File',
+          }),
+        ],
+      );
+    });
+  });
+}


### PR DESCRIPTION
Part 2 of prep for moving this to flutter/plugins:
- Adds a Linux Dart implementation based on the shared method channel implementation.
  - Renamed the channel, as usual for internal method channels.
  - Added the assertion for unsupported type groups, matching the other platforms.
  - Moved some logic for converting type groups to the format needed by the GTK APIs from C to Dart.
  - Added more use of string constants for ease of keeping Dart and C in sync.
- Updates the example with a recent copy from another desktop implementation.